### PR TITLE
fix mnt share bugs

### DIFF
--- a/console/services/app_config/mnt_service.py
+++ b/console/services/app_config/mnt_service.py
@@ -72,7 +72,7 @@ class AppMntService(object):
         services = service_repo.get_services_by_service_ids(service_ids)
         state_services = []  # 有状态组件
         for svc in services:
-            if not is_state(svc.extend_method):
+            if is_state(svc.extend_method):
                 state_services.append(svc)
         state_service_ids = [svc.service_id for svc in state_services]
 


### PR DESCRIPTION
查询可挂载共享存储时，过滤掉有状态组件的存储，仅可共享无状态组件的共享存储（文件）存储类型