### PR TITLE
delete a tenant when deleting a team

### DIFF
--- a/console/services/exception.py
+++ b/console/services/exception.py
@@ -60,3 +60,17 @@ ErrAutoscalerRuleNotFound = ServiceHandleException(
     msg_show="自动伸缩规程不存在",
     status_code=404
 )
+
+ErrStillHasServices = ServiceHandleException(
+    msg="the team still has service",
+    msg_show="团队仍有组件, 无法删除",
+    status_code=409,
+    error_code=2001
+)
+
+ErrAllTenantDeletionFailed = ServiceHandleException(
+    msg="delete of all tenants failed",
+    msg_show="所有租户的删除都失败了",
+    status_code=400,
+    error_code=400
+)

--- a/console/views/team.py
+++ b/console/views/team.py
@@ -540,21 +540,15 @@ class TeamDelView(JWTAuthApiView):
                 code = 400
                 result = general_message(code, "no identity", "您不是最高管理员，不能删除团队")
                 return Response(result, status=code)
-        try:
-            service_count = team_services.get_team_service_count_by_team_name(team_name=team_name)
-            if service_count >= 1:
-                result = general_message(400, "failed", "当前团队内有应用,不可以删除")
-                return Response(result, status=400)
-            team_services.delete_tenant(tenant_name=team_name)
-            result = general_message(code, "delete a tenant successfully", "删除团队成功")
-        except Tenants.DoesNotExist as e:
-            code = 400
-            logger.exception(e)
+
+        tenant = team_services.get_tenant_by_tenant_name(tenant_name=team_name)
+        if tenant is None:
+            code = 404
             result = general_message(code, "tenant not exist", "{}团队不存在".format(team_name))
-        except Exception as e:
-            code = 500
-            result = general_message(code, "sys exception", "系统异常")
-            logger.exception(e)
+
+        team_services.delete_by_tenant_id(tenant.tenant_id)
+        result = general_message(code, "delete a tenant successfully", "删除团队成功")
+
         return Response(result, status=code)
 
 

--- a/openapi/views/exceptions.py
+++ b/openapi/views/exceptions.py
@@ -4,13 +4,6 @@ from console.exception.main import ServiceHandleException
 # 业务码
 # 企业: 1xxx 团队2xxx 组件3xxx
 
-ErrStillHasServices = ServiceHandleException(
-    msg="the team still has service",
-    msg_show="团队仍有组件, 无法删除",
-    status_code=409,
-    error_code=2001
-)
-
 ErrTeamNotFound = ServiceHandleException(
     msg="the team is not found",
     msg_show="团队不存在",

--- a/openapi/views/team_view.py
+++ b/openapi/views/team_view.py
@@ -19,6 +19,7 @@ from console.services.user_services import user_services
 from openapi.serializer.base_serializer import FailSerializer
 from openapi.serializer.team_serializer import CreateTeamReqSerializer
 from openapi.serializer.team_serializer import CreateTeamUserReqSerializer
+from openapi.serializer.team_serializer import ListRegionTeamServicesSerializer
 from openapi.serializer.team_serializer import ListTeamRegionsRespSerializer
 from openapi.serializer.team_serializer import ListTeamRespSerializer
 from openapi.serializer.team_serializer import RoleInfoRespSerializer
@@ -26,11 +27,9 @@ from openapi.serializer.team_serializer import TeamBaseInfoSerializer
 from openapi.serializer.team_serializer import TeamInfoSerializer
 from openapi.serializer.team_serializer import TeamRegionReqSerializer
 from openapi.serializer.team_serializer import UpdateTeamInfoReqSerializer
-from openapi.serializer.team_serializer import ListRegionTeamServicesSerializer
 from openapi.serializer.user_serializer import ListTeamUsersRespSerializer
 from openapi.views.base import BaseOpenAPIView
 from openapi.views.base import ListAPIView
-from openapi.views.exceptions import ErrStillHasServices
 from openapi.views.exceptions import ErrTeamNotFound
 from www.models.main import PermRelTenant
 from www.models.main import Tenants
@@ -146,10 +145,6 @@ class TeamInfo(BaseOpenAPIView):
     )
     def delete(self, req, team_id,  *args, **kwargs):
         try:
-            service_count = team_services.count_by_tenant_id(tenant_id=team_id)
-            if service_count >= 1:
-                raise ErrStillHasServices
-
             res = team_services.delete_by_tenant_id(tenant_id=team_id)
             if res:
                 return Response(None, status.HTTP_200_OK)


### PR DESCRIPTION
删除团队的同时, 删除与之关联的租户.
一个团队可能有多个租户, 删除租户是调用各个租户所在数据中心的接口, 无法使用事务, 无法一个失败即全部失败.
现在的策略是, 有一个租户的删除成功了, 即为成功.  对于没有删除成功的租户, 需要走其他的删除途径, 例如: 管理后台删除游离租户

另外, 团队能删除的条件是: 该团队没有组件了.