### PR TITLE
fix: keep plugin backend SSE stream unbuffered past GZipMiddleware

### DIFF
--- a/www/apiclient/regionapibaseclient.py
+++ b/www/apiclient/regionapibaseclient.py
@@ -523,6 +523,13 @@ class RegionApiBaseHttpClient(object):
                 proxy_response[key] = self.make_absolute_location(response.url, value)
             else:
                 proxy_response[key] = value
+        # Keep the streamed body unbuffered. Django's GZipMiddleware would
+        # otherwise wrap this StreamingHttpResponse in a gzip compressor whose
+        # buffer swallows the small SSE chunks until it fills, killing the
+        # live typewriter effect. Declaring an explicit Content-Encoding makes
+        # GZipMiddleware skip the response (same trick as the component log
+        # stream view).
+        proxy_response['Content-Encoding'] = 'identity'
         return proxy_response
 
     def get_headers(self, environ):


### PR DESCRIPTION
stream_proxy() builds a StreamingHttpResponse but did not declare a Content-Encoding, so Django's GZipMiddleware wrapped it in a gzip compressor for clients sending `Accept-Encoding: gzip` (every browser). The compressor buffers small chunks until its window fills, so Server-Sent Events from a plugin backend (e.g. the copilot run event stream) arrived in bursts instead of token by token — the live typewriter effect was lost. Declare `Content-Encoding: identity` so GZipMiddleware skips the response, matching the component log stream view.