### PR TITLE
Fix Bug: Error creating tag

### DIFF
--- a/console/repositories/app.py
+++ b/console/repositories/app.py
@@ -242,7 +242,7 @@ class AppTagRepository(object):
 
     def create_tags(self, enterprise_id, names):
         tag_list = []
-        old_tag = RainbondCenterAppTag.objects.filter(name__in=names)
+        old_tag = RainbondCenterAppTag.objects.filter(enterprise_id=enterprise_id, name__in=names)
         if old_tag:
             return False
         for name in names:

--- a/sql/5.2.2-5.2.3.sql
+++ b/sql/5.2.2-5.2.3.sql
@@ -1,1 +1,3 @@
 alter table user_oauth_service modify column access_token varchar(2047);
+alter table `rainbond_center_app_tag` drop index `name`;
+alter table `rainbond_center_app_tag` ADD unique(`name`,`enterprise_id`);

--- a/sql/5.2.2-5.2.3.sql
+++ b/sql/5.2.2-5.2.3.sql
@@ -1,3 +1,3 @@
 alter table user_oauth_service modify column access_token varchar(2047);
 alter table `rainbond_center_app_tag` drop index `name`;
-alter table `rainbond_center_app_tag` ADD unique(`name`,`enterprise_id`);
+alter table `rainbond_center_app_tag` add unique(`name`,`enterprise_id`);


### PR DESCRIPTION
**Bug Detail**
- Because the application tag name is unique, different enterprises cannot create the same tag

**Solution**
- Limit tag name and enterprise ID unique