### PR TITLE
BUG FIX: wrong response

### DIFF
--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -575,7 +575,7 @@ class AppPortService(object):
 
     def get_access_info(self, tenant, service):
         access_type = ""
-        data = {}
+        data = []
         service_ports = port_repo.get_service_ports(tenant.tenant_id, service.service_id)
         # ①是否有端口
         if not service_ports:
@@ -666,7 +666,7 @@ class AppPortService(object):
 
         if unopened_port:
             access_type = ServicePortConstants.NO_PORT
-            return access_type, {}
+            return access_type, []
 
     def __get_stream_outer_url(self, tenant, service, port):
         region = region_repo.get_region_by_region_name(service.service_region)


### PR DESCRIPTION
The response data of `get_access_info` should be list, not map.  ref: https://github.com/goodrain/rainbond-console/blob/80da68f0364b7580036050f8e4214ae3e42be76d/console/services/app_config/port_service.py#L632

