### PR TITLE
delete Exception

### DIFF
--- a/console/views/app_config/app_mnt.py
+++ b/console/views/app_config/app_mnt.py
@@ -107,19 +107,14 @@ class AppMntView(AppBaseView):
               paramType: body
 
         """
-        result = {}
-        try:
-            dep_vol_data = request.data["body"]
-            dep_vol_data = json.loads(dep_vol_data)
-            code, msg = mnt_service.batch_mnt_serivce_volume(self.tenant, self.service, dep_vol_data)
+        dep_vol_data = request.data["body"]
+        dep_vol_data = json.loads(dep_vol_data)
+        code, msg = mnt_service.batch_mnt_serivce_volume(self.tenant, self.service, dep_vol_data)
 
-            if code != 200:
-                return Response(general_message(code, "add error", msg), status=code)
+        if code != 200:
+            return Response(general_message(code, "add error", msg), status=code)
 
-            result = general_message(200, "success", "操作成功")
-        except Exception as e:
-            logger.exception(e)
-            result = error_message(e.message)
+        result = general_message(200, "success", "操作成功")
         return Response(result, status=result["code"])
 
 


### PR DESCRIPTION
```
ServiceHandleException: (400, None, 'path error', '\xe8\xb7\xaf\xe5\xbe\x84\xe4\xbb\x85\xe6\x94\xaf\xe6\x8c\x81linux\xe5\x92\x8cwindows')
2020-03-26 07:16:35 [ERROR] localhost [post] /app/ui/console/views/app_config/app_mnt.py:121 (400, None, 'path error', '\xe8\xb7\xaf\xe5\xbe\x84\xe4\xbb\x85\xe6\x94\xaf\xe6\x8c\x81linux\xe5\x92\x8cwindows')
Traceback (most recent call last):
  File "/app/ui/console/views/app_config/app_mnt.py", line 114, in post
    code, msg = mnt_service.batch_mnt_serivce_volume(self.tenant, self.service, dep_vol_data)
  File "/app/ui/console/services/app_config/mnt_service.py", line 159, in batch_mnt_serivce_volume
    volume_service.check_volume_path(service, dep_vol["path"], local_path=local_path)
  File "/app/ui/console/services/app_config/volume_service.py", line 200, in check_volume_path
    raise ServiceHandleException(msg="path error", msg_show="路径仅支持linux和windows")
ServiceHandleException: (400, None, 'path error', '\xe8\xb7\xaf\xe5\xbe\x84\xe4\xbb\x85\xe6\x94\xaf\xe6\x8c\x81linux\xe5\x92\x8cwindows')
```

不直接捕获 Exception, 直接捕获 Exception 的话, 碰到上面的报错, 会把`系统异常`, 而不是 `路径仅支持linux和windows`