### PR TITLE
Fix Bug: Application upgrade display

### DIFF
--- a/console/services/app_actions/properties_changes.py
+++ b/console/services/app_actions/properties_changes.py
@@ -14,6 +14,7 @@ from console.services.app import app_market_service, app_service
 from console.services.app_config.volume_service import AppVolumeService
 from console.services.plugin import app_plugin_service
 from console.services.rbd_center_app_service import rbd_center_app_service
+from console.services.group_service import group_service
 
 logger = logging.getLogger("default")
 volume_service = AppVolumeService()
@@ -96,6 +97,8 @@ class PropertiesChanges(object):
         if not self.current_version:
             return None
         upgradeble_versions = []
+        group_id = service_group_relation_repo.get_group_id_by_service(self.service)
+        services = group_service.get_rainbond_services(group_id, self.service_source.group_key)
         if not self.install_from_cloud:
             # 获取最新的时间列表, 判断版本号大小，TODO 确认版本号大小
             # 直接查出当前版本，对比时间，对比版本号大小
@@ -109,9 +112,11 @@ class PropertiesChanges(object):
                 current_version_time = time.mktime(self.service_source.create_time.timetuple())
                 same, max_version = self.checkVersionG2(self.current_version.version, version.version)
                 if not same and max_version != self.current_version.version:
-                    upgradeble_versions.append(version.version)
+                    if self.have_upgrade_info(self.tenant, services, version.version):
+                        upgradeble_versions.append(version.version)
                 elif same and new_version_time > current_version_time:
-                    upgradeble_versions.append(version.version)
+                    if self.have_upgrade_info(self.tenant, services, version.version):
+                        upgradeble_versions.append(version.version)
 
         else:
             app_version_list = app_market_service.get_market_app_model_versions(self.market, self.service_source.group_key)
@@ -122,10 +127,22 @@ class PropertiesChanges(object):
                 current_version_time = time.mktime(self.current_version.update_time.timetuple())
                 same, max_version = self.checkVersionG2(self.current_version.version, version.version)
                 if not same and max_version != self.current_version.version:
-                    upgradeble_versions.append(version.version)
+                    if self.have_upgrade_info(self.tenant, services, version.version):
+                        upgradeble_versions.append(version.version)
                 elif same and new_version_time > current_version_time:
-                    upgradeble_versions.append(version.version)
+                    if self.have_upgrade_info(self.tenant, services, version.version):
+                        upgradeble_versions.append(version.version)
         return upgradeble_versions
+
+    def have_upgrade_info(self, tenant, services, version):
+        from console.services.upgrade_services import upgrade_service
+        if not services:
+            return False
+        for service in services:
+            upgrade_info = upgrade_service.get_service_changes(service, tenant, version)
+            if upgrade_info:
+                return True
+        return False
 
     def checkVersionG2(self, currentversion, expectedversion):
         same = False

--- a/console/services/app_actions/properties_changes.py
+++ b/console/services/app_actions/properties_changes.py
@@ -112,8 +112,7 @@ class PropertiesChanges(object):
                 current_version_time = time.mktime(self.service_source.create_time.timetuple())
                 same, max_version = self.checkVersionG2(self.current_version.version, version.version)
                 if not same and max_version != self.current_version.version:
-                    if self.have_upgrade_info(self.tenant, services, version.version):
-                        upgradeble_versions.append(version.version)
+                    upgradeble_versions.append(version.version)
                 elif same and new_version_time > current_version_time:
                     if self.have_upgrade_info(self.tenant, services, version.version):
                         upgradeble_versions.append(version.version)
@@ -127,8 +126,7 @@ class PropertiesChanges(object):
                 current_version_time = time.mktime(self.current_version.update_time.timetuple())
                 same, max_version = self.checkVersionG2(self.current_version.version, version.version)
                 if not same and max_version != self.current_version.version:
-                    if self.have_upgrade_info(self.tenant, services, version.version):
-                        upgradeble_versions.append(version.version)
+                    upgradeble_versions.append(version.version)
                 elif same and new_version_time > current_version_time:
                     if self.have_upgrade_info(self.tenant, services, version.version):
                         upgradeble_versions.append(version.version)


### PR DESCRIPTION
**Bug Detail:**
- After the application is upgraded, you will be prompted that there is an upgrade version

**Reason:**
- There are no changes to the application, and the application template can be redistributed, so the creation time of the application template is changed. So it will appear at the place to be upgraded

**Solution:**
- Check whether there are changes to the components when getting the upgrade list