### PR TITLE
fix not visit bugs

### DIFF
--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -616,7 +616,13 @@ class AppPortService(object):
             port_info_list = []
             for p in http_outer_port:
                 port_dict = p.to_dict()
-                port_dict["access_urls"] = self.__get_port_access_url(tenant, service, p.container_port)
+                access_urls = self.__get_port_access_url(tenant, service, p.container_port)
+                if not access_urls:
+                    port_and_url = self.__get_stream_outer_url(tenant, service, p)
+                    if port_and_url:
+                        access_type = ServicePortConstants.NOT_HTTP_OUTER
+                        access_urls = [port_and_url]
+                port_dict["access_urls"] = access_urls
                 port_dict["service_cname"] = service.service_cname
                 port_info_list.append(port_dict)
             return access_type, port_info_list


### PR DESCRIPTION
1、问题描述：
        组件端口协议采用HTTP，但添加了TCP访问策略时，找不到组件的访问地址，导致错误的判断为组件未开启对外访问端口
2、问题解决思路：
        HTTP策略的端口，在没有HTTP访问策略时检查是否有TCP访问策略，如果有，则访问方式使用成TCP访问策略，访问地址使用TCP访问地址；如果有HTTP访问策略，则直接使用HTTP访问策略，不使用TCP访问策略