### PR TITLE
[FIX] failed to share app

### DIFF
--- a/console/services/share_services.py
+++ b/console/services/share_services.py
@@ -781,6 +781,8 @@ class ShareService(object):
                     if sid:
                         transaction.savepoint_rollback(sid)
                     return 400, "分享的应用信息不能为空", None
+            except ServiceHandleException as e:
+                raise ServiceHandleException(msg=e.msg, msg_show=e.msg_show)
             except Exception as e:
                 if sid:
                     transaction.savepoint_rollback(sid)
@@ -813,6 +815,8 @@ class ShareService(object):
             if sid:
                 transaction.savepoint_commit(sid)
             return 200, "分享信息处理成功", share_record.to_dict()
+        except ServiceHandleException as e:
+            raise ServiceHandleException(msg=e.msg, msg_show=e.msg_show)
         except Exception as e:
             logger.exception(e)
             if sid:


### PR DESCRIPTION
关联issue #203
分享时报错信息被Exception全局捕获了, 导致报错信息不对. 当报错""应用市场主服务服务缺少依赖服务，请添加依赖服务，或强制执行"时, 应该由前端处理(rainbond-ui相关issue: goodrain/rainbond-ui#186)