### PR TITLE
Fix Bug: Gitee authentication failed

### DIFF
--- a/console/utils/oauth/base/exception.py
+++ b/console/utils/oauth/base/exception.py
@@ -15,3 +15,8 @@ class NoOAuthServiceErr(Exception):
 
     def __str__(self):
         return self.message
+
+
+class GetOAuthUserErr(Exception):
+    def __init__(self, msg):
+        super(GetOAuthUserErr, self).__init__(msg)

--- a/console/utils/oauth/gitee_api.py
+++ b/console/utils/oauth/gitee_api.py
@@ -3,7 +3,7 @@ import logging
 
 import requests
 
-from console.utils.oauth.base.exception import (NoAccessKeyErr, NoOAuthServiceErr)
+from console.utils.oauth.base.exception import (NoAccessKeyErr, NoOAuthServiceErr, GetOAuthUserErr)
 from console.utils.oauth.base.git_oauth import GitOAuth2Interface
 from console.utils.oauth.base.oauth import OAuth2User
 from console.utils.urlutil import set_get_url
@@ -193,7 +193,9 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
     def get_user_info(self, code=None):
         access_token, refresh_token = self._get_access_token(code=code)
         user = self.api.get_user()
-        return OAuth2User(user["login"], user["id"], user["email"]), access_token, refresh_token
+        if not user:
+            raise GetOAuthUserErr("No OAuth user was obtained")
+        return OAuth2User(user[0]["login"], user[0]["id"], user[0]["email"]), access_token, refresh_token
 
     def get_authorize_url(self):
         if self.oauth_service:


### PR DESCRIPTION
- Because the obtained user information is tuple，tuple indices must be integers. Therefore, the correct information cannot be obtained, resulting in the failure of updating the authentication information
Solution: Use integer index value