### PR TITLE
Fix Bug: plugin copy error

### DIFF
--- a/console/services/groupapp_recovery/groupapps_migrate.py
+++ b/console/services/groupapp_recovery/groupapps_migrate.py
@@ -304,11 +304,12 @@ class GroupappsMigrateService(object):
         versions = self.__save_plugin_build_versions(migrate_tenant, metadata["plugin_info"]["plugin_build_versions"])
         self.__save_plugins(migrate_region, migrate_tenant, metadata["plugin_info"]["plugins"])
         for app in apps:
+            new_service_id = old_new_service_id_map[app["service_base"]["service_id"]]
             # plugin
             if app.get("service_plugin_relation", None):
-                self.__save_plugin_relations(ts, app["service_plugin_relation"], versions)
+                self.__save_plugin_relations(new_service_id, app["service_plugin_relation"], versions)
             if app.get("service_plugin_config", None):
-                self.__save_service_plugin_config(ts.service_id, app["service_plugin_config"])
+                self.__save_service_plugin_config(new_service_id, app["service_plugin_config"])
         self.__save_service_relations(migrate_tenant, service_relations_list, old_new_service_id_map)
         self.__save_service_mnt_relation(migrate_tenant, service_mnt_list, old_new_service_id_map)
 
@@ -619,14 +620,14 @@ class GroupappsMigrateService(object):
     #     if endpoints_list:
     #         ThirdPartyServiceEndpoints.objects.bulk_create(endpoints_list)
 
-    def __save_plugin_relations(self, service, plugin_relations, plugin_versions):
+    def __save_plugin_relations(self, service_id, plugin_relations, plugin_versions):
         if not plugin_relations:
             return
         new_plugin_relations = []
         for pr in plugin_relations:
             pr.pop("ID")
             new_pr = TenantServicePluginRelation(**pr)
-            new_pr.service_id = service.service_id
+            new_pr.service_id = service_id
             if not new_pr.min_memory:
                 for plugin_version in plugin_versions:
                     if new_pr.plugin_id == plugin_version.plugin_id:

--- a/console/services/groupcopy_service.py
+++ b/console/services/groupcopy_service.py
@@ -100,9 +100,10 @@ class GroupAppCopyService(object):
                 # Handling plugin config
                 if change_service_map and service["service_plugin_config"]:
                     for plugin in service["service_plugin_config"]:
-                        # Get the new next service ID pointed to by the plugin through the old service ID
-                        plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
-                        plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
+                        if plugin["dest_service_id"] != "":
+                            # Get the new next service ID pointed to by the plugin through the old service ID
+                            plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
+                            plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
             return metadata
         new_metadata = {}
         new_metadata["compose_group_info"] = metadata["compose_group_info"]
@@ -139,9 +140,10 @@ class GroupAppCopyService(object):
             # Handling plugin config
             if change_service_map and service["service_plugin_config"]:
                 for plugin in service["service_plugin_config"]:
-                    # Get the new next service ID pointed to by the plugin through the old service ID
-                    plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
-                    plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
+                    if plugin["dest_service_id"] != "":
+                        # Get the new next service ID pointed to by the plugin through the old service ID
+                        plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
+                        plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
 
         if metadata["compose_service_relation"] is not None:
             for service in metadata["compose_service_relation"]:


### PR DESCRIPTION
- The plugin failed to copy the application
Reason：The ‘ts’ is one service, When there are multiple app, ‘ts' does not change，So All saved plugins point to a component
Solution：Each traverse modifies the value of the service ID