### PR TITLE
[FIX] token too long

### DIFF
--- a/openapi/serializer/team_serializer.py
+++ b/openapi/serializer/team_serializer.py
@@ -71,7 +71,7 @@ class TeamRegionsRespSerializer(serializers.Serializer):
     wsurl = serializers.CharField(max_length=256, help_text=u"数据中心Websocket url")
     httpdomain = serializers.CharField(max_length=256, help_text=u"数据中心http应用访问根域名")
     tcpdomain = serializers.CharField(max_length=256, help_text=u"数据中心tcp应用访问根域名")
-    token = serializers.CharField(max_length=40, allow_null=True, allow_blank=True, default="", help_text=u"数据中心token")
+    token = serializers.CharField(max_length=127, allow_null=True, allow_blank=True, default="", help_text=u"数据中心token")
     status = serializers.CharField(max_length=2, help_text=u"数据中心状态 0：编辑中 1:启用 2：停用 3:维护中")
     desc = serializers.CharField(max_length=128, allow_blank=True, help_text=u"数据中心描述")
     scope = serializers.CharField(max_length=10, default="private", help_text=u"数据中心范围 private|public")


### PR DESCRIPTION
The length of token is limited to 127, too short, changed to 127