### PR TITLE
bug fix: plugin conflict

### DIFF
--- a/.github/workflows/commit-ci-build.yaml
+++ b/.github/workflows/commit-ci-build.yaml
@@ -32,4 +32,4 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOMESTIC_DOCKER_PASSWORD: ${{ secrets.DOMESTIC_DOCKER_PASSWORD }}
           DOMESTIC_DOCKER_USERNAME: ${{ secrets.DOMESTIC_DOCKER_USERNAME }}
-        run: VERSION=${{ steps.extract_branch.outputs.branch }}-dev ./release.sh
+        run: VERSION=${{ github.base_ref }}-dev ./release.sh

--- a/.github/workflows/pr-ci-build.yaml
+++ b/.github/workflows/pr-ci-build.yaml
@@ -32,4 +32,4 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOMESTIC_DOCKER_PASSWORD: ${{ secrets.DOMESTIC_DOCKER_PASSWORD }}
           DOMESTIC_DOCKER_USERNAME: ${{ secrets.DOMESTIC_DOCKER_USERNAME }}
-        run: VERSION=${{ steps.extract_branch.outputs.branch }}-dev ./release.sh
+        run: VERSION=${{ github.base_ref }}-dev ./release.sh

--- a/console/services/plugin/app_plugin.py
+++ b/console/services/plugin/app_plugin.py
@@ -231,7 +231,6 @@ class AppPluginService(object):
         region_api.uninstall_service_plugin(region_name, tenant.tenant_name, old_plugin["plugin_id"], service.service_alias)
         region_api.install_service_plugin(region_name, tenant.tenant_name, service.service_alias, data)
 
-
     def save_default_plugin_config(self, tenant, service, plugin_id, build_version):
         """console层保存默认的数据"""
         config_groups = plugin_config_service.get_config_group(plugin_id, build_version)

--- a/console/services/plugin/app_plugin.py
+++ b/console/services/plugin/app_plugin.py
@@ -204,6 +204,8 @@ class AppPluginService(object):
             if msg == "can not add this kind plugin, a same kind plugin has been linked":
                 old_plugin = body.get("bean")
                 self.handle_network_plugin_conflict(tenant, region, service, old_plugin, data)
+                return
+            raise e
 
     @staticmethod
     def handle_network_plugin_conflict(tenant, region_name, service, old_plugin, data):


### PR DESCRIPTION
There are two situations that can cause network plugin conflicts:
1. The network plugin is indeed installed.
2. The console and region data are inconsistent. There are network plugin in the region, but the console does not.
In situation 2, we have to ensure the network plugins between console and region are consistent.
And the network plugin in the console should take effect.

Refer to: goodrain/rainbond#962