### PR TITLE
fix: data loss during backup and recovery

### DIFF
--- a/console/services/groupapp_recovery/groupapps_migrate.py
+++ b/console/services/groupapp_recovery/groupapps_migrate.py
@@ -21,6 +21,7 @@ from console.repositories.plugin.plugin_version import build_version_repo
 from console.repositories.probe_repo import probe_repo
 from console.repositories.region_repo import region_repo
 from console.repositories.team_repo import team_repo
+from console.repositories.region_app import region_app_repo
 from console.services.app import app_service
 from console.services.app_config import port_service, volume_service
 from console.services.app_config.component_graph import component_graph_service
@@ -205,6 +206,11 @@ class GroupappsMigrateService(object):
                             backup_record_repo.get_record_by_group_id(
                                 migrate_record.original_group_id).update(group_id=migrate_record.group_id)
                             self.update_migrate_original_group_id(migrate_record.original_group_id, migrate_record.group_id)
+                        region_app_id = region_app_repo.get_region_app_id(migrate_record.migrate_region,
+                                                                          migrate_record.group_id)
+                        group_service.sync_app_services(migrate_team, migrate_record.migrate_region, migrate_record.group_id)
+                        region_api.change_application_volumes(migrate_team.tenant_name, migrate_record.migrate_region,
+                                                              region_app_id)
                 except Exception as e:
                     logger.exception(e)
                     status = "failed"


### PR DESCRIPTION
问题：应用备份恢复后，有状态组件数据丢失

原因：
有状态组件共享存储的存储路径为 /grdata/tenant/{tenant_id}/services/{service_id}/{storage_path}/{POD_NAME}
在 5.5 版本以后，支持用户修改组件的 {POD_NAME}，因此，其对应的数据目录在修改后会发生变化。

解决方案：
因此在备份恢复后，需要将新应用下有状态组件的存储路径名，修改为新的 {POD_NAME}

相关Issues：https://github.com/goodrain/rainbond/issues/1203