### PR TITLE
bad SQL syntax

### DIFF
--- a/sql/5.1.8-5.1.9.sql
+++ b/sql/5.1.8-5.1.9.sql
@@ -1,6 +1,5 @@
 -- 更新版本
 update console.console_sys_config set `value`="5.1.9" where `key`="RAINBOND_VERSION";
-------------------------------## module console ##--------------------------------------
 
 -- console_sys_config
 alter table console_sys_config modify `desc` varchar(100);
@@ -65,7 +64,6 @@ alter table region_info modify `region_name` varchar(64);
 alter table region_info modify `region_alias` varchar(64);
 alter table region_info modify `desc` varchar(200);
 
--------------------------------## module www ##-------------------------------------
 -- user_info
 alter table user_info modify `nick_name` varchar(64);
 alter table user_info modify `password` varchar(64);

--- a/sql/5.1.8-5.1.9.sql
+++ b/sql/5.1.8-5.1.9.sql
@@ -1,6 +1,3 @@
--- 更新版本
-update console.console_sys_config set `value`="5.1.9" where `key`="RAINBOND_VERSION";
-
 -- console_sys_config
 alter table console_sys_config modify `desc` varchar(100);
 
@@ -208,3 +205,6 @@ CREATE TABLE `user_oauth_service` (
 -- **2019-11-26 在tenant_service表中增加oauth_service_id字段，用来记录源码创建使用的oauth服务id
 alter table console.tenant_service add column oauth_service_id int(11) null default null;
 alter table console.tenant_service add column git_full_name varchar(64) null default null;
+
+-- 更新版本
+update console.console_sys_config set `value`="5.1.9" where `key`="RAINBOND_VERSION";


### PR DESCRIPTION
wrong SQL syntax `------------------------------## module console ##--------------------------------------`, will cause the blew error:
```
Dec 11 10:55:17 manage01 bash[8000]: exec sql:
Dec 11 10:55:17 manage01 bash[8000]: ------------------------------## module console ##--------------------------------------
Dec 11 10:55:17 manage01 bash[8000]: -- console_sys_config
Dec 11 10:55:17 manage01 bash[8000]: alter table console_sys_config modify `desc` varchar(100)
Dec 11 10:55:17 manage01 bash[8000]: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '------------------------------## module console ##------------------------------' at line 1")
```