### PR TITLE
Fix Bug: Copy Error

### DIFF
--- a/console/services/groupcopy_service.py
+++ b/console/services/groupcopy_service.py
@@ -140,10 +140,13 @@ class GroupAppCopyService(object):
             # Handling plugin config
             if change_service_map and service["service_plugin_config"]:
                 for plugin in service["service_plugin_config"]:
-                    if plugin["dest_service_id"] != "":
+                    if plugin["dest_service_id"] != "" and plugin["dest_service_id"] not in remove_service_ids:
                         # Get the new next service ID pointed to by the plugin through the old service ID
                         plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
                         plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
+                    else:
+                        plugin["dest_service_alias"] = ""
+                        plugin["dest_service_id"] = ""
 
         if metadata["compose_service_relation"] is not None:
             for service in metadata["compose_service_relation"]:


### PR DESCRIPTION
**Bug Detail**
- When the plug-in configuration of component A points to another component B, an error occurs when only component A is copied

**Reason**
- Failed to get the downstream component ID pointed to by the plug-in configuration, resulting in an error

**Solution**
- If the downstream component that the plug-in configuration points to is not copied, the plug-in configuration is not added