### PR TITLE
fix: recurse MCP serializer into nested SDK model objects

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -4255,14 +4255,18 @@ class MCPQueryService(object):
     def _serialize_model_item(obj):
         if obj is None:
             return None
-        if isinstance(obj, dict):
+        if isinstance(obj, (str, int, float, bool)):
             return obj
+        if isinstance(obj, dict):
+            return {k: MCPQueryService._serialize_model_item(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple, set)):
+            return [MCPQueryService._serialize_model_item(v) for v in obj]
         if hasattr(obj, "to_dict") and callable(obj.to_dict):
-            return obj.to_dict()
+            return MCPQueryService._serialize_model_item(obj.to_dict())
         data = {}
         for key, value in getattr(obj, "__dict__", {}).items():
             if not key.startswith("_"):
-                data[key] = value
+                data[key] = MCPQueryService._serialize_model_item(value)
         return data
 
     def _serialize_app_share_record_summary(self, record, user):

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -5196,3 +5196,43 @@ class MCPQueryServiceDeleteAppTests(SimpleTestCase):
                     "confirmation_token": "invalid-token",
                 },
             )
+
+
+class MCPQueryServiceSerializeModelItemTests(SimpleTestCase):
+
+    # capability_id: console.mcp.serialize-nested-sdk-models
+    def test_serialize_model_item_recurses_into_dict_values(self):
+        class FakeSDKModel(object):
+            def __init__(self, value):
+                self.value = value
+
+            def to_dict(self):
+                return {"value": self.value}
+
+        nested = {
+            "app_id": "abc",
+            "versions": [FakeSDKModel("v1"), FakeSDKModel("v2")],
+            "meta": {"latest": FakeSDKModel("v2")},
+        }
+
+        result = mcp_query_service._serialize_model_item(nested)
+
+        self.assertEqual(result["app_id"], "abc")
+        self.assertEqual(result["versions"], [{"value": "v1"}, {"value": "v2"}])
+        self.assertEqual(result["meta"], {"latest": {"value": "v2"}})
+        json.dumps(result)
+
+    def test_serialize_model_item_handles_object_with_nested_sdk_attribute(self):
+        class FakeSDKModel(object):
+            def to_dict(self):
+                return {"k": "v"}
+
+        class Container(object):
+            def __init__(self):
+                self.name = "demo"
+                self.payload = FakeSDKModel()
+
+        result = mcp_query_service._serialize_model_item(Container())
+
+        self.assertEqual(result, {"name": "demo", "payload": {"k": "v"}})
+        json.dumps(result)

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -4629,6 +4629,28 @@
       "status": "active"
     },
     {
+      "id": "console.mcp.serialize-nested-sdk-models",
+      "title": "Serialize nested SDK models in MCP responses",
+      "title_zh": "MCP 响应中递归序列化嵌套 SDK 模型",
+      "interface_type": "internal",
+      "interface": "console.services.mcp_query_service.MCPQueryService._serialize_model_item",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_recurses_into_dict_values"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_handles_object_with_nested_sdk_attribute"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.mcp.http-delete-session",
       "title": "Close MCP session over HTTP",
       "title_zh": "\u901a\u8fc7 HTTP \u5173\u95ed MCP \u4f1a\u8bdd",


### PR DESCRIPTION
Serialize cloud V1AppVersionBase instances embedded inside get_market_app_model(extend=True) responses so MCP query_app_model_versions no longer fails with 'V1AppVersionBase is not JSON serializable'.