### PR TITLE
Bug Fix: update update_time

### DIFF
--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -182,11 +182,12 @@ class NewComponents(object):
         extend_info["source_deploy_version"] = tmpl.get("deploy_version")
         extend_info["source_service_share_uuid"] = tmpl.get("service_share_uuid") if tmpl.get(
             "service_share_uuid", None) else tmpl.get("service_key", "")
-        if "update_time" in tmpl:
-            if type(tmpl["update_time"]) == datetime:
-                extend_info["update_time"] = tmpl["update_time"].strftime('%Y-%m-%d %H:%M:%S')
-            elif type(tmpl["update_time"]) == str:
-                extend_info["update_time"] = tmpl["update_time"]
+        update_time = self.app_template.get("update_time")
+        if update_time:
+            if type(update_time) == datetime:
+                extend_info["update_time"] = update_time.strftime('%Y-%m-%d %H:%M:%S')
+            elif type(update_time) == str:
+                extend_info["update_time"] = update_time
         if self.install_from_cloud:
             extend_info["install_from_cloud"] = True
             extend_info["market"] = "default"

--- a/console/services/market_app_service.py
+++ b/console/services/market_app_service.py
@@ -93,6 +93,7 @@ class MarketAppService(object):
             raise AbortRequest("app version not found", "应用市场应用版本不存在", status_code=404, error_code=404)
 
         app_template = json.loads(app_version.app_template)
+        app_template["update_time"] = app_version.update_time
 
         component_group = self._create_tenant_service_group(region.region_name, tenant.tenant_id, app.app_id, market_app.app_id,
                                                             version, market_app.app_name)
@@ -1333,6 +1334,8 @@ class MarketAppService(object):
                     versions.append(version.version)
                 elif current_version_time:
                     version_time = time.mktime(current_version_time.timetuple())
+                    logger.debug("current version time: {}; new version time: {}; need update: {}".format(
+                        new_version_time, version_time, new_version_time > version_time))
                     if compare == 0 and new_version_time > version_time:
                         versions.append(version.version)
             else:

--- a/console/services/upgrade_services.py
+++ b/console/services/upgrade_services.py
@@ -145,7 +145,9 @@ class UpgradeService(object):
             raise AbortRequest("app template not found", "找不到应用模板", status_code=404, error_code=404)
 
         try:
-            return json.loads(app_version.app_template)
+            app_template = json.loads(app_version.app_template)
+            app_template["update_time"] = app_version.update_time
+            return app_template
         except JSONDecodeError:
             raise AbortRequest("invalid app template", "该版本应用模板已损坏, 无法升级")
 


### PR DESCRIPTION
### Bug 原因

升级时, 如果两个版本号一样, 需要比较两个版本号的 update_time.

1.  update_time 是从组件模板里面取的(`tmpl["update_time"]`), 组件模板里没有 update_time
2. 每次更新组件时, 只更新版本号, 并未更新 update_time(extend_info)

这会导致只升级了版本号, 未更新 update_time. 所以每次升级后, 还是有可升级的版本, 可以继续升级.

### 解决办法

1. update_time 从应用模板(app_template)里面取
2. 每次更新组件时, 都必须更新 service_source 的 extend_info 字段.

