### PR TITLE
update get export app region

### DIFF
--- a/console/services/app_import_and_export_service.py
+++ b/console/services/app_import_and_export_service.py
@@ -52,9 +52,9 @@ class AppExportService(object):
         return 200, "success", new_export_record
 
     def _export_app_region(self, eid):
-        tenant_info = region_repo.get_region_by_enterprise_id(eid)
-        if tenant_info:
-            return tenant_info.region_name
+        tenant_region_info = region_repo.get_region_by_enterprise_id(eid)
+        if tenant_region_info:
+            return tenant_region_info.region_name
         raise RecordNotFound("数据中心未找到")
 
     def export_app(self, eid, app_id, version, export_format):


### PR DESCRIPTION
导出组件库应用时，现有方案采用企业中一条数据中心进行导出操作

后续优化点：针对应用的来源，区分不同的数据中心，处理多数据中心使用不同镜像仓库的问题

ps：不同的数据中心使用不同的镜像仓库时，会导致导出任务找不到镜像