### PR TITLE
Bug Fix: delete component port

### DIFF
--- a/console/repositories/app_config.py
+++ b/console/repositories/app_config.py
@@ -511,6 +511,10 @@ class ServiceDomainRepository(object):
     def delete_service_domain_by_port(self, service_id, container_port):
         ServiceDomain.objects.filter(service_id=service_id, container_port=container_port).delete()
 
+    @staticmethod
+    def list_service_domain_by_port(service_id, container_port):
+        return ServiceDomain.objects.filter(service_id=service_id, container_port=container_port)
+
     def delete_service_domain(self, service_id):
         ServiceDomain.objects.filter(service_id=service_id).delete()
 
@@ -760,6 +764,10 @@ class ServiceTcpDomainRepository(object):
     def count_by_service_ids(region_id, service_ids):
         return ServiceTcpDomain.objects.filter(region_id=region_id, service_id__in=service_ids).count()
 
+    @staticmethod
+    def delete_by_component_port(component_id, port):
+        ServiceTcpDomain.objects.filter(service_id=component_id, container_port=port).delete()
+
 
 class TenantServiceEndpoints(object):
     def get_service_endpoints_by_service_id(self, service_id):
@@ -804,6 +812,10 @@ class GatewayCustom(object):
 
     def add_configuration(self, **configuration_info):
         return GatewayCustomConfiguration.objects.create(**configuration_info)
+
+    @staticmethod
+    def delete_by_rule_ids(rule_ids):
+        GatewayCustomConfiguration.objects.filter(rule_id__in=rule_ids).delete()
 
 
 tcp_domain = ServiceTcpDomainRepository()

--- a/console/services/app_config/domain_service.py
+++ b/console/services/app_config/domain_service.py
@@ -853,3 +853,17 @@ class DomainService(object):
                     msg_show="Header Key不合法",
                     status_code=400,
                     error_code=400)
+
+    @staticmethod
+    def delete_by_port(component_id, port):
+        http_rules = domain_repo.list_service_domain_by_port(component_id, port)
+        http_rule_ids = [rule.http_rule_id for rule in http_rules]
+        # delete rule extensions
+        configuration_repo.delete_by_rule_ids(http_rule_ids)
+        # delete http rules
+        domain_repo.delete_service_domain_by_port(component_id, port)
+        # delete tcp rules
+        tcp_domain.delete_by_component_port(component_id, port)
+
+
+domain_service = DomainService()

--- a/console/views/app_config/app_port.py
+++ b/console/views/app_config/app_port.py
@@ -206,11 +206,8 @@ class AppPortManageView(AppBaseView):
         """
         container_port = kwargs.get("port", None)
         if not container_port:
-            return Response(general_message(400, "container_port not specify", "端口变量名未指定"), status=400)
-        code, msg, data = port_service.delete_port_by_container_port(self.tenant, self.service, int(container_port),
-                                                                     self.user.nick_name)
-        if code != 200:
-            return Response(general_message(code, "delete port fail", msg), status=code)
+            raise AbortRequest("container_port not specify", "端口变量名未指定")
+        data = port_service.delete_port_by_container_port(self.tenant, self.service, int(container_port), self.user.nick_name)
         result = general_message(200, "success", "删除成功", bean=model_to_dict(data))
         return Response(result, status=result["code"])
 


### PR DESCRIPTION
We should delete ingress rules, rule configs, and rule extensions after deleting a component port.
refer to: goodrain/rainbond#990