### PR TITLE
Fix Bug: Plugin copy errors

### DIFF
--- a/console/services/groupcopy_service.py
+++ b/console/services/groupcopy_service.py
@@ -102,8 +102,10 @@ class GroupAppCopyService(object):
                     for plugin in service["service_plugin_config"]:
                         if plugin["dest_service_id"] != "":
                             # Get the new next service ID pointed to by the plugin through the old service ID
-                            plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
-                            plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
+                            plugin["dest_service_alias"] = change_service_map.get(plugin["dest_service_id"], {}).get(
+                                "ServiceAlias", "")
+                            plugin["dest_service_id"] = change_service_map.get(plugin["dest_service_id"], {}).get(
+                                "ServiceID", "")
             return metadata
         new_metadata = {}
         new_metadata["compose_group_info"] = metadata["compose_group_info"]
@@ -142,8 +144,9 @@ class GroupAppCopyService(object):
                 for plugin in service["service_plugin_config"]:
                     if plugin["dest_service_id"] != "" and plugin["dest_service_id"] not in remove_service_ids:
                         # Get the new next service ID pointed to by the plugin through the old service ID
-                        plugin["dest_service_alias"] = change_service_map[plugin["dest_service_id"]]["ServiceAlias"]
-                        plugin["dest_service_id"] = change_service_map[plugin["dest_service_id"]]["ServiceID"]
+                        plugin["dest_service_alias"] = change_service_map.get(plugin["dest_service_id"], {}).get(
+                            "ServiceAlias", "")
+                        plugin["dest_service_id"] = change_service_map.get(plugin["dest_service_id"], {}).get("ServiceID", "")
                     else:
                         plugin["dest_service_alias"] = ""
                         plugin["dest_service_id"] = ""


### PR DESCRIPTION
**Bug Detail**
- Failed to get the component ID pointed to by the plugin configuration when copying the application, resulting in an error

**Reason**
- Due to dirty data in the plug-in configuration item

**Solution**
- Ignore when the component ID cannot be obtained