### PR TITLE
Bug Fix: wrong port envs

### DIFF
--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -28,7 +28,6 @@ from console.exception.main import ErrVolumePath
 # enum
 from console.enum.component_enum import ComponentType
 from console.constants import AppConstants
-from console.enum.app import GovernanceModeEnum
 # util
 from www.utils.crypt import make_uuid
 
@@ -95,7 +94,6 @@ class NewComponents(object):
             inner_envs = component_tmpl.get("service_env_map_list")
             outer_envs = component_tmpl.get("service_connect_info_map_list")
             envs = self._template_to_envs(cpt, inner_envs, outer_envs)
-            envs = self._ensure_port_envs(cpt, envs, ports, self.original_app.governance_mode)
             # volumes
             volumes, config_files = self._template_to_volumes(cpt, component_tmpl.get("service_volume_map_list"))
             # probe
@@ -115,9 +113,11 @@ class NewComponents(object):
                 tenant_id=self.tenant.tenant_id,
                 region_name=self.region_name,
             )
-            result.append(
-                Component(cpt, component_source, envs, ports, volumes, config_files, probe, extend_info, monitors, graphs, [],
-                          http_rules, service_group_rel))
+
+            component = Component(cpt, component_source, envs, ports, volumes, config_files, probe, extend_info, monitors,
+                                  graphs, [], http_rules, service_group_rel)
+            component.ensure_port_envs(self.original_app.governance_mode)
+            result.append(component)
         return result
 
     def _template_to_component(self, tenant_id, template):
@@ -257,22 +257,6 @@ class NewComponents(object):
             if gateway_rule:
                 gateway_rules.append(gateway_rule)
         return new_ports, gateway_rules
-
-    def _ensure_port_envs(self, component, envs, ports, governance_mode):
-        # filter out the old port envs
-        envs = [env for env in envs if env.container_port == 0]
-        # create outer envs for every port
-        for port in ports:
-            envs.extend(self._create_envs_4_ports(component, port, governance_mode))
-        return envs
-
-    def _create_envs_4_ports(self, component: TenantServiceInfo, port: TenantServicesPort, governance_mode):
-        port_alias = component.service_alias.upper()
-        host_value = "127.0.0.1" if governance_mode == GovernanceModeEnum.BUILD_IN_SERVICE_MESH.name else port.k8s_service_name
-        attr_name_prefix = port_alias + str(port.container_port)
-        host_env = self._create_port_env(component, port, "连接地址", attr_name_prefix + "_HOST", host_value)
-        port_env = self._create_port_env(component, port, "端口", attr_name_prefix + "_PORT", str(port.container_port))
-        return [host_env, port_env]
 
     @staticmethod
     def _create_port_env(component: TenantServiceInfo, port: TenantServicesPort, name, attr_name, attr_value):


### PR DESCRIPTION
### Bug Detail

```python
port_alias = self.component.service_alias.upper()
```

The code below is wrong, should use port.port_alias first.

### Solution

1. should use port.port_alias first
2. eliminate duplicate function `_ensure_port_envs`