### PR TITLE
Cannot use None as a query value

### DIFF
--- a/console/repositories/group.py
+++ b/console/repositories/group.py
@@ -177,7 +177,7 @@ class GroupServiceRelationRepository(object):
     def list_serivce_ids_by_app_id(tenant_id, region_name, app_id):
         relations = ServiceGroupRelation.objects.filter(tenant_id=tenant_id, region_name=region_name, group_id=app_id)
         if not relations:
-            return
+            return []
         return relations.values_list("service_id", flat=True)
 
     @staticmethod


### PR DESCRIPTION
`list_serivce_ids_by_app_id` 返回 None 会导致 https://github.com/goodrain/rainbond-console/blob/9fdf557ec916e9a0983aa36a1e6414dc5fd36a0a/console/services/group_service.py#L599

发送 `Cannot use None as a query value` 错误.

在没有组件时, 返回 [], 不返回 None.