### PR TITLE
raise explicit error: CallApiError

### DIFF
--- a/console/services/region_services.py
+++ b/console/services/region_services.py
@@ -383,6 +383,8 @@ class RegionService(object):
             raise ServiceHandleException(status_code=400, msg="", msg_show="集群ID{0}已存在".format(region_data["region_name"]))
         try:
             region_api.test_region_api(region_data)
+        except region_api.CallApiError:
+            raise ServiceHandleException(status_code=400, msg="request timed out", msg_show="连接集群超时，请确保访问地址的可用性, 且已放行 8443 端口")
         except ServiceHandleException:
             raise ServiceHandleException(status_code=400, msg="test link region field", msg_show="连接集群测试失败，请确认网络和集群状态")
         region = region_repo.create_region(region_data)

--- a/www/apiclient/regionapibaseclient.py
+++ b/www/apiclient/regionapibaseclient.py
@@ -170,6 +170,12 @@ class RegionApiBaseHttpClient(object):
                 "error_code": 10411,
             })
         except MaxRetryError as e:
+            if type(e.reason) is urllib3.exceptions.ConnectTimeoutError:
+                raise self.CallApiError(self.apitype, url, method, Dict({"status": 101}), {
+                    "type": "request time out",
+                    "error": e.reason.args[1],
+                    "error_code": 10411,
+                })
             logger.debug("error url {}".format(url))
             logger.exception(e)
             raise ServiceHandleException(error_code=10411, msg="MaxRetryError", msg_show="访问数据中心异常，请稍后重试")


### PR DESCRIPTION
添加集群时, 如果连接超时, 则提示: "连接集群超时，请确保访问地址的可用性, 且已放行 8443 端口"