### PR TITLE
Fix Bug: Build Plugin Failed

### DIFF
--- a/console/services/market_app_service.py
+++ b/console/services/market_app_service.py
@@ -396,8 +396,8 @@ class MarketAppService(object):
             "build_source": "image",
             "image": image,
             "code_repo": plugin_template["code_repo"],
-            "username": "",
-            "password": ""
+            "username": plugin_template["plugin_image"]["hub_user"],
+            "password": plugin_template["plugin_image"]["hub_password"]
         }
         status, msg, plugin_base_info = plugin_service.create_tenant_plugin(plugin_params)
         if status != 200:


### PR DESCRIPTION
- When installing an app from the app store, the app plugin image is a private repository. At this time, the plugin is rebuilt in the plugin list and cannot be built
Reason：The first build did not save the user name and password
Solution：Save user name and password