### PR TITLE
New Feature: add default market url

### DIFF
--- a/console/services/config_service.py
+++ b/console/services/config_service.py
@@ -83,6 +83,8 @@ class ConfigService(object):
                 rst_data = {key.lower(): {"enable": tar_key.enable, "value": rst_value}}
                 rst_datas.update(rst_data)
 
+        rst_datas["default_market_url"] = os.getenv("DEFAULT_APP_MARKET_URL", "https://store.goodrain.com")
+
         return rst_datas
 
     def update_config(self, key, value):


### PR DESCRIPTION
add the parameter `default_market_url ` to tell frontend what the default app market url is