### PR TITLE
Fix Bug: Record the name of the app store and template

### DIFF
--- a/console/models/main.py
+++ b/console/models/main.py
@@ -227,7 +227,9 @@ class ServiceShareRecord(BaseModel):
     status = models.IntegerField(default=0, help_text="当前发布状态 1, 2, 3")
     app_id = models.CharField(max_length=64, null=True, blank=True, help_text="应用id")
     scope = models.CharField(max_length=64, null=True, blank=True, help_text="分享范围")
-    share_app_market_name = models.CharField(max_length=64, null=True, blank=True, help_text="分享应用商店名称")
+    share_app_market_name = models.CharField(max_length=64, null=True, blank=True, help_text="分享应用商店标识")
+    share_store_name = models.CharField(max_length=64, null=True, blank=True, help_text="分享应用商店名称，用于记录发布范围指定的应用商店名")
+    share_app_model_name = models.CharField(max_length=64, null=True, blank=True, help_text="分享应用模板名称")
     create_time = models.DateTimeField(auto_now_add=True, help_text="创建时间")
     update_time = models.DateTimeField(auto_now_add=True, help_text="更新时间")
 

--- a/console/services/share_services.py
+++ b/console/services/share_services.py
@@ -703,6 +703,7 @@ class ShareService(object):
             market_id = None
             market = None
             app_model_name = None
+            share_store_name = ''
             if target:
                 market_id = target.get("store_id")
             if not market_id:
@@ -710,9 +711,10 @@ class ShareService(object):
             if market_id:
                 scope = "goodrain"
                 market = app_market_service.get_app_market_by_name(share_team.enterprise_id, market_id, raise_exception=True)
-                cloud_app = app_market_service.get_market_app_model(market, app_model_id)
+                cloud_app = app_market_service.get_market_app_model(market, app_model_id, True)
                 if cloud_app:
                     app_model_name = cloud_app.app_name
+                    share_store_name = cloud_app.market_name
             else:
                 local_app_version = RainbondCenterApp.objects.filter(app_id=app_model_id).first()
                 if not local_app_version:
@@ -862,6 +864,8 @@ class ShareService(object):
             share_record.share_version = version
             share_record.share_version_alias = version_alias
             share_record.share_app_market_name = market_id
+            share_record.share_app_model_name = app_model_name
+            share_record.share_store_name = share_store_name
             share_record.update_time = datetime.datetime.now()
             share_record.share_app_version_info = version_describe
             share_record.save()

--- a/console/views/service_share.py
+++ b/console/views/service_share.py
@@ -53,36 +53,33 @@ class ServiceShareRecordView(RegionTenantHeaderView):
             store_name = share_record.share_store_name
             store_id = share_record.share_app_market_name
             scope = share_record.scope
-            app = rainbond_app_repo.get_rainbond_app_by_app_id(self.tenant.enterprise_id, share_record.app_id)
-            if app:
-                if not app_model_name:
-                    app_model_name = app.app_name
-                    app_version = rainbond_app_repo.get_rainbond_app_version_by_record_id(share_record.ID)
-                    if app_version:
-                        upgrade_time = app_version.upgrade_time
-                        share_record.share_version_alias = app_version.version_alias
-                        share_record.share_app_version_info = app_version.app_version_info
-                    share_record.share_app_model_name = app_model_name
-                    share_record.save()
-            else:
+            if scope != "goodrain" and not app_model_name:
+                app = rainbond_app_repo.get_rainbond_app_by_app_id(self.tenant.enterprise_id, share_record.app_id)
+                app_model_name = app.app_name
+                app_version = rainbond_app_repo.get_rainbond_app_version_by_record_id(share_record.ID)
+                if app_version:
+                    upgrade_time = app_version.upgrade_time
+                    share_record.share_version_alias = app_version.version_alias
+                    share_record.share_app_version_info = app_version.app_version_info
+                share_record.share_app_model_name = app_model_name
+                share_record.save()
+            if scope == "goodrain" and store_id and share_record.app_id and not app_model_name:
                 try:
-                    if store_id and share_record.app_id:
-                        if not app_model_name:
-                            mkt = market.get(share_record.share_app_market_name, None)
-                            if not mkt:
-                                mkt = app_market_service.get_app_market_by_name(
-                                    self.tenant.enterprise_id, share_record.share_app_market_name, raise_exception=True)
-                                market[share_record.share_app_market_name] = mkt
+                    mkt = market.get(share_record.share_app_market_name, None)
+                    if not mkt:
+                        mkt = app_market_service.get_app_market_by_name(
+                            self.tenant.enterprise_id, share_record.share_app_market_name, raise_exception=True)
+                        market[share_record.share_app_market_name] = mkt
 
-                            c_app = cloud_app.get(share_record.app_id, None)
-                            if not c_app:
-                                c_app = app_market_service.get_market_app_model(mkt, share_record.app_id, True)
-                                cloud_app[share_record.app_id] = c_app
-                            store_name = c_app.market_name
-                            app_model_name = c_app.app_name
-                            share_record.share_app_model_name = app_model_name
-                            share_record.share_store_name = store_name
-                            share_record.save()
+                    c_app = cloud_app.get(share_record.app_id, None)
+                    if not c_app:
+                        c_app = app_market_service.get_market_app_model(mkt, share_record.app_id, True)
+                        cloud_app[share_record.app_id] = c_app
+                    store_name = c_app.market_name
+                    app_model_name = c_app.app_name
+                    share_record.share_app_model_name = app_model_name
+                    share_record.share_store_name = store_name
+                    share_record.save()
                 except ServiceHandleException:
                     app_model_id = share_record.app_id
             data.append({

--- a/console/views/service_share.py
+++ b/console/views/service_share.py
@@ -83,33 +83,22 @@ class ServiceShareRecordView(RegionTenantHeaderView):
                 except ServiceHandleException:
                     app_model_id = share_record.app_id
             data.append({
-                "app_model_id":
-                app_model_id,
-                "app_model_name":
-                app_model_name,
-                "version":
-                share_record.share_version,
+                "app_model_id": app_model_id,
+                "app_model_name": app_model_name,
+                "version": share_record.share_version,
                 "version_alias": share_record.share_version_alias,
-                "scope":
-                scope,
-                "create_time":
-                share_record.create_time,
-                "upgrade_time":
-                upgrade_time,
-                "step":
-                share_record.step,
-                "is_success":
-                share_record.is_success,
-                "status":
-                share_record.status,
+                "scope": scope,
+                "create_time": share_record.create_time,
+                "upgrade_time": upgrade_time,
+                "step": share_record.step,
+                "is_success": share_record.is_success,
+                "status": share_record.status,
                 "scope_target": {
                     "store_name": store_name,
                     "store_id": store_id,
                 },
-                "record_id":
-                share_record.ID,
-                "app_version_info":
-                share_record.share_app_version_info,
+                "record_id": share_record.ID,
+                "app_version_info": share_record.share_app_version_info,
             })
         result = general_message(200, "success", "获取成功", bean={'total': total}, list=data)
         return Response(result, status=200)

--- a/sql/5.3.1-5.3.2.sql
+++ b/sql/5.3.1-5.3.2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE service_share_record ADD COLUMN `share_store_name` VARCHAR(64) DEFAULT '';
+ALTER TABLE service_share_record ADD COLUMN `share_app_model_name` VARCHAR(64) DEFAULT '';


### PR DESCRIPTION
- Problem：When obtaining the publishing record, if the app store does not exist, the app store name and app template name cannot be obtained. 
- Solution：it is modified to be recorded at publishing time. When obtaining the publishing record, if there is a record, the value of the record is used directly. Otherwise, call the interface to get the name