### PR TITLE
[FIX] wrong env name

### DIFF
--- a/console/services/app_config/env_service.py
+++ b/console/services/app_config/env_service.py
@@ -24,7 +24,7 @@ class AppEnvVarService(object):
         if attr_name in self.SENSITIVE_ENV_NAMES:
             return False, u"不允许的变量名{0}".format(attr_name)
 
-        if not re.match(r"[-._a-zA-Z][-._a-zA-Z0-9]*", attr_name):
+        if not re.match(r"^[-._a-zA-Z][-._a-zA-Z0-9]*$", attr_name):
             return False, u"变量名称{0}不符合规范".format(attr_name)
         return True, u"success"
 


### PR DESCRIPTION
bug fix: wrong env name goodrain/rainbond#391

due to the incorrect regular expression, it is possible to add non-conforming environment variable names