### PR TITLE
Fix Bug: Gitee detection and creation failed

### DIFF
--- a/console/utils/oauth/gitee_api.py
+++ b/console/utils/oauth/gitee_api.py
@@ -286,8 +286,8 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
         rst_list = []
         tags, _ = self.api.get_tags(full_name=full_name)
         if tags is not None:
-            for branch in tags:
-                rst_list.append(branch["name"])
+            for tag in tags:
+                rst_list.append(tag["name"])
         return rst_list
 
     def get_branches_or_tags(self, type, full_name):

--- a/console/utils/oauth/gitee_api.py
+++ b/console/utils/oauth/gitee_api.py
@@ -156,8 +156,8 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
             if self.oauth_user:
                 self.set_api(self.oauth_service.home_url, self.oauth_user.access_token)
                 try:
-                    user = self.api.get_user()
-                    if user[0]["login"]:
+                    user, _ = self.api.get_user()
+                    if user["login"]:
                         return self.oauth_user.access_token, self.oauth_user.refresh_token
                 except Exception:
                     if self.oauth_user.refresh_token:
@@ -275,16 +275,18 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
     def get_branches(self, full_name):
         access_token, _ = self._get_access_token()
         rst_list = []
-        if self.api.get_tags(full_name=full_name) is not None:
-            for branch in self.api.get_branches(full_name=full_name)[0]:
+        branches, _ = self.api.get_branches(full_name=full_name)
+        if branches is not None:
+            for branch in branches:
                 rst_list.append(branch["name"])
         return rst_list
 
     def get_tags(self, full_name):
         access_token, _ = self._get_access_token()
         rst_list = []
-        if self.api.get_tags(full_name=full_name) is not None:
-            for branch in self.api.get_tags(full_name=full_name)[0]:
+        tags, _ = self.api.get_tags(full_name=full_name)
+        if tags is not None:
+            for branch in tags:
                 rst_list.append(branch["name"])
         return rst_list
 

--- a/console/utils/oauth/gitee_api.py
+++ b/console/utils/oauth/gitee_api.py
@@ -157,7 +157,7 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
                 self.set_api(self.oauth_service.home_url, self.oauth_user.access_token)
                 try:
                     user = self.api.get_user()
-                    if user["login"]:
+                    if user[0]["login"]:
                         return self.oauth_user.access_token, self.oauth_user.refresh_token
                 except Exception:
                     if self.oauth_user.refresh_token:
@@ -187,7 +187,7 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
             self.access_token = data.get("access_token")
             self.refresh_token = data.get("refresh_token")
             self.set_api(self.oauth_service.home_url, self.oauth_user.access_token)
-            self.oauth_user = self.oauth_user.save()
+            self.oauth_user.save()
         return
 
     def get_user_info(self, code=None):
@@ -276,7 +276,7 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
         access_token, _ = self._get_access_token()
         rst_list = []
         if self.api.get_tags(full_name=full_name) is not None:
-            for branch in self.api.get_branches(full_name=full_name):
+            for branch in self.api.get_branches(full_name=full_name)[0]:
                 rst_list.append(branch["name"])
         return rst_list
 
@@ -284,7 +284,7 @@ class GiteeApiV5(GiteeApiV5MiXin, GitOAuth2Interface):
         access_token, _ = self._get_access_token()
         rst_list = []
         if self.api.get_tags(full_name=full_name) is not None:
-            for branch in self.api.get_tags(full_name=full_name):
+            for branch in self.api.get_tags(full_name=full_name)[0]:
                 rst_list.append(branch["name"])
         return rst_list
 


### PR DESCRIPTION
**Bug Detail:**
- Gitee was unable to detect the project language
- Gitee could not get the branch information when creating the component

**Reason:**
- The interface returned by API is tuple type, not list, so there is an error in getting the return information

**Solution:**
- Modify data acquisition method