### PR TITLE
Fix Bug: Failed to specify application owner

### DIFF
--- a/console/views/team.py
+++ b/console/views/team.py
@@ -204,6 +204,7 @@ class TeamUserView(RegionTenantHeaderView):
                 users_list.append({
                     "user_id": user.user_id,
                     "user_name": user.get_name(),
+                    "nick_name": user.nick_name,
                     "email": user.email,
                     "role_info": role_info_list["roles"]
                 })


### PR DESCRIPTION
**Bug detail:**
- The designated application owner prompts that the user does not exist

**Reason:**
- The user name to be modified may be a real name, which cannot be searched by real name

**Solution:**
- return nick_name