### PR TITLE
fix(mcp/storage): expose config-file volumes in summary and enforce c…

### DIFF
--- a/console/services/app_config/volume_service.py
+++ b/console/services/app_config/volume_service.py
@@ -187,6 +187,42 @@ class AppVolumeService(object):
         settings["changed"] = True
         return settings
 
+    def get_all_service_volumes_with_status(self, tenant, service):
+        # Used by MCP tools that need full visibility into a component's
+        # storage. The legacy `get_service_volumes(is_config_file=...)`
+        # exposes only one half of the volume set per call because the
+        # console web view drives a tabbed UI off that contract; do not
+        # change that contract here.
+        volumes = volume_repo.get_service_volumes_with_config_file(service.service_id)
+        return self._attach_volume_runtime_status(tenant, service, volumes)
+
+    def _attach_volume_runtime_status(self, tenant, service, volumes):
+        vos = []
+        if service.create_status != "complete":
+            for volume in volumes:
+                vo = volume.to_dict()
+                vo["status"] = volume_not_bound
+                vos.append(vo)
+            return vos
+        res, body = region_api.get_service_volumes(
+            service.service_region, tenant.tenant_name, service.service_alias,
+            tenant.enterprise_id)
+        if body and body.list:
+            status = {v["volume_name"]: v["status"] for v in body.list}
+            for volume in volumes:
+                vo = volume.to_dict()
+                vo_status = status.get(vo["volume_name"], None)
+                vo["status"] = volume_not_bound
+                if vo_status and vo_status == volume_ready:
+                    vo["status"] = volume_bound
+                vos.append(vo)
+        else:
+            for volume in volumes:
+                vo = volume.to_dict()
+                vo["status"] = volume_not_bound
+                vos.append(vo)
+        return vos
+
     def get_service_volumes(self, tenant, service, is_config_file=False):
         volumes = []
         if is_config_file:

--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -646,7 +646,7 @@ class MCPQueryService(object):
         ports = port_service.get_service_ports(service)
         envs = env_var_service.get_self_define_env(service)
         build_envs = env_var_service.get_service_build_envs(service)
-        volumes = volume_service.get_service_volumes(team, service)
+        volumes = volume_service.get_all_service_volumes_with_status(team, service)
         mnts, mnt_total = mnt_service.get_service_mnt_details(team, service, None, page=1, page_size=1000)
         autoscaler_rules = autoscaler_service.list_autoscaler_rules(service.service_id)
         probe_code, _, probe = probe_service.get_service_probe(service)
@@ -1333,6 +1333,25 @@ class MCPQueryService(object):
         result["service_id"] = service.service_id
         return result
 
+    def _mcp_assert_volume_path_available(self, service, new_volume_path):
+        existing_rows = volume_repo.get_service_volumes_with_config_file(
+            service.service_id
+        ).values("volume_path")
+        for row in existing_rows:
+            existing = row["volume_path"]
+            if existing == new_volume_path:
+                raise ServiceHandleException(
+                    msg="path already exists",
+                    msg_show="持久化路径[{0}]已存在".format(existing),
+                    status_code=412,
+                )
+            if existing.startswith(new_volume_path + "/") or new_volume_path.startswith(existing + "/"):
+                raise ServiceHandleException(
+                    msg="path conflict",
+                    msg_show="已存在以{0}开头的路径".format(existing),
+                    status_code=412,
+                )
+
     def manage_component_storage(self, user, arguments):
         team, app, service = self._get_team_app_service_context(
             user,
@@ -1348,9 +1367,13 @@ class MCPQueryService(object):
             "存储",
         )
         if operation == "summary":
-            is_config = bool(arguments.get("is_config", False))
+            # MCP summary intentionally returns every volume type (including
+            # config-file). The `is_config` argument is kept in the schema
+            # only because `list_unmounted` still uses it; ignoring it here
+            # avoids the historical default-False filter that hid config-file
+            # volumes from AI assistants.
             volume_options = volume_service.get_service_support_volume_options(team, service)
-            volumes = volume_service.get_service_volumes(team, service, is_config)
+            volumes = volume_service.get_all_service_volumes_with_status(team, service)
             mnts, total = mnt_service.get_service_mnt_details(team, service, arguments.get("volume_types"), page=1, page_size=1000)
             return {
                 "service_id": service.service_id,
@@ -1372,10 +1395,17 @@ class MCPQueryService(object):
             )
             return {"items": items, "total": total, "page": page, "page_size": page_size}
         if operation == "create_volume":
+            volume_path = self._require_string(arguments, "volume_path")
+            # The shared `volume_service.check_volume_path` filters out
+            # config-file volumes by design (console contract). MCP creators
+            # need full path-conflict coverage so the AI cannot create a
+            # persistent volume whose path collides with an existing
+            # config-file mount, and vice versa.
+            self._mcp_assert_volume_path_available(service, volume_path)
             volume = volume_service.add_service_volume(
                 team,
                 service,
-                self._require_string(arguments, "volume_path"),
+                volume_path,
                 self._require_string(arguments, "volume_type"),
                 self._require_string(arguments, "volume_name"),
                 arguments.get("file_content"),

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -965,7 +965,7 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.port_service.get_service_ports")
     @patch("console.services.mcp_query_service.env_var_service.get_self_define_env")
     @patch("console.services.mcp_query_service.env_var_service.get_service_build_envs")
-    @patch("console.services.mcp_query_service.volume_service.get_service_volumes")
+    @patch("console.services.mcp_query_service.volume_service.get_all_service_volumes_with_status")
     @patch("console.services.mcp_query_service.mnt_service.get_service_mnt_details")
     @patch("console.services.mcp_query_service.autoscaler_service.list_autoscaler_rules")
     @patch("console.services.mcp_query_service.probe_service.get_service_probe")
@@ -1477,7 +1477,7 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
     @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
     @patch("console.services.mcp_query_service.volume_service.get_service_support_volume_options")
-    @patch("console.services.mcp_query_service.volume_service.get_service_volumes")
+    @patch("console.services.mcp_query_service.volume_service.get_all_service_volumes_with_status")
     @patch("console.services.mcp_query_service.mnt_service.get_service_mnt_details")
     # capability_id: console.component.storage-summary
     def test_manage_component_storage_summary_returns_storage_snapshot(

--- a/console/tests/mcp_query_storage_ops_test.py
+++ b/console/tests/mcp_query_storage_ops_test.py
@@ -14,6 +14,7 @@ sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
 django.setup()
 
+from console.exception.main import ServiceHandleException
 from console.services.mcp_query_service import mcp_query_service
 
 
@@ -54,9 +55,18 @@ class ManageComponentStorageTests(SimpleTestCase):
             "volume_name": "data-vol",
             "volume_capacity": 20,
         }
+        empty_query = mock.Mock()
+        empty_query.values.return_value = []
         with patch.object(mcp_query_service, "_get_team_app_service_context", return_value=(team, app, service)):
-            with patch("console.services.mcp_query_service.volume_service.add_service_volume", return_value=volume) as mock_add:
-                result = mcp_query_service.manage_component_storage(user, arguments)
+            with patch(
+                "console.services.mcp_query_service.volume_repo.get_service_volumes_with_config_file",
+                return_value=empty_query,
+            ):
+                with patch(
+                    "console.services.mcp_query_service.volume_service.add_service_volume",
+                    return_value=volume,
+                ) as mock_add:
+                    result = mcp_query_service.manage_component_storage(user, arguments)
 
         self.assertTrue(result["created"])
         self.assertEqual(result["volume"]["volume_id"], 11)
@@ -182,6 +192,72 @@ class ManageComponentStorageTests(SimpleTestCase):
         self.assertTrue(result["created"])
         self.assertEqual(result["items"], [{"dep_vol_id": 101}, {"dep_vol_id": 102}])
         self.assertEqual(result["total"], len(mounts))
+
+    # capability_id: console.component.storage-summary
+    def test_summary_includes_config_file_volumes(self):
+        team, app, service = self._make_context()
+        service.create_status = "complete"
+        user = self._make_user()
+        arguments = {
+            "team_name": "team-1",
+            "region_name": "region-1",
+            "app_id": 100,
+            "service_id": "service-1",
+            "operation": "summary",
+        }
+        all_volumes = [
+            {"volume_id": 21, "volume_name": "cfg", "volume_type": "config-file", "volume_path": "/etc/app/conf.json"},
+            {"volume_id": 22, "volume_name": "data", "volume_type": "nas", "volume_path": "/data"},
+        ]
+        with patch.object(mcp_query_service, "_get_team_app_service_context", return_value=(team, app, service)):
+            with patch(
+                "console.services.mcp_query_service.volume_service.get_service_support_volume_options",
+                return_value=[],
+            ):
+                with patch(
+                    "console.services.mcp_query_service.volume_service.get_all_service_volumes_with_status",
+                    return_value=all_volumes,
+                ) as mock_all:
+                    with patch(
+                        "console.services.mcp_query_service.mnt_service.get_service_mnt_details",
+                        return_value=([], 0),
+                    ):
+                        result = mcp_query_service.manage_component_storage(user, arguments)
+
+        mock_all.assert_called_once_with(team, service)
+        volume_types = {v["volume_type"] for v in result["volumes"]["items"]}
+        self.assertEqual(volume_types, {"config-file", "nas"})
+        self.assertEqual(result["volumes"]["total"], 2)
+
+    # capability_id: console.component.storage-create-volume
+    def test_create_volume_rejects_collision_with_existing_config_file_path(self):
+        team, app, service = self._make_context()
+        user = self._make_user()
+        arguments = {
+            "team_name": "team-1",
+            "region_name": "region-1",
+            "app_id": 100,
+            "service_id": "service-1",
+            "operation": "create_volume",
+            "volume_path": "/etc/app/config.json",
+            "volume_type": "nas",
+            "volume_name": "data-vol",
+        }
+        existing_query = mock.Mock()
+        existing_query.values.return_value = [{"volume_path": "/etc/app/config.json"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context", return_value=(team, app, service)):
+            with patch(
+                "console.services.mcp_query_service.volume_repo.get_service_volumes_with_config_file",
+                return_value=existing_query,
+            ):
+                with patch(
+                    "console.services.mcp_query_service.volume_service.add_service_volume"
+                ) as mock_add:
+                    with self.assertRaises(ServiceHandleException) as ctx:
+                        mcp_query_service.manage_component_storage(user, arguments)
+
+        mock_add.assert_not_called()
+        self.assertEqual(ctx.exception.status_code, 412)
 
     # capability_id: console.component.storage-delete-mount
     def test_delete_mnt_removes_relation(self):

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -3513,6 +3513,10 @@
         {
           "path": "console/tests/mcp_query_storage_ops_test.py",
           "selector": "ManageComponentStorageTests.test_create_volume_returns_created_and_volume"
+        },
+        {
+          "path": "console/tests/mcp_query_storage_ops_test.py",
+          "selector": "ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path"
         }
       ],
       "test_type": "regression",
@@ -3593,6 +3597,10 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot"
+        },
+        {
+          "path": "console/tests/mcp_query_storage_ops_test.py",
+          "selector": "ManageComponentStorageTests.test_summary_includes_config_file_volumes"
         }
       ],
       "test_type": "regression",


### PR DESCRIPTION
…ross-type path conflicts

The two MCP storage entry points went through volume_service.get_service_volumes, whose default `is_config_file=False` filter excluded config-file volumes from the result. As a consequence:

- rainbond_manage_component_storage summary returned an empty volumes list right after a successful config-file create_volume, making it look like the create operation had silently failed.
- rainbond_get_component_summary missed config-file volumes from the aggregated component snapshot for the same reason.
- create_volume accepted persistent volume paths that collided with an existing config-file mount (and vice versa) because the shared check_volume_path uses the same filtered repo query.

The console web view (app_volume.py) and other callers still rely on the legacy filter semantics to drive tabbed UI, so they keep using get_service_volumes with their explicit is_config_file flag. Only the MCP call sites switch to a new service entry, get_all_service_volumes_with_status, that returns every volume type with runtime status. MCP create_volume gains an additional path-conflict pre-check that scans across all volume types.

Test manifest registers the two new regression tests against the existing storage-summary and storage-create-volume capabilities.