### PR TITLE
feat(plugin): stream plugin backend proxy responses

### DIFF
--- a/console/services/market_app_service.py
+++ b/console/services/market_app_service.py
@@ -210,7 +210,7 @@ class MarketAppService(object):
                         if entry_path:
                             frontend_service = frontend_service.rstrip("/") + "/" + entry_path.lstrip("/")
 
-                    # Find backend: get frontend's dependencies
+                    # Find backend: prefer the frontend component's declared dependency.
                     deps = dep_relation_repo.get_service_dependencies(tenant.tenant_id, frontend_cpt.service_id)
                     if deps:
                         backend_cpt_id = deps[0].dep_service_id
@@ -219,6 +219,13 @@ class MarketAppService(object):
                             bp = backend_ports[0]
                             backend_service = "{}.{}.svc.cluster.local:{}".format(
                                 bp.k8s_service_name, namespace, bp.container_port)
+                    # Fallback for single-component plugins (frontend and backend are the
+                    # same component, so there is no dependency edge): use the frontend
+                    # component's own service address as the backend service.
+                    if not backend_service and frontend_ports:
+                        fp = frontend_ports[0]
+                        backend_service = "{}.{}.svc.cluster.local:{}".format(
+                            fp.k8s_service_name, namespace, fp.container_port)
 
             # Resolve region_app_id from app_id
             region_app_id = ""

--- a/console/views/rbd_plugin.py
+++ b/console/views/rbd_plugin.py
@@ -23,14 +23,15 @@ class RainbondPluginStaticView(AlowAnyApiView):
         return HttpResponse(resp, content_type="application/javascript")
 
 class RainbondPluginBackendView(JWTAuthApiView):
+    # 流式代理插件后端 API：支持 SSE / 长响应，转发 body 与请求头（含 Cookie/JWT），
+    # 不缓冲、不走 proxy() 的固定 20s 超时。
     def get(self, request, region_name, plugin_name, file_path, *args, **kwargs):
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
         # 传递查询参数
         query_string = request.META.get('QUERY_STRING', '')
         if query_string:
             path = path + "?" + query_string
-        # 使用完整代理以支持文件下载，保留 Content-Type 等响应头
-        return region_api.proxy(request, path, region_name)
+        return region_api.stream_proxy(request, path, region_name)
 
     def post(self, request, region_name, plugin_name, file_path, *args, **kwargs):
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
@@ -38,8 +39,7 @@ class RainbondPluginBackendView(JWTAuthApiView):
         query_string = request.META.get('QUERY_STRING', '')
         if query_string:
             path = path + "?" + query_string
-        # 使用完整代理以支持文件上传，保留 Content-Type 等响应头
-        return region_api.proxy(request, path, region_name)
+        return region_api.stream_proxy(request, path, region_name)
 
     def put(self, request, region_name, plugin_name, file_path, *args, **kwargs):
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
@@ -47,8 +47,7 @@ class RainbondPluginBackendView(JWTAuthApiView):
         query_string = request.META.get('QUERY_STRING', '')
         if query_string:
             path = path + "?" + query_string
-        # 使用完整代理以支持文件上传，保留 Content-Type 等响应头
-        return region_api.proxy(request, path, region_name)
+        return region_api.stream_proxy(request, path, region_name)
 
     def delete(self, request, region_name, plugin_name, file_path, *args, **kwargs):
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
@@ -56,8 +55,7 @@ class RainbondPluginBackendView(JWTAuthApiView):
         query_string = request.META.get('QUERY_STRING', '')
         if query_string:
             path = path + "?" + query_string
-        # 使用完整代理，保留 Content-Type 等响应头
-        return region_api.proxy(request, path, region_name)
+        return region_api.stream_proxy(request, path, region_name)
 
 class RainbondPluginStatusView(EnterpriseAdminView):
     def post(self, request, region_name, plugin_name, *args, **kwargs):

--- a/www/apiclient/regionapibaseclient.py
+++ b/www/apiclient/regionapibaseclient.py
@@ -18,7 +18,7 @@ from console.exception.main import ServiceHandleException, ErrClusterLackOfMemor
     ErrClusterAuthLackOfLicenseExpire, ErrTenantLackOfCPU, ErrTenantQuotaCPULack, ErrTenantQuotaMemoryLack
 from console.repositories.region_repo import region_repo
 from django.conf import settings
-from django.http import HttpResponse, QueryDict
+from django.http import HttpResponse, QueryDict, StreamingHttpResponse
 from urllib3.exceptions import MaxRetryError
 
 logger = logging.getLogger('default')
@@ -460,6 +460,69 @@ class RegionApiBaseHttpClient(object):
             else:
                 proxy_response[key] = value
 
+        return proxy_response
+
+    def stream_proxy(self, request, url, region_name):
+        """
+        Streaming variant of proxy(). Forwards the request method, body and headers,
+        and streams the upstream response back without buffering it into memory.
+
+        Use this instead of proxy() for plugin backend APIs that may return
+        Server-Sent Events or other long-running streaming responses: proxy()
+        buffers the whole body and uses a fixed 20s timeout, which breaks streaming.
+        """
+        headers = self.get_headers(request.META)
+        # Django usually upper-cases content-length; drop it and let the length be
+        # recomputed by the upstream / streaming response.
+        for key in list(headers.keys()):
+            if key.lower() == 'content-length':
+                del headers[key]
+
+        region = region_repo.get_region_by_region_name(region_name)
+        if not region:
+            raise ServiceHandleException("region {0} not found".format(region_name), error_code=10412)
+        client = self.get_client(region_config=region)
+        response = client.request(
+            method=request.method,
+            url="{}{}".format(region.url, url),
+            body=request.body,
+            headers=headers,
+            preload_content=False,
+            timeout=urllib3.Timeout(connect=30, read=60 * 60),
+        )
+
+        def stream_content():
+            try:
+                for chunk in response.stream(8192, decode_content=True):
+                    yield chunk
+            finally:
+                response.release_conn()
+
+        # Hop-by-hop headers must not be tunneled through. content-type is set from
+        # the upstream response; content-length/encoding are handled by streaming.
+        excluded_headers = set([
+            'connection',
+            'keep-alive',
+            'proxy-authenticate',
+            'proxy-authorization',
+            'te',
+            'trailers',
+            'transfer-encoding',
+            'upgrade',
+            'content-encoding',
+            'content-length',
+            'content-type',
+        ])
+        content_type = response.headers.get('Content-Type', 'application/octet-stream')
+        proxy_response = StreamingHttpResponse(
+            stream_content(), status=response.status, content_type=content_type)
+        for key, value in list(response.headers.items()):
+            if key.lower() in excluded_headers:
+                continue
+            elif key.lower() == 'location':
+                proxy_response[key] = self.make_absolute_location(response.url, value)
+            else:
+                proxy_response[key] = value
         return proxy_response
 
     def get_headers(self, environ):


### PR DESCRIPTION
Add stream_proxy() forwarding method/body/headers and streaming the upstream response without buffering, with a long read timeout. Switch RainbondPluginBackendView to it so plugin backend APIs can return SSE and long responses (proxy() buffers and times out at 20s). Also render backend_service for single-component plugins via a frontend-service fallback when no dependency edge exists.