### PR TITLE
feat: authenticate agent-llm-config runtime endpoint with enterprise_id

### DIFF
--- a/console/services/auth/authentication.py
+++ b/console/services/auth/authentication.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
+import ipaddress
+import logging
+
 from rest_framework import authentication
 from rest_framework import exceptions
 from django.conf import settings
-from www.models.main import Users
-import logging
+from www.models.main import Users, TenantEnterprise
 
 logger = logging.getLogger('default')
+
+# 任一代理头存在，即说明请求经过了 L7 网关/代理，视为集群外来源。
+_PROXY_HEADERS = (
+    'HTTP_X_FORWARDED_FOR',
+    'HTTP_X_REAL_IP',
+    'HTTP_X_FORWARDED_HOST',
+    'HTTP_FORWARDED',
+)
 
 class InternalTokenAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
@@ -27,5 +37,66 @@ class InternalTokenAuthentication(authentication.BaseAuthentication):
             # 如果没有超级管理员，抛出异常，因为我们需要一个用户上下文
             logger.error("InternalAuth: No superuser found!")
             raise exceptions.AuthenticationFailed('No superuser found for internal authentication')
-            
+
         return (user, None)
+
+
+class AgentRuntimeAuthentication(authentication.BaseAuthentication):
+    """AI 助手 runtime 配置接口的零配置鉴权。
+
+    rainagent (rainbond-copilot) 部署在集群内，调用方把 enterprise_id 作为
+    X-Internal-Token 传入。两道关卡都通过才放行：
+
+      1. 来源关卡：必须是集群内直连。console 由 gunicorn 直接服务，走公网
+         网关的请求一定带代理头(X-Forwarded-For 等)且网关只追加不能删除；
+         带任一代理头、或直连对端不是私网/回环地址，都视为集群外请求拒绝。
+      2. 身份关卡：token 必须命中已存在的 enterprise_id；为兼容老部署，
+         settings.INTERNAL_API_TOKEN 配置了的话也接受其值。
+
+    这样开源用户无需在 console / copilot 两端手动配置共享密钥。
+    """
+
+    def authenticate(self, request):
+        token = request.META.get('HTTP_X_INTERNAL_TOKEN')
+
+        if not token:
+            return None
+
+        # 关卡 1：仅允许集群内直连。
+        if not self._is_cluster_internal(request):
+            logger.warning("AgentRuntimeAuth: rejected non-cluster-internal request")
+            raise exceptions.AuthenticationFailed(
+                'agent runtime config endpoint is reachable from inside the cluster only')
+
+        # 关卡 2：token 必须能标识本 console。
+        if not self._token_allowed(token):
+            return None
+
+        user = Users.objects.filter(sys_admin=True).first()
+
+        if not user:
+            logger.error("AgentRuntimeAuth: No superuser found!")
+            raise exceptions.AuthenticationFailed('No superuser found for internal authentication')
+
+        return (user, None)
+
+    @staticmethod
+    def _is_cluster_internal(request):
+        # 任一代理头存在 = 经过了网关 = 判定为外部。网关对这些头只追加不删除，
+        # 所以外部调用方无法靠去掉该头来伪装成内部。
+        if any(request.META.get(h) for h in _PROXY_HEADERS):
+            return False
+        # 直连对端必须是私网/回环地址(集群 Pod 网络)。console 被 NodePort 等
+        # 方式直接暴露到公网时，外部直连的对端是公网 IP，可据此挡掉。
+        try:
+            ip = ipaddress.ip_address(request.META.get('REMOTE_ADDR') or '')
+        except ValueError:
+            return False
+        return ip.is_private or ip.is_loopback
+
+    @staticmethod
+    def _token_allowed(token):
+        legacy_token = getattr(settings, 'INTERNAL_API_TOKEN', None)
+        if legacy_token and token == legacy_token:
+            return True
+        return TenantEnterprise.objects.filter(enterprise_id=token).exists()

--- a/console/tests/agent_llm_config_view_test.py
+++ b/console/tests/agent_llm_config_view_test.py
@@ -64,7 +64,7 @@ class AgentLLMConfigViewTests(SimpleTestCase):
         self.assertEqual(response.status_code, 403)
 
     @override_settings(INTERNAL_API_TOKEN="token-1")
-    def test_runtime_config_requires_internal_token_and_returns_runtime_values(self):
+    def test_runtime_config_accepts_legacy_internal_token(self):
         request = self.factory.get(
             "/console/internal/agent-llm-config/runtime",
             HTTP_X_INTERNAL_TOKEN="token-1",
@@ -79,7 +79,61 @@ class AgentLLMConfigViewTests(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual("sk-runtime", response.data["data"]["bean"]["OPENAI_API_KEY"])
 
-    @override_settings(INTERNAL_API_TOKEN="token-1")
+    def test_runtime_config_accepts_enterprise_id_as_token(self):
+        request = self.factory.get(
+            "/console/internal/agent-llm-config/runtime",
+            HTTP_X_INTERNAL_TOKEN="5ae43b0db81042d0ba8005386022d1c5",
+        )
+
+        with mock.patch("console.services.auth.authentication.Users.objects.filter") as users_filter, \
+                mock.patch("console.services.auth.authentication.TenantEnterprise.objects.filter") as ent_filter, \
+                mock.patch("console.views.agent_llm_config.agent_llm_config_service.get_runtime_config",
+                           return_value={"OPENAI_API_KEY": "sk-runtime", "OPENAI_MODEL": "gpt-4o-mini"}):
+            users_filter.return_value.first.return_value = self._admin_user()
+            ent_filter.return_value.exists.return_value = True
+            response = self.runtime_view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual("sk-runtime", response.data["data"]["bean"]["OPENAI_API_KEY"])
+
+    def test_runtime_config_rejects_request_through_public_gateway(self):
+        request = self.factory.get(
+            "/console/internal/agent-llm-config/runtime",
+            HTTP_X_INTERNAL_TOKEN="5ae43b0db81042d0ba8005386022d1c5",
+            HTTP_X_FORWARDED_FOR="203.0.113.7",
+        )
+
+        with mock.patch("console.services.auth.authentication.TenantEnterprise.objects.filter") as ent_filter:
+            ent_filter.return_value.exists.return_value = True
+            response = self.runtime_view(request)
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_runtime_config_rejects_public_source_ip(self):
+        request = self.factory.get(
+            "/console/internal/agent-llm-config/runtime",
+            HTTP_X_INTERNAL_TOKEN="5ae43b0db81042d0ba8005386022d1c5",
+            REMOTE_ADDR="203.0.113.7",
+        )
+
+        with mock.patch("console.services.auth.authentication.TenantEnterprise.objects.filter") as ent_filter:
+            ent_filter.return_value.exists.return_value = True
+            response = self.runtime_view(request)
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_runtime_config_rejects_unknown_token(self):
+        request = self.factory.get(
+            "/console/internal/agent-llm-config/runtime",
+            HTTP_X_INTERNAL_TOKEN="not-an-enterprise-id",
+        )
+
+        with mock.patch("console.services.auth.authentication.TenantEnterprise.objects.filter") as ent_filter:
+            ent_filter.return_value.exists.return_value = False
+            response = self.runtime_view(request)
+
+        self.assertIn(response.status_code, (401, 403))
+
     def test_runtime_config_rejects_missing_internal_token(self):
         request = self.factory.get("/console/internal/agent-llm-config/runtime")
 

--- a/console/views/agent_llm_config.py
+++ b/console/views/agent_llm_config.py
@@ -5,7 +5,7 @@ from rest_framework.views import APIView
 
 from console.exception.main import ServiceHandleException
 from console.services.agent_llm_config_service import agent_llm_config_service
-from console.services.auth.authentication import InternalTokenAuthentication
+from console.services.auth.authentication import AgentRuntimeAuthentication
 from console.views.base import EnterpriseAdminView
 from www.utils.return_message import general_message
 
@@ -39,7 +39,7 @@ class AgentLLMConfigView(EnterpriseAdminView):
 
 
 class AgentLLMRuntimeConfigView(APIView):
-    authentication_classes = (InternalTokenAuthentication, )
+    authentication_classes = (AgentRuntimeAuthentication, )
     permission_classes = (IsAuthenticated, )
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Add AgentRuntimeAuthentication for the internal runtime config endpoint so rainbond-copilot needs no operator-configured shared secret. Two gates must pass: the request must not carry X-Forwarded-For (only the public gateway adds it, so its presence means an external caller), and the X-Internal-Token must match an existing enterprise_id. The legacy INTERNAL_API_TOKEN is still accepted when configured.