### PR TITLE
bug fix: tenant_service_group_id not match

### DIFF
--- a/sql/5.3.0-5.3.1-sqlite.sql
+++ b/sql/5.3.0-5.3.1-sqlite.sql
@@ -142,6 +142,8 @@ FROM
  tenant_service_group 
 WHERE
  id NOT IN ( SELECT id FROM ( SELECT min( id ) AS id FROM tenant_service_group GROUP BY group_key, service_group_id ) AS b );
+UPDATE tenant_service 
+	SET tenant_service_group_id = ( SELECT c.ID FROM service_group_relation b, tenant_service_group c WHERE tenant_service.service_id = b.service_id AND c.service_group_id = b.group_id  AND tenant_service.service_source = "market");
 
 -- update tenant_service_group version --
 UPDATE `tenant_service_group` 

--- a/sql/5.3.0-5.3.1.sql
+++ b/sql/5.3.0-5.3.1.sql
@@ -38,6 +38,14 @@ FROM
  tenant_service_group 
 WHERE
  id NOT IN ( SELECT id FROM ( SELECT min( id ) AS id FROM tenant_service_group GROUP BY group_key, service_group_id ) AS b );
+UPDATE tenant_service a
+	JOIN service_group_relation b
+	JOIN tenant_service_group c ON a.service_id = b.service_id 
+	AND c.service_group_id = b.group_id 
+	AND b.group_id 
+	AND a.service_source = "market" 
+	AND a.tenant_service_group_id <> c.ID
+	SET a.tenant_service_group_id = c.ID;
 
 -- update tenant_service_group version --
 UPDATE `tenant_service_group` 


### PR DESCRIPTION
### Bugs
5.3.1 升 5.3.2 的时候, 会执行下面的 sql 对 tenant_service_group 去重, 去重后没有更新 tenent_service 的 tenant_service_group_id, 导致 tenant_service_group 和 tenent_service 关联不上.
```
DELETE 
FROM
 tenant_service_group 
WHERE
 id NOT IN ( SELECT id FROM ( SELECT min( id ) AS id FROM tenant_service_group GROUP BY group_key, service_group_id ) AS b );
```

### Solutions

同步 tenant_service_group  的 ID 到 tenent_service 的 tenant_service_group_id.