### PR TITLE
error decoding signature

### DIFF
--- a/console/views/base.py
+++ b/console/views/base.py
@@ -150,8 +150,24 @@ class JSONWebTokenAuthentication(BaseJSONWebTokenAuthentication):
         return user
 
 
+class JWTAuthenticationSafe(JSONWebTokenAuthentication):
+    """
+    Use authentication_classes=[] in the view, but this always bypasses JWT authentication,
+    even when there is a valid Authorization-header with a token.
+    This class can obtain relevant user information when it has a token,
+    and is used for apis that do not require authentication
+    """
+
+    def authenticate(self, request):
+        try:
+            return super().authenticate(request=request)
+        except AuthenticationInfoHasExpiredError:
+            return None
+
+
 class BaseApiView(APIView):
     permission_classes = (AllowAny, )
+    authentication_classes = (JWTAuthenticationSafe, )
 
     def __init__(self, *args, **kwargs):
         super(BaseApiView, self).__init__(*args, **kwargs)


### PR DESCRIPTION
### Bug Detail

在 arm, python 3.6 环境, 任何 `BaseApiView` 的子类都会报 `error decoding signature`.

```python
class APIView(View):

    # The following policies may be set at either globally, or per-view.
    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES
    parser_classes = api_settings.DEFAULT_PARSER_CLASSES
    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
    throttle_classes = api_settings.DEFAULT_THROTTLE_CLASSES
    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES
    content_negotiation_class = api_settings.DEFAULT_CONTENT_NEGOTIATION_CLASS
    metadata_class = api_settings.DEFAULT_METADATA_CLASS
    versioning_class = api_settings.DEFAULT_VERSIONING_CLASS
```
BaseApiView 没有重写 permission_classes, 所以走 APIView 的默认 permission_classes, 即 api_settings.DEFAULT_PERMISSION_CLASSES. 在 arm, python 3.6 环境, api_settings.DEFAULT_PERMISSION_CLASSES, 不提供 token 就会报 `error decoding signature`.

### Solution

用 `JWTAuthenticationSafe` 重写 `authentication_classes`, 可以不提供token(捕获并忽略了不提供 token 的 Exception). 类似 `AlowAnyApiView` (两个基类应该是重复了):

```pyhon
class AlowAnyApiView(APIView):
    """
    该API不需要通过任何认证
    """
    permission_classes = (AllowAny, )
    authentication_classes = (JWTAuthenticationSafe, )

    def __init__(self, *args, **kwargs):
        super(AlowAnyApiView, self).__init__(*args, **kwargs)
        self.report = Dict({"ok": True})
        self.user = None

    def initial(self, request, *args, **kwargs):
        self.user = request.user
```