### PR TITLE
Fix Bug: Fix error creating third party component

### DIFF
--- a/openapi/views/apps/apps.py
+++ b/openapi/views/apps/apps.py
@@ -241,8 +241,8 @@ class CreateThirdComponentView(TeamAppAPIView):
         req_date = ctcs.data
         validate_endpoints_info(req_date["endpoints"])
         new_component = console_app_service.create_third_party_app(self.region_name, self.team, self.user,
-                                                                   req_date["component_name"], req_date["endpoints_type"],
-                                                                   req_date["endpoints"])
+                                                                   req_date["component_name"], req_date["endpoints"],
+                                                                   req_date["endpoints_type"])
         # add component to app
         code, msg_show = group_service.add_service_to_group(self.team, self.region_name, app_id, new_component.service_id)
         if code != 200:


### PR DESCRIPTION
- When OpenAPI creates a third-party component, the parameter is passed in the wrong position
![image](https://user-images.githubusercontent.com/30614084/128140674-49cfe100-41ab-4301-ac3f-940d261eaa8a.png)
