### PR TITLE
bug fix: error decoding signature

### DIFF
--- a/console/captcha/captcha_code.py
+++ b/console/captcha/captcha_code.py
@@ -6,7 +6,7 @@ import re
 import uuid
 from io import BytesIO
 
-from console.views.base import BaseApiView
+from console.views.base import AlowAnyApiView
 from django.conf import settings
 from django.http import HttpResponse
 from PIL import Image, ImageDraw, ImageFont
@@ -18,7 +18,7 @@ current_path = settings.BASE_DIR
 NON_DIGITS_RX = re.compile('[^\d]')
 
 
-class CaptchaView(BaseApiView):
+class CaptchaView(AlowAnyApiView):
     def getsize(self, font, text):
         if hasattr(font, 'getoffset'):
             return [x + y for x, y in zip(font.getsize(text), font.getoffset(text))]


### PR DESCRIPTION
### Bug Detail

arm 架构下:

![image](https://user-images.githubusercontent.com/21967570/124712503-f747c700-df31-11eb-9428-195b326ff067.png)

### Solution

用 AlowAnyApiView 替换 BaseApiView, 可以解决问题.

```python
class BaseApiView(APIView):
    permission_classes = (AllowAny, )

    def __init__(self, *args, **kwargs):
        super(BaseApiView, self).__init__(*args, **kwargs)
        self.report = Dict({"ok": True})

class AlowAnyApiView(APIView):
    """
    该API不需要通过任何认证
    """
    permission_classes = (AllowAny, )
    authentication_classes = ()

    def __init__(self, *args, **kwargs):
        super(AlowAnyApiView, self).__init__(*args, **kwargs)
        self.report = Dict({"ok": True})
        self.user = None

    def initial(self, request, *args, **kwargs):
        self.user = request.user

可能是 arm 下的 rest_framework 和 amd64 上不完全一样, 导致 BaseApiView 在获取验证码时无法正常工作.
```

