### PR TITLE
Bug Fix: The outer environment variable is missing

### DIFF
--- a/console/services/share_services.py
+++ b/console/services/share_services.py
@@ -309,17 +309,15 @@ class ShareService(object):
                 data['service_connect_info_map_list'] = list()
                 if service_env_map.get(service.service_id):
                     for env_change in service_env_map.get(service.service_id):
-                        if env_change.container_port == 0:
-                            e_c = dict()
-                            e_c['name'] = env_change.name
-                            e_c['attr_name'] = env_change.attr_name
-                            e_c['attr_value'] = env_change.attr_value
-                            e_c['is_change'] = env_change.is_change
-                            if env_change.scope == "outer":
-                                e_c['container_port'] = env_change.container_port
-                                data['service_connect_info_map_list'].append(e_c)
-                            else:
-                                data['service_env_map_list'].append(e_c)
+                        e_c = dict()
+                        e_c['name'] = env_change.name
+                        e_c['attr_name'] = env_change.attr_name
+                        e_c['attr_value'] = env_change.attr_value
+                        e_c['is_change'] = env_change.is_change
+                        if env_change.scope == "outer":
+                            data['service_connect_info_map_list'].append(e_c)
+                        else:
+                            data['service_env_map_list'].append(e_c)
 
                 data['service_related_plugin_config'] = list()
                 # plugins_attr_list = share_repo.get_plugin_config_var_by_service_ids(service_ids=service_ids)


### PR DESCRIPTION
发布应用的时候，不知道 `if env_change.container_port == 0` 这个条件的作用是什么。它会导致发布出去的应用缺少连接信息，导致 docker-compose.yaml 缺少一些环境变量。

把这个条件去除了，没有影响安装。在安装时候，和端口相关的环境变量没有冲突。