### PR TITLE
Fix Bug: Application rollback failed

### DIFF
--- a/console/views/app_upgrade.py
+++ b/console/views/app_upgrade.py
@@ -314,7 +314,7 @@ class AppUpgradeRollbackView(RegionTenantHeaderView):
             service_id__in=service_ids)
 
         if not service_records:
-            raise AbortRequest(msg="This upgrade cannot be rolled back", msg_show="本次升级无法回滚")
+            raise AbortRequest(msg="This upgrade cannot be rolled back", msg_show="本次升级不支持回滚")
 
         services = service_repo.get_services_by_service_ids_and_group_key(
             app_record.group_key,

--- a/console/views/app_upgrade.py
+++ b/console/views/app_upgrade.py
@@ -312,6 +312,10 @@ class AppUpgradeRollbackView(RegionTenantHeaderView):
                         UpgradeStatus.ROLLBACK_FAILED.value),
             upgrade_type=ServiceUpgradeRecord.UpgradeType.UPGRADE.value,
             service_id__in=service_ids)
+
+        if not service_records:
+            raise AbortRequest(msg="This upgrade cannot be rolled back", msg_show="本次升级无法回滚")
+
         services = service_repo.get_services_by_service_ids_and_group_key(
             app_record.group_key,
             service_records.values_list('service_id', flat=True) or [])


### PR DESCRIPTION
- When an upgrade only adds new components, it cannot be rolled back, but in the end, the status of this record is changed to rolling back, resulting in inability to operate. So the pre-restriction cannot be rolled back