### PR TITLE
fix: rainbond-cert-controller update httpdomain failed issue.

### DIFF
--- a/console/services/app_config/domain_service.py
+++ b/console/services/app_config/domain_service.py
@@ -475,7 +475,8 @@ class DomainService(object):
         domain_info["container_port"] = int(domain_info["container_port"])
         domain_info["service_id"] = service.service_id
         domain_info["service_name"] = service.service_alias
-        domain_info["rewrites"] = json.dumps(update_data["rewrites"])
+        if "rewrites" in list(update_data.keys()):
+            domain_info["rewrites"] = json.dumps(update_data["rewrites"])
         model_data = ServiceDomain(**domain_info)
         model_data.save()
         if re_model:


### PR DESCRIPTION
[#1318](https://github.com/goodrain/rainbond/issues/1318)
再加入路由重写功能后，rainbond-cert-controller更新网关由于缺少rewrites参数，导致更新失败，自签证书不生效。
PR已修复。