### PR TITLE
delete metrics

### DIFF
--- a/console/repositories/autoscaler_repo.py
+++ b/console/repositories/autoscaler_repo.py
@@ -53,6 +53,9 @@ class AutoscalerRuleMetricsRepository(object):
                 metric_target_type=metric["metric_target_type"],
                 metric_target_value=metric["metric_target_value"])
 
+    def delete_by_rule_id(self, rule_id):
+        AutoscalerRuleMetrics.objects.filter(rule_id=rule_id).delete()
+
 
 autoscaler_rules_repo = AutoscalerRulesRepository()
 autoscaler_rule_metrics_repo = AutoscalerRuleMetricsRepository()


### PR DESCRIPTION
Put 方法更新自动伸缩规则时,  用新的规则覆盖旧的规则. 
对于规则中的各个指标, 就是先删除就得指标, 再创建新的指标.