### PR TITLE
# fix #335 挂载共享目录时共享存储查询查询错误

### DIFF
--- a/console/services/app_config/mnt_service.py
+++ b/console/services/app_config/mnt_service.py
@@ -3,6 +3,7 @@
   Created on 18/1/19.
 """
 import logging
+import copy
 
 from console.exception.main import ErrDepVolumeNotFound
 from console.exception.main import ErrInvalidVolume
@@ -69,7 +70,8 @@ class AppMntService(object):
             .exclude(volume_name__in=dep_mnt_names).filter(q)
         # 只展示无状态的组件(有状态组件的存储类型为config-file也可)
         volumes = list(service_volumes)
-        for volume in volumes:
+        copy_volumes = copy.copy(volumes)
+        for volume in copy_volumes:
             service_obj = service_repo.get_service_by_service_id(volume.service_id)
             if service_obj:
                 if service_obj.extend_method != "stateless" and volume.volume_type != "config-file":


### PR DESCRIPTION
在原有volume列表执行remove操作，会导致循环提前退出，不能判断所有volume的状态
将volume 进行复制，在复制后的volume列表进行循环判断操作，在原volume列表进行remove操作