### PR TITLE
Bug Fix: update component and port env

### DIFF
--- a/console/services/app_config/env_service.py
+++ b/console/services/app_config/env_service.py
@@ -271,7 +271,7 @@ class AppEnvVarService(object):
             service_id=port.service_id,
             container_port=port.container_port,
             name=name,
-            attr_name=port.port_alias + str(port.container_port) + "_" + attr_name_suffix,
+            attr_name=port.port_alias + "_" + attr_name_suffix,
             attr_value=attr_value,
             is_change=False,
             scope="outer",

--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -148,6 +148,9 @@ class AppPortService(object):
             component_base["component_id"] = component_base["service_id"]
             component_base["component_name"] = component_base["service_name"]
             component_base["component_alias"] = component_base["service_alias"]
+            component_base["container_cpu"] = cpt.min_cpu
+            component_base["container_memory"] = cpt.min_memory
+            component_base["replicas"] = cpt.min_node
             component = {
                 "component_base": component_base,
                 "ports": [port.to_dict() for port in ports if port.service_id == cpt.component_id],


### PR DESCRIPTION
1. 生成端口环境变量时, 不需要在 port_alias 后添加端口号
2. 同步组件时, 数据中心接收的参数是 `container_cpu`, 而不是 `min_cpu`