### PR TITLE
Fix Bug: the problem that the probe failed to copy the component

### DIFF
--- a/console/services/app_config/domain_service.py
+++ b/console/services/app_config/domain_service.py
@@ -627,7 +627,8 @@ class DomainService(object):
     def get_app_service_domain_list(self, region, tenant, app_id, search_conditions, page, page_size):
         # 查询分页排序
         if search_conditions:
-            search_conditions = search_conditions.decode('utf-8')
+            if isinstance(search_conditions, bytes):
+                search_conditions = search_conditions.decode('utf-8')
             # 获取总数
             cursor = connection.cursor()
             cursor.execute("select count(sd.domain_name) \
@@ -696,7 +697,8 @@ class DomainService(object):
     def get_app_service_tcp_domain_list(self, region, tenant, app_id, search_conditions, page, page_size):
         # 查询分页排序
         if search_conditions:
-            search_conditions = search_conditions.decode('utf-8')
+            if isinstance(search_conditions, bytes):
+                search_conditions = search_conditions.decode('utf-8')
             # 获取总数
             cursor = connection.cursor()
             cursor.execute("select count(1) from service_tcp_domain std \

--- a/console/services/groupapp_recovery/groupapps_migrate.py
+++ b/console/services/groupapp_recovery/groupapps_migrate.py
@@ -234,7 +234,8 @@ class GroupappsMigrateService(object):
                                app["service_config_file"] if 'service_config_file' in app else None)
             self.__save_compile_env(ts, app["service_compile_env"])
             self.__save_service_label(migrate_tenant, ts, migrate_region, app["service_labels"])
-            self.__save_service_probes(ts, app["service_probes"])
+            if sync_flag:
+                self.__save_service_probes(ts, app["service_probes"])
             self.__save_service_source(migrate_tenant, ts, app["service_source"])
             self.__save_service_auth(ts, app["service_auths"])
             self.__save_third_party_service_endpoints(ts, app.get("third_party_service_endpoints", []))


### PR DESCRIPTION
- When copying components, the probe information was added to the console database first, so the probe could not be created in the data center. So do not create component probe information here.