### PR TITLE
fix: sse log cannot be displayed normally

### DIFF
--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -2935,4 +2935,6 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
             for chunk in resp.stream(4096):
                 yield str(chunk, encoding="utf-8")
 
-        return StreamingHttpResponse(event_stream(), content_type='text/event-stream')
+        response = StreamingHttpResponse(event_stream(), content_type='text/event-stream')
+        response['Content-Encoding'] = 'identity'
+        return response


### PR DESCRIPTION
sse 规范中：

服务器向浏览器发送的 SSE 数据，必须是 UTF-8 编码的文本，具有如下的 HTTP 头信息。

Content-Type: text/event-stream
Cache-Control: no-cache
Connection: keep-alive

由于之前代码中没有显式指定 response['Content-Encoding'] = 'identity'，导致响应头中默认是 response['Content-Encoding'] = 'gzip'，浏览器无法正常展示。