### PR TITLE
resource insufficient

### DIFF
--- a/console/exception/main.py
+++ b/console/exception/main.py
@@ -160,3 +160,15 @@ class StoreNoPermissionsError(ServiceHandleException):
 class ErrVolumePath(ServiceHandleException):
     def __init__(self, msg="path error", msg_show="路径错误", status_code=412):
         super(ErrVolumePath, self).__init__(msg, msg_show, status_code)
+
+
+class ErrInsufficientResource(ServiceHandleException):
+    def __init__(self, msg):
+        super(ErrInsufficientResource, self).__init__(msg)
+        msg_shows = {"cluster_lack_of_memory": "集群可用资源不足，请联系集群管理员", "tenant_lack_of_memory": "团队使用内存已超过限额，请联系企业管理员增加限额"}
+        msg_show = msg_shows.get(msg)
+        if not msg_show:
+            msg_show = "资源不足，请联系管理员"
+        self.msg_show = msg_show
+        self.status_code = 412
+        self.error_code = 10406

--- a/console/services/app_actions/app_manage.py
+++ b/console/services/app_actions/app_manage.py
@@ -167,9 +167,6 @@ class AppManageService(AppManageBase):
             except region_api.CallApiError as e:
                 logger.exception(e)
                 return 507, "组件异常"
-            except region_api.ResourceNotEnoughError as e:
-                logger.exception(e)
-                return 412, e.msg
             except region_api.CallApiFrequentError as e:
                 logger.exception(e)
                 return 409, "操作过于频繁，请稍后再试"
@@ -205,9 +202,6 @@ class AppManageService(AppManageBase):
             except region_api.CallApiError as e:
                 logger.exception(e)
                 return 507, "组件异常"
-            except region_api.ResourceNotEnoughError as e:
-                logger.exception(e)
-                return 412, e.msg
             except region_api.CallApiFrequentError as e:
                 logger.exception(e)
                 return 409, "操作过于频繁，请稍后再试"
@@ -303,9 +297,6 @@ class AppManageService(AppManageBase):
                 raise ErrVersionAlreadyExists()
             logger.exception(e)
             return 507, "构建异常", ""
-        except region_api.ResourceNotEnoughError as e:
-            logger.exception(e)
-            return 412, e.msg, ""
         except region_api.CallApiFrequentError as e:
             logger.exception(e)
             return 409, "操作过于频繁，请稍后再试", ""
@@ -453,9 +444,6 @@ class AppManageService(AppManageBase):
         except region_api.CallApiError as e:
             logger.exception(e)
             return 507, "更新异常", ""
-        except region_api.ResourceNotEnoughError as e:
-            logger.exception(e)
-            return 412, e.msg, ""
         except region_api.CallApiFrequentError as e:
             logger.exception(e)
             return 409, "操作过于频繁，请稍后再试", ""
@@ -503,9 +491,6 @@ class AppManageService(AppManageBase):
             except region_api.CallApiError as e:
                 logger.exception(e)
                 return 507, "组件异常"
-            except region_api.ResourceNotEnoughError as e:
-                logger.exception(e)
-                return 412, e.msg
             except region_api.CallApiFrequentError as e:
                 logger.exception(e)
                 return 409, "操作过于频繁，请稍后再试"
@@ -793,9 +778,6 @@ class AppManageService(AppManageBase):
             except region_api.CallApiError as e:
                 logger.exception(e)
                 return 507, "组件异常"
-            except region_api.ResourceNotEnoughError as e:
-                logger.exception(e)
-                return 412, e.msg
             except region_api.CallApiFrequentError as e:
                 logger.exception(e)
                 return 409, "操作过于频繁，请稍后再试"
@@ -829,9 +811,6 @@ class AppManageService(AppManageBase):
             except region_api.CallApiError as e:
                 logger.exception(e)
                 raise ServiceHandleException(status_code=507, msg="component error", msg_show="组件异常")
-            except region_api.ResourceNotEnoughError as e:
-                logger.exception(e)
-                raise ServiceHandleException(status_code=412, msg="resource not enough", msg_show=e.msg)
             except region_api.CallApiFrequentError as e:
                 logger.exception(e)
                 raise ServiceHandleException(status_code=409, msg="just wait a moment", msg_show="操作过于频繁，请稍后再试")

--- a/goodrain_web/settings.py
+++ b/goodrain_web/settings.py
@@ -26,6 +26,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 HOME_DIR = os.getenv("HOME_DIR", BASE_DIR)
 
 DATA_DIR = os.path.join(HOME_DIR, 'data')
+DATA_DIR = os.getenv("DATA_DIR", DATA_DIR)
 # Create log directory
 LOG_PATH = os.getenv("LOG_PATH", os.path.join(HOME_DIR, 'logs'))
 folder = os.path.exists(LOG_PATH)


### PR DESCRIPTION
### 问题

构建组件的时候, 如果资源不足, 会导致构建失败. 但是没有任何提示.

```
except region_api.ResourceNotEnoughError as e:
      logger.exception(e)
      return 412, e.msg
```
使用以上的方式处理异常, 然后在调用端又没有接收返回值, 进行异常处理. 导致异常被忽略了

### 解决方法

1. 改用 raise exception 的方式处理异常
2. region_api.ResourceNotEnoughError 改写为标准的异常类 ErrInsufficientResource

