### PR TITLE
Fix Bug: Do not display the repositorys under gitlab

### DIFF
--- a/console/utils/oauth/gitlab_api.py
+++ b/console/utils/oauth/gitlab_api.py
@@ -126,7 +126,7 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
         repo_list = []
         if per_page is None:
             per_page = 10
-        for repo in self.api.projects.list(page=page, per_page=per_page, order_by="last_activity_at", owned=True):
+        for repo in self.api.projects.list(page=page, per_page=per_page, order_by="last_activity_at", membership="true"):
             if hasattr(repo, "default_branch"):
                 default_branch = repo.default_branch
             else:
@@ -143,9 +143,12 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
                 "created_at": repo.created_at
             })
         total = len(repo_list)
-        meta = self.api.projects.list(as_list=False, owned=True)
-        if meta and meta.total:
-            total = meta.total
+        meta = self.api.projects.list(as_list=False, membership="true")
+        try:
+            if meta and meta.total:
+                total = meta.total
+        except TypeError:
+            total = 10000
         return repo_list, total
 
     def search_repos(self, full_name, *args, **kwargs):
@@ -154,7 +157,8 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
         per_page = kwargs.get("per_page", 10)
         repo_list = []
         name = full_name.split("/")[-1]
-        for repo in self.api.projects.list(search=name, page=page, per_page=per_page, order_by="last_activity_at", owned=True):
+        for repo in self.api.projects.list(
+                search=name, page=page, per_page=per_page, order_by="last_activity_at", membership="true"):
             repo_list.append({
                 "project_id": repo.id,
                 "project_full_name": repo.path_with_namespace,
@@ -167,9 +171,12 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
                 "created_at": repo.created_at
             })
         total = len(repo_list)
-        meta = self.api.projects.list(search=name, as_list=False, owned=True)
-        if meta and meta.total:
-            total = meta.total
+        meta = self.api.projects.list(search=name, as_list=False, membership="true")
+        try:
+            if meta and meta.total:
+                total = meta.total
+        except TypeError:
+            total = 10000
         return repo_list, total
 
     def get_repo_detail(self, full_name, *args, **kwargs):

--- a/console/utils/oauth/gitlab_api.py
+++ b/console/utils/oauth/gitlab_api.py
@@ -126,7 +126,7 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
         repo_list = []
         if per_page is None:
             per_page = 10
-        for repo in self.api.projects.list(page=page, per_page=per_page, order_by="last_activity_at"):
+        for repo in self.api.projects.list(page=page, per_page=per_page, order_by="last_activity_at", owned=True):
             if hasattr(repo, "default_branch"):
                 default_branch = repo.default_branch
             else:
@@ -143,7 +143,7 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
                 "created_at": repo.created_at
             })
         total = len(repo_list)
-        meta = self.api.projects.list(as_list=False)
+        meta = self.api.projects.list(as_list=False, owned=True)
         if meta and meta.total:
             total = meta.total
         return repo_list, total
@@ -154,7 +154,7 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
         per_page = kwargs.get("per_page", 10)
         repo_list = []
         name = full_name.split("/")[-1]
-        for repo in self.api.projects.list(search=name, page=page, per_page=per_page, order_by="last_activity_at"):
+        for repo in self.api.projects.list(search=name, page=page, per_page=per_page, order_by="last_activity_at", owned=True):
             repo_list.append({
                 "project_id": repo.id,
                 "project_full_name": repo.path_with_namespace,
@@ -167,7 +167,7 @@ class GitlabApiV4(GitlabApiV4MiXin, GitOAuth2Interface):
                 "created_at": repo.created_at
             })
         total = len(repo_list)
-        meta = self.api.projects.list(search=name, as_list=False)
+        meta = self.api.projects.list(search=name, as_list=False, owned=True)
         if meta and meta.total:
             total = meta.total
         return repo_list, total


### PR DESCRIPTION
Bug详情：
- 对接gitlab.com时，无法显示Gitlab下的项目

原因：
> 参考文档：https://git.goodrain.com/help/api/README.md

> **Caution:** For performance reasons since [GitLab 11.8](https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/23931) and **behind the `api_kaminari_count_with_limit` [feature flag](../development/feature_flags.md)**, if the number of resources is more than 10,000, the `X-Total` and `X-Total-Pages` headers as well as the `rel="last"` `Link` are not present in the response headers.
- 对接gitlab.com后，会获取Gitlab中全部项目信息，根据上面文档描述可知，由于数量过大，所以不会返回总数，所以调用SDK时，由于没有`X-Total`，所以在获取项目总数时出错，导致无法展示仓库信息

解决方案：
- 限定只列出自己相关的项目