### PR TITLE
Fix #265 安装插件需要有判断与限制

### DIFF
--- a/console/services/plugin/app_plugin.py
+++ b/console/services/plugin/app_plugin.py
@@ -528,6 +528,28 @@ class AppPluginService(object):
 
         ServicePluginConfigVar.objects.bulk_create(config_list)
 
+    def check_the_same_plugin(self, plugin_id, tenant_id, service_id):
+        print plugin_id, tenant_id, service_id
+        plugin_list = []
+        categories = []
+        flag = False
+        service_plugins = app_plugin_relation_repo.get_service_plugin_relation_by_service_id(service_id)
+        plugin_info = plugin_repo.get_plugin_by_plugin_id(tenant_id, plugin_id)
+        print service_plugins
+        if len(service_plugins) != 0:
+            for i in service_plugins:
+                plugin_list.append(i.plugin_id)
+            plugins = plugin_repo.get_plugin_by_plugin_ids(plugin_list)
+            for i in plugins:
+                categories.append(i.category)
+        print plugin_info.category
+        if plugin_info.category.split(":")[0] == "net-plugin" and plugin_info.category in categories:
+            flag = True
+        if plugin_info.category == "net-plugin:in-and-out" and (
+                "net-plugin:up" in categories or "net-plugin:down" in categories):
+            flag = True
+        return flag
+
 
 class PluginService(object):
     def get_plugins_by_service_ids(self, service_ids):

--- a/console/views/plugin/service_plugin.py
+++ b/console/views/plugin/service_plugin.py
@@ -89,6 +89,9 @@ class ServicePluginInstallView(AppBaseView):
         try:
             if not plugin_id:
                 return Response(general_message(400, "params error", "参数错误"), status=400)
+            rst = app_plugin_service.check_the_same_plugin(plugin_id, self.tenant.tenant_id, self.service.service_id)
+            if rst:
+                return Response(general_message(400, "params error", u"该组件已存在相同功能插件"), status=400)
             if not build_version:
                 plugin_version = plugin_version_service.get_newest_usable_plugin_version(plugin_id)
                 build_version = plugin_version.build_version


### PR DESCRIPTION
添加如下情况的插件禁止一同安装的判断：

出口网络 与 出口网络
入口网络 与 入口网络
出入口共治 与 出入口共治
出入口共治 与 入口网络
出入口共治 与 出口网络
对于只有tcp/udp协议端口的服务组件禁止其安装服务实时性能分析插件。
并在禁止的同时提示信息： 服务实时性能分析插件仅支持 http 与 mysql 协议。