### PR TITLE
CloundBangImages matching query does not exist

### DIFF
--- a/console/services/config_service.py
+++ b/console/services/config_service.py
@@ -232,8 +232,7 @@ class ConfigService(object):
         try:
             cbi = CloundBangImages.objects.get(identify=identify)
             logo = cbi.logo.name
-        except CloundBangImages.DoesNotExist as e:
-            logger.error(e)
+        except CloundBangImages.DoesNotExist:
             logo = ""
         return logo
 


### PR DESCRIPTION
ref #340
The absence of the logo in CloundBangImages is normal and should not be reported as an error
