### PR TITLE
Bug Fix: Ignore components that are not in the template

### DIFF
--- a/console/services/market_app/app_restore.py
+++ b/console/services/market_app/app_restore.py
@@ -194,7 +194,9 @@ class AppRestore(MarketApp):
         # ports
         ports = [TenantServicesPort(**port) for port in snap["service_ports"]]
         # service_extend_method
-        extend_info = ServiceExtendMethod(**snap["service_extend_method"])
+        extend_info = None
+        if snap.get("service_extend_method"):
+            extend_info = ServiceExtendMethod(**snap.get("service_extend_method"))
         # volumes
         volumes = [TenantServiceVolume(**volume) for volume in snap["service_volumes"]]
         # configuration files

--- a/console/services/market_app/market_app.py
+++ b/console/services/market_app/market_app.py
@@ -87,7 +87,10 @@ class MarketApp(object):
         component_ids = [cpt.component.component_id for cpt in self.original_app.components()]
         if tmpl_component_ids:
             component_ids = [component_id for component_id in component_ids if component_id in tmpl_component_ids]
-        deps = [dep for dep in self.original_app.component_deps if dep.dep_service_id not in component_ids]
+        deps = [
+            dep for dep in self.original_app.component_deps
+            if dep.dep_service_id not in component_ids or dep.service_id not in tmpl_component_ids
+        ]
         deps.extend(new_deps)
         return deps
 
@@ -109,7 +112,10 @@ class MarketApp(object):
         component_ids = [cpt.component.component_id for cpt in self.original_app.components()]
         if tmpl_component_ids:
             component_ids = [component_id for component_id in component_ids if component_id in tmpl_component_ids]
-        deps = [dep for dep in self.original_app.volume_deps if dep.dep_service_id not in component_ids]
+        deps = [
+            dep for dep in self.original_app.volume_deps
+            if dep.dep_service_id not in component_ids or dep.service_id not in tmpl_component_ids
+        ]
         deps.extend(new_deps)
         return deps
 


### PR DESCRIPTION
只有依赖关系中的依赖方和被依赖方都存在于模板中时, 才对依赖进行处理.

在版本 1.0 中, A 依赖 B, B 依赖 C.
在版本 2.0 中, 模板中只有组件 B, 没有 A 和 B.

1.0 升级到 2.0, 因为 A 和 C 都不在2.0模板中, 所以不出来依赖A->B和依赖B->C.