### PR TITLE
region not found

### DIFF
--- a/console/views/team.py
+++ b/console/views/team.py
@@ -932,22 +932,18 @@ class EnterpriseInfoView(RegionTenantHeaderView):
         """
         查询企业信息
         """
+        enter = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id=self.team.enterprise_id)
+        ent = enter.to_dict()
+        is_ent = False
         try:
-            enter = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id=self.team.enterprise_id)
-            ent = enter.to_dict()
-            is_ent = False
-            try:
-                res, body = region_api.get_api_version_v2(self.team.tenant_name, self.response_region)
-                if res.status == 200 and body is not None and "enterprise" in body["raw"]:
-                    is_ent = True
-            except region_api.CallApiError as e:
-                logger.warning("数据中心{0}不可达,无法获取相关信息: {1}".format(self.response_region.region_name, e.message))
-            ent["is_enterprise"] = is_ent
+            res, body = region_api.get_api_version_v2(self.team.tenant_name, self.response_region)
+            if res.status == 200 and body is not None and "enterprise" in body["raw"]:
+                is_ent = True
+        except region_api.CallApiError as e:
+            logger.warning("数据中心{0}不可达,无法获取相关信息: {1}".format(self.response_region.region_name, e.message))
+        ent["is_enterprise"] = is_ent
 
-            result = general_message(200, "success", "查询成功", bean=ent)
-        except Exception as e:
-            logger.exception(e)
-            result = error_message(e.message)
+        result = general_message(200, "success", "查询成功", bean=ent)
         return Response(result, status=result["code"])
 
 

--- a/www/apiclient/exception.py
+++ b/www/apiclient/exception.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from console.exception.main import ServiceHandleException
+
+err_region_not_found = ServiceHandleException("region not found", u"数据中心不存在", 404, 404)

--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -9,6 +9,7 @@ from django.conf import settings
 
 from console.models.main import RegionConfig
 from www.apiclient.baseclient import client_auth_service
+from www.apiclient.exception import err_region_not_found
 from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient
 from www.models.main import TenantRegionInfo
 from www.models.main import Tenants
@@ -1078,6 +1079,8 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
         # 如果团队所在企业所属数据中心信息不存在则使用通用的配置(兼容未申请数据中心token的企业)
         # 管理后台数据需要及时生效，对于数据中心的信息查询使用直接查询原始数据库
         region_info = self.get_region_info(region_name=region)
+        if region_info is None:
+            raise err_region_not_found
         url = region_info.url
         if not token:
             # region_map = self.get_region_map(region)


### PR DESCRIPTION
ref: #331

问题原因: 在没有选择过数据中心时, 调用接口 `/console/enterprise/info` 时传的 region_name 是 `no-region`, 导致查出来的 region_info 是 None.

从两个方面解决:
1. API 不应该报系统异常, 应该返回 404 (数据中心不存在)
2. UI 在没有选择数据中心之前, 都不应该调用 `/console/enterprise/info` 接口. ref: goodrain/rainbond-ui#278