### PR TITLE
bug fix: SUBSTRING does not exist

### DIFF
--- a/sql/5.3.0-5.3.1.sql
+++ b/sql/5.3.0-5.3.1.sql
@@ -71,6 +71,6 @@ WHERE
 UPDATE service_source SET service_share_uuid=CONCAT(SUBSTRING(service_share_uuid, 34),"+",SUBSTRING(service_share_uuid, 34));
 UPDATE tenant_service a
 JOIN service_source b ON a.service_id = b.service_id 
-SET a.service_key = SUBSTRING ( b.service_share_uuid, 34 ) 
+SET a.service_key = SUBSTRING( b.service_share_uuid, 34 )
 WHERE
 	a.service_source = "market";


### PR DESCRIPTION
### Bug Detail

ERROR 1630 (42000): FUNCTION rbdconsole.SUBSTRING does not exist. Check the 'Function Name Parsing and Resolution' section in the Reference Manual