### PR TITLE
fix invalid reference format

### DIFF
--- a/travis_build.sh
+++ b/travis_build.sh
@@ -37,7 +37,7 @@ function release(){
      docker push  ${IMAGE_DOMAIN}/${IMAGE_NAMESPACE}/rbd-app-ui:${VERSION}
      if [ ${DOMESTIC_BASE_NAME} ];
 			then
-				docker tag "${IMAGE_BASE_NAME}/rbd-app-ui:${VERSION}" "${DOMESTIC_BASE_NAME}/${DOMESTIC_NAMESPACE}/rbd-app-ui:${VERSION}"
+				docker tag "${IMAGE_DOMAIN}/${IMAGE_NAMESPACE}/rbd-app-ui:${VERSION}" "${DOMESTIC_BASE_NAME}/${DOMESTIC_NAMESPACE}/rbd-app-ui:${VERSION}"
 				docker login -u "$DOMESTIC_DOCKER_USERNAME" -p "$DOMESTIC_DOCKER_PASSWORD" ${DOMESTIC_BASE_NAME}
 				docker push "${DOMESTIC_BASE_NAME}/${DOMESTIC_NAMESPACE}/rbd-app-ui:${VERSION}"
 			fi


### PR DESCRIPTION
修复脚本错误, 使用更灵活的 `${IMAGE_DOMAIN}/${IMAGE_NAMESPACE}` 取代 `${IMAGE_BASE_NAME}`