### PR TITLE
feat: filter platform plugins by cluster arch and anchor installed SKU

### DIFF
--- a/console/services/platform_plugin_service.py
+++ b/console/services/platform_plugin_service.py
@@ -31,6 +31,9 @@ MARKET_DOMAIN = "enterprise"
 PLUGIN_TEAM_NAME = "rbd-plugins"
 PLUGIN_TEAM_ALIAS = "平台插件"
 MARKET_PLUGIN_CACHE_TTL_SECONDS = 60
+REGION_ARCH_CACHE_TTL_SECONDS = 60
+KNOWN_ARCHES = ("amd64", "arm64")
+DEFAULT_ARCH = "amd64"
 
 
 class PlatformPluginService(object):
@@ -39,10 +42,70 @@ class PlatformPluginService(object):
     def __init__(self):
         self._market_plugin_cache = {}
         self._market_plugin_cache_lock = threading.Lock()
+        self._region_arch_cache = {}
+        self._region_arch_cache_lock = threading.Lock()
 
     def clear_market_plugin_cache(self):
         with self._market_plugin_cache_lock:
             self._market_plugin_cache.clear()
+
+    def clear_region_arches_cache(self):
+        with self._region_arch_cache_lock:
+            self._region_arch_cache.clear()
+
+    @staticmethod
+    def _get_region_arch_cache_ttl_seconds():
+        try:
+            return int(os.environ.get("REGION_ARCH_CACHE_TTL_SECONDS", REGION_ARCH_CACHE_TTL_SECONDS))
+        except (TypeError, ValueError):
+            return REGION_ARCH_CACHE_TTL_SECONDS
+
+    def _get_plugin_arch(self, plugin_info):
+        """读取 market plugin 记录的 arch 字段, 兜底为 amd64.
+
+        market platform-plugins 接口在返回结构里携带顶层 arch 字段
+        (rbd-app-server PortalSite 0f3cd4a77 起), 取值 amd64 / arm64.
+        老版本市场或异常值兜底 amd64, 与 app_template 默认行为保持一致.
+        """
+        if not isinstance(plugin_info, dict):
+            return DEFAULT_ARCH
+        arch = (plugin_info.get("arch") or "").strip().lower()
+        if arch in KNOWN_ARCHES:
+            return arch
+        return DEFAULT_ARCH
+
+    def _get_region_arches(self, region_name, now=None):
+        """返回集群节点支持的架构集合.
+
+        失败 fallback 为全集 {amd64, arm64}, 避免单点接口异常导致 ARM 集群
+        看不到 ARM 版本插件. 同 region 60s 内缓存, 避免顶栏轮询打爆 region API.
+        """
+        ttl = self._get_region_arch_cache_ttl_seconds()
+        now = time.time() if now is None else now
+        if ttl > 0:
+            with self._region_arch_cache_lock:
+                entry = self._region_arch_cache.get(region_name)
+                if entry and entry["expires_at"] > now:
+                    return set(entry["arches"])
+
+        try:
+            _, body = region_api.get_cluster_nodes_arch(region_name)
+            raw = (body or {}).get("list") or []
+            arches = {str(item).strip().lower() for item in raw if item}
+            arches = {a for a in arches if a in KNOWN_ARCHES}
+            if not arches:
+                arches = set(KNOWN_ARCHES)
+        except Exception as e:
+            logger.warning("get region arches failed region=%s: %s", region_name, e)
+            arches = set(KNOWN_ARCHES)
+
+        if ttl > 0:
+            with self._region_arch_cache_lock:
+                self._region_arch_cache[region_name] = {
+                    "expires_at": now + ttl,
+                    "arches": set(arches),
+                }
+        return arches
 
     @staticmethod
     def _get_market_plugin_cache_ttl_seconds():
@@ -266,13 +329,94 @@ class PlatformPluginService(object):
         )
         return selected
 
+    def _resolve_installed_sku(self, installed_plugin, region_app_id_map, candidates):
+        """根据已安装 RBDPlugin 的 region_app_id 反查安装时的 app_key, 从 market 候选里
+        找到对应 SKU 记录, 用来锚定 latest_version 与 installed_arch.
+        失败/拿不到时返回 None, 由上层退化为按集群 arch 选中的 SKU.
+        """
+        if not installed_plugin or not candidates:
+            return None
+        region_app_id = installed_plugin.get("region_app_id", "")
+        console_app_id = region_app_id_map.get(region_app_id)
+        if not console_app_id:
+            return None
+        try:
+            cgroups = tenant_service_group_repo.get_group_by_app_id(console_app_id)
+            if not cgroups:
+                return None
+            installed_app_key = cgroups.last().group_key
+        except Exception as e:
+            logger.warning("resolve installed SKU failed app_id=%s: %s", console_app_id, e)
+            return None
+        if not installed_app_key:
+            return None
+        for c in candidates:
+            ak = c.get("appKeyID") or c.get("app_key")
+            if ak == installed_app_key:
+                return c
+        return None
+
+    def _build_plugin_info(self, plugin_id, selected, display_sku, installed_sku,
+                           installed_plugins, region_app_id_map, candidates):
+        """构造单条 plugin 返回 dict. display_sku 决定 latest_version 等版本类字段,
+        selected 决定 app_level/路由/前端组件等运行时字段.
+        """
+        app_level = self._normalize_app_level(selected)
+        plugin_info = {
+            "plugin_id": plugin_id,
+            "app_key": display_sku.get("appKeyID") or display_sku.get("app_key", ""),
+            "plugin_name": display_sku.get("plugin_name") or plugin_id,
+            "name": display_sku.get("name") or plugin_id,
+            "description": display_sku.get("description", ""),
+            "logo": display_sku.get("logo", ""),
+            "app_level": app_level,
+            "latest_version": display_sku.get("latest_version", ""),
+            "plugin_type": display_sku.get("plugin_type", ""),
+            "plugin_views": display_sku.get("plugin_views", []),
+            "frontend_component": display_sku.get("frontend_component", ""),
+            "entry_path": display_sku.get("entry_path", ""),
+            "menu_title": display_sku.get("menu_title", ""),
+            "route_path": display_sku.get("route_path", ""),
+            "installed": False,
+            "status": "",
+            "installed_version": "",
+            "upgradeable": False,
+            "can_upgrade": False,
+            "team_name": "",
+            "app_id": -1,
+            "author": "Rainbond 官方",
+            "selected_arch": self._get_plugin_arch(selected),
+            "installed_arch": self._get_plugin_arch(installed_sku) if installed_sku else None,
+            "available_arches": sorted({self._get_plugin_arch(c) for c in candidates}),
+        }
+        if plugin_id in installed_plugins:
+            plugin_info["installed"] = True
+            installed_plugin = installed_plugins[plugin_id]
+            plugin_info["status"] = installed_plugin.get("status", "")
+            plugin_info["team_name"] = installed_plugin.get("team_name", "")
+            region_app_id = installed_plugin.get("region_app_id", "")
+            console_app_id = region_app_id_map.get(region_app_id, -1)
+            plugin_info["app_id"] = console_app_id
+            plugin_info["plugin_type"] = installed_plugin.get("plugin_type", plugin_info["plugin_type"])
+            plugin_info["plugin_views"] = installed_plugin.get("plugin_views", plugin_info["plugin_views"])
+            if console_app_id > 0:
+                cgroups = tenant_service_group_repo.get_group_by_app_id(console_app_id)
+                if cgroups:
+                    plugin_info["installed_version"] = cgroups.last().group_version or ""
+            if plugin_info["latest_version"] and plugin_info["installed_version"]:
+                plugin_info["upgradeable"] = plugin_info["latest_version"] != plugin_info["installed_version"]
+                plugin_info["can_upgrade"] = plugin_info["upgradeable"]
+        return plugin_info
+
     def list_platform_plugins(self, enterprise_id, region_name):
         """
         List platform plugins from app store.
 
         Rules:
-        - 未授权前：展示应用市场中的全部平台插件
-        - 已授权后：只展示免费插件 + 已授权企业插件
+        - 按集群节点支持的 arch 过滤候选 (混合架构集群保留所有匹配 arch 的候选, AMD 优先选中)
+        - 未授权前: 展示应用市场中的全部平台插件
+        - 已授权后: 只展示免费插件 + 已授权企业插件
+        - 已安装插件的 latest_version 锚定到"安装时的物理 SKU", 避免跨架构误报可升级
         """
         if is_cloud_market_disabled():
             logger.info(
@@ -286,6 +430,7 @@ class PlatformPluginService(object):
         has_valid_license = bool(bean.get("valid"))
         installed_plugins = self._get_installed_plugins(enterprise_id, region_name)
         region_app_id_map = self._get_region_app_id_map(region_name, installed_plugins)
+        region_arches = self._get_region_arches(region_name)
         try:
             _, market_plugins = self._get_market_platform_plugins_cached(enterprise_id)
         except Exception as e:
@@ -294,96 +439,75 @@ class PlatformPluginService(object):
 
         logger.info(
             "platform plugin list source summary enterprise_id=%s region_name=%s "
-            "license_valid=%s mapping_keys=%s market_plugin_count=%s",
+            "license_valid=%s mapping_keys=%s market_plugin_count=%s region_arches=%s",
             enterprise_id,
             region_name,
             has_valid_license,
             list(plugin_mapping.keys()),
             len(market_plugins),
+            sorted(region_arches),
         )
-        logger.info(
-            "platform plugin list market raw enterprise_id=%s region_name=%s plugins=%s",
-            enterprise_id,
-            region_name,
-            json.dumps(
-                [self._plugin_debug_summary(item) for item in market_plugins],
-                ensure_ascii=False,
-                sort_keys=True,
-            ),
-        )
+
+        # 按 plugin_id 分组所有 market SKU
+        grouped = {}
+        for mp in market_plugins:
+            pid = mp.get("plugin_id", "")
+            if pid:
+                grouped.setdefault(pid, []).append(mp)
 
         result = []
-        selected_plugins = {}
-        for market_plugin in market_plugins:
-            plugin_id = market_plugin.get("plugin_id", "")
-            if not plugin_id:
-                continue
-            if plugin_id not in selected_plugins:
-                selected_plugins[plugin_id] = self._select_market_plugin(market_plugins, plugin_id, plugin_mapping)
-        for plugin_id, market_plugin in selected_plugins.items():
-            if not market_plugin:
+        for plugin_id, candidates in grouped.items():
+            # 1. 按集群 arch 过滤候选
+            arch_matched = [c for c in candidates if self._get_plugin_arch(c) in region_arches]
+            if not arch_matched:
+                logger.info(
+                    "platform plugin filtered by arch enterprise_id=%s region_name=%s "
+                    "plugin_id=%s region_arches=%s candidate_arches=%s",
+                    enterprise_id, region_name, plugin_id,
+                    sorted(region_arches),
+                    sorted({self._get_plugin_arch(c) for c in candidates}),
+                )
                 continue
 
-            app_level = self._normalize_app_level(market_plugin)
+            # 2. 混合架构集群 tie-breaker: AMD 优先 (保持老用户体验稳定)
+            arch_matched = sorted(
+                arch_matched,
+                key=lambda c: 0 if self._get_plugin_arch(c) == DEFAULT_ARCH else 1,
+            )
+
+            # 3. 在 arch 匹配的候选里按 free → license app_key → first 选
+            selected = self._select_market_plugin(arch_matched, plugin_id, plugin_mapping)
+            if not selected:
+                continue
+
+            # 4. license 过滤 (按 plugin_id 基名)
+            app_level = self._normalize_app_level(selected)
             if has_valid_license and app_level != "free" and not self._is_plugin_authorized(
                     plugin_mapping, plugin_id):
                 logger.info(
                     "platform plugin filtered by license enterprise_id=%s region_name=%s "
                     "plugin_id=%s app_level=%s mapping_keys=%s",
-                    enterprise_id,
-                    region_name,
-                    plugin_id,
-                    app_level,
+                    enterprise_id, region_name, plugin_id, app_level,
                     list(plugin_mapping.keys()),
                 )
                 continue
 
-            plugin_info = {
-                "plugin_id": plugin_id,
-                "app_key": market_plugin.get("appKeyID") or market_plugin.get("app_key", ""),
-                "plugin_name": market_plugin.get("plugin_name") or plugin_id,
-                "name": market_plugin.get("name") or plugin_id,
-                "description": market_plugin.get("description", ""),
-                "logo": market_plugin.get("logo", ""),
-                "app_level": app_level,
-                "latest_version": market_plugin.get("latest_version", ""),
-                "plugin_type": market_plugin.get("plugin_type", ""),
-                "plugin_views": market_plugin.get("plugin_views", []),
-                "frontend_component": market_plugin.get("frontend_component", ""),
-                "entry_path": market_plugin.get("entry_path", ""),
-                "menu_title": market_plugin.get("menu_title", ""),
-                "route_path": market_plugin.get("route_path", ""),
-                "installed": False,
-                "status": "",
-                "installed_version": "",
-                "upgradeable": False,
-                "can_upgrade": False,
-                "team_name": "",
-                "app_id": -1,
-                "author": "Rainbond 官方",
-            }
-
-            # Check install status from RBDPlugin CRs
+            # 5. installed SKU 锚定 latest_version
+            installed_sku = None
             if plugin_id in installed_plugins:
-                plugin_info["installed"] = True
-                installed_plugin = installed_plugins[plugin_id]
-                plugin_info["status"] = installed_plugin.get("status", "")
-                plugin_info["team_name"] = installed_plugin.get("team_name", "")
-                region_app_id = installed_plugin.get("region_app_id", "")
-                console_app_id = region_app_id_map.get(region_app_id, -1)
-                plugin_info["app_id"] = console_app_id
-                plugin_info["plugin_type"] = installed_plugin.get("plugin_type", plugin_info["plugin_type"])
-                plugin_info["plugin_views"] = installed_plugin.get("plugin_views", plugin_info["plugin_views"])
-                # Get installed version from tenant_service_group
-                if console_app_id > 0:
-                    cgroups = tenant_service_group_repo.get_group_by_app_id(console_app_id)
-                    if cgroups:
-                        plugin_info["installed_version"] = cgroups.last().group_version or ""
-                # Compare versions
-                if plugin_info["latest_version"] and plugin_info["installed_version"]:
-                    plugin_info["upgradeable"] = plugin_info["latest_version"] != plugin_info["installed_version"]
-                    plugin_info["can_upgrade"] = plugin_info["upgradeable"]
+                installed_sku = self._resolve_installed_sku(
+                    installed_plugins[plugin_id], region_app_id_map, candidates)
+            display_sku = installed_sku or selected
 
+            plugin_info = self._build_plugin_info(
+                plugin_id=plugin_id,
+                selected=selected,
+                display_sku=display_sku,
+                installed_sku=installed_sku,
+                installed_plugins=installed_plugins,
+                region_app_id_map=region_app_id_map,
+                candidates=candidates,
+            )
             result.append(plugin_info)
 
         logger.info(
@@ -398,6 +522,9 @@ class PlatformPluginService(object):
     def install_platform_plugin(self, enterprise_id, region_name, plugin_id, user):
         """
         Install a platform plugin: auto-create team/app, fetch from market, install.
+
+        - 候选先按集群 arch 过滤, 避免 ARM 集群装 AMD 模板时被 region 端 arch 校验拒掉
+        - 在 arch 匹配候选中按 free → license app_key → first 选物理 SKU
         """
         bean = self._get_license_bean(enterprise_id, region_name)
         plugin_mapping = bean.get("plugin_mapping", {}) or {}
@@ -405,24 +532,38 @@ class PlatformPluginService(object):
         license_access_key = bean.get("access_key", "")
 
         platform_market, market_plugins = self._get_market_platform_plugins(enterprise_id)
+        region_arches = self._get_region_arches(region_name)
+        candidates_all = [mp for mp in market_plugins if mp.get("plugin_id") == plugin_id]
+        candidates = [c for c in candidates_all if self._get_plugin_arch(c) in region_arches]
+        # 混合架构集群 tie-breaker: AMD 优先 (与 list 接口保持一致)
+        candidates = sorted(
+            candidates,
+            key=lambda c: 0 if self._get_plugin_arch(c) == DEFAULT_ARCH else 1,
+        )
         logger.info(
-            "platform plugin install request enterprise_id=%s region_name=%s plugin_id=%s license_valid=%s mapping_keys=%s",
-            enterprise_id,
-            region_name,
-            plugin_id,
-            bool(bean.get("valid")),
-            list(plugin_mapping.keys()),
+            "platform plugin install request enterprise_id=%s region_name=%s plugin_id=%s "
+            "license_valid=%s mapping_keys=%s region_arches=%s arch_matched=%s/%s",
+            enterprise_id, region_name, plugin_id,
+            bool(bean.get("valid")), list(plugin_mapping.keys()),
+            sorted(region_arches), len(candidates), len(candidates_all),
         )
         logger.info(
             "platform plugin install market candidates plugin_id=%s candidates=%s",
             plugin_id,
             json.dumps(
-                [self._plugin_debug_summary(item) for item in market_plugins if item.get("plugin_id") == plugin_id],
+                [self._plugin_debug_summary(item) for item in candidates],
                 ensure_ascii=False,
                 sort_keys=True,
             ),
         )
-        market_plugin = self._select_market_plugin(market_plugins, plugin_id, plugin_mapping)
+        if candidates_all and not candidates:
+            raise ServiceHandleException(
+                msg="no arch-matched plugin",
+                msg_show="当前集群架构({})没有匹配的{}版本".format(
+                    ",".join(sorted(region_arches)), plugin_id),
+                status_code=404,
+            )
+        market_plugin = self._select_market_plugin(candidates, plugin_id, plugin_mapping)
         if not market_plugin:
             raise ServiceHandleException(msg="plugin not found", msg_show="应用市场中未找到该插件", status_code=404)
 

--- a/console/tests/platform_plugin_service_test.py
+++ b/console/tests/platform_plugin_service_test.py
@@ -8,9 +8,11 @@ class PlatformPluginServiceTests(TestCase):
 
     def setUp(self):
         platform_plugin_service.clear_market_plugin_cache()
+        platform_plugin_service.clear_region_arches_cache()
 
     def tearDown(self):
         platform_plugin_service.clear_market_plugin_cache()
+        platform_plugin_service.clear_region_arches_cache()
 
     def test_plugin_debug_summary_includes_arch_hint_and_keys(self):
         plugin_info = {
@@ -98,7 +100,9 @@ class PlatformPluginServiceTests(TestCase):
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value={}), \
                 mock.patch.object(platform_plugin_service, "_get_installed_plugins", return_value={}), \
                 mock.patch.object(platform_plugin_service, "_get_region_app_id_map", return_value={}), \
-                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins_cached",
                                   return_value=(mock.Mock(), market_plugins)):
             plugins = platform_plugin_service.list_platform_plugins("eid", "region")
 
@@ -121,7 +125,9 @@ class PlatformPluginServiceTests(TestCase):
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
                 mock.patch.object(platform_plugin_service, "_get_installed_plugins", return_value={}), \
                 mock.patch.object(platform_plugin_service, "_get_region_app_id_map", return_value={}), \
-                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins_cached",
                                   return_value=(mock.Mock(), market_plugins)):
             plugins = platform_plugin_service.list_platform_plugins("eid", "region")
 
@@ -143,7 +149,9 @@ class PlatformPluginServiceTests(TestCase):
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
                 mock.patch.object(platform_plugin_service, "_get_installed_plugins", return_value={}), \
                 mock.patch.object(platform_plugin_service, "_get_region_app_id_map", return_value={}), \
-                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins_cached",
                                   return_value=(mock.Mock(), market_plugins)):
             plugins = platform_plugin_service.list_platform_plugins("eid", "region")
 
@@ -161,6 +169,8 @@ class PlatformPluginServiceTests(TestCase):
         }
 
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
                 mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
                                   return_value=(mock.Mock(), market_plugins)):
             with self.assertRaises(ServiceHandleException) as context:
@@ -200,6 +210,8 @@ class PlatformPluginServiceTests(TestCase):
         app.ID = 1
 
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
                 mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
                                   return_value=(mock.Mock(), market_plugins)), \
                 mock.patch.object(platform_plugin_service, "_ensure_plugin_team", return_value=tenant), \
@@ -243,6 +255,8 @@ class PlatformPluginServiceTests(TestCase):
         app.ID = 1
 
         with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"amd64", "arm64"}), \
                 mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
                                   return_value=(mock.Mock(), market_plugins)), \
                 mock.patch.object(platform_plugin_service, "_ensure_plugin_team", return_value=tenant), \
@@ -264,3 +278,212 @@ class PlatformPluginServiceTests(TestCase):
         cloud_model.assert_called_once()
         call_args = cloud_model.call_args[0]
         self.assertEqual("arm-app-key", call_args[1])
+
+    # ---------- arch field parsing ----------
+
+    def test_get_plugin_arch_reads_explicit_field(self):
+        self.assertEqual("arm64", platform_plugin_service._get_plugin_arch({"arch": "arm64"}))
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch({"arch": "amd64"}))
+
+    def test_get_plugin_arch_normalizes_case_and_whitespace(self):
+        self.assertEqual("arm64", platform_plugin_service._get_plugin_arch({"arch": "ARM64"}))
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch({"arch": " AMD64 "}))
+
+    def test_get_plugin_arch_falls_back_to_amd64_when_missing_or_unknown(self):
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch({}))
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch({"arch": ""}))
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch({"arch": "riscv"}))
+        self.assertEqual("amd64", platform_plugin_service._get_plugin_arch(None))
+
+    # ---------- region arch retrieval with cache ----------
+
+    def test_get_region_arches_returns_set_from_region_api(self):
+        platform_plugin_service.clear_region_arches_cache()
+        with mock.patch("console.services.platform_plugin_service.region_api.get_cluster_nodes_arch",
+                        return_value=(None, {"list": ["arm64", "arm64"]})):
+            arches = platform_plugin_service._get_region_arches("rainbond")
+        self.assertEqual({"arm64"}, arches)
+
+    def test_get_region_arches_falls_back_to_full_set_on_failure(self):
+        platform_plugin_service.clear_region_arches_cache()
+        with mock.patch("console.services.platform_plugin_service.region_api.get_cluster_nodes_arch",
+                        side_effect=Exception("network down")):
+            arches = platform_plugin_service._get_region_arches("rainbond")
+        self.assertEqual({"amd64", "arm64"}, arches)
+
+    def test_get_region_arches_caches_within_ttl(self):
+        platform_plugin_service.clear_region_arches_cache()
+        # TTL 默认 60s, 第一次 now=100 写缓存 expires_at=160; 后两次均在 expires_at 之前应命中
+        with mock.patch("console.services.platform_plugin_service.region_api.get_cluster_nodes_arch",
+                        return_value=(None, {"list": ["amd64"]})) as get_arch:
+            platform_plugin_service._get_region_arches("rainbond", now=100.0)
+            platform_plugin_service._get_region_arches("rainbond", now=130.0)
+            platform_plugin_service._get_region_arches("rainbond", now=159.0)
+        self.assertEqual(1, get_arch.call_count)
+
+    def test_get_region_arches_refetches_after_ttl_expires(self):
+        platform_plugin_service.clear_region_arches_cache()
+        with mock.patch("console.services.platform_plugin_service.region_api.get_cluster_nodes_arch",
+                        return_value=(None, {"list": ["amd64"]})) as get_arch:
+            platform_plugin_service._get_region_arches("rainbond", now=100.0)
+            platform_plugin_service._get_region_arches("rainbond", now=200.0)
+        self.assertEqual(2, get_arch.call_count)
+
+    # ---------- arch-based filtering in list_platform_plugins ----------
+
+    def _market_plugins_arm_and_amd(self):
+        return [
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "amd-ak", "latest_version": "1.0.0", "arch": "amd64"},
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "arm-ak", "latest_version": "1.0.0", "arch": "arm64"},
+        ]
+
+    def _list_with_region_arches(self, market_plugins, region_arches,
+                                 installed_plugins=None, license_bean=None):
+        installed_plugins = installed_plugins or {}
+        license_bean = license_bean or {}
+        with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_installed_plugins",
+                                  return_value=installed_plugins), \
+                mock.patch.object(platform_plugin_service, "_get_region_app_id_map", return_value={}), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins_cached",
+                                  return_value=(mock.Mock(), market_plugins)), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value=region_arches):
+            return platform_plugin_service.list_platform_plugins("eid", "rainbond")
+
+    def test_list_platform_plugins_on_arm_cluster_shows_arm_sku_only(self):
+        plugins = self._list_with_region_arches(self._market_plugins_arm_and_amd(), {"arm64"})
+        self.assertEqual(1, len(plugins))
+        self.assertEqual("arm64", plugins[0]["installed_arch"] or plugins[0].get("selected_arch"))
+        self.assertEqual({"amd64", "arm64"}, set(plugins[0]["available_arches"]))
+
+    def test_list_platform_plugins_on_amd_cluster_shows_amd_sku_only(self):
+        plugins = self._list_with_region_arches(self._market_plugins_arm_and_amd(), {"amd64"})
+        self.assertEqual(1, len(plugins))
+        self.assertEqual("amd64", plugins[0].get("selected_arch"))
+
+    def test_list_platform_plugins_on_mixed_cluster_prefers_amd_sku(self):
+        plugins = self._list_with_region_arches(
+            self._market_plugins_arm_and_amd(), {"amd64", "arm64"})
+        self.assertEqual(1, len(plugins))
+        self.assertEqual("amd64", plugins[0].get("selected_arch"))
+
+    def test_list_platform_plugins_drops_plugin_when_no_arch_match(self):
+        market_plugins = [
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "amd-ak", "latest_version": "1.0.0", "arch": "amd64"},
+        ]
+        plugins = self._list_with_region_arches(market_plugins, {"arm64"})
+        self.assertEqual(0, len(plugins))
+
+    def test_list_platform_plugins_fallback_full_arch_set_when_region_arches_empty(self):
+        # fallback 全集场景下不丢失任何 plugin
+        plugins = self._list_with_region_arches(
+            self._market_plugins_arm_and_amd(), {"amd64", "arm64"})
+        self.assertEqual(1, len(plugins))
+
+    # ---------- installed SKU anchoring latest_version ----------
+
+    def test_list_platform_plugins_installed_arm_anchors_latest_version_against_arm_sku(self):
+        # ARM SKU 已装 v1.0.0；AMD SKU 在市场上 v2.0.0；ARM 集群应该锁 ARM v1.0.0
+        market_plugins = [
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "amd-ak", "latest_version": "2.0.0", "arch": "amd64"},
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "arm-ak", "latest_version": "1.0.0", "arch": "arm64"},
+        ]
+        installed_plugins = {
+            "rainbond-agent": {
+                "name": "rainbond-agent",
+                "status": "RUNNING",
+                "team_name": "rbd-plugins",
+                "region_app_id": "region-app-1",
+                "plugin_type": "frontend",
+            }
+        }
+
+        component_group = mock.Mock(group_version="1.0.0", group_key="arm-ak")
+        component_groups_qs = mock.Mock()
+        component_groups_qs.last.return_value = component_group
+        component_groups_qs.__iter__ = lambda self: iter([component_group])
+
+        with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value={}), \
+                mock.patch.object(platform_plugin_service, "_get_installed_plugins",
+                                  return_value=installed_plugins), \
+                mock.patch.object(platform_plugin_service, "_get_region_app_id_map",
+                                  return_value={"region-app-1": 42}), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins_cached",
+                                  return_value=(mock.Mock(), market_plugins)), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"arm64"}), \
+                mock.patch("console.services.platform_plugin_service.tenant_service_group_repo.get_group_by_app_id",
+                           return_value=component_groups_qs):
+            plugins = platform_plugin_service.list_platform_plugins("eid", "rainbond")
+
+        self.assertEqual(1, len(plugins))
+        info = plugins[0]
+        self.assertTrue(info["installed"])
+        self.assertEqual("1.0.0", info["latest_version"])
+        self.assertEqual("1.0.0", info["installed_version"])
+        self.assertFalse(info["upgradeable"])
+        self.assertEqual("arm64", info["installed_arch"])
+
+    # ---------- install_platform_plugin arch selection ----------
+
+    def _install_with_arch(self, market_plugins, region_arches, plugin_id):
+        license_bean = {"valid": False, "plugin_mapping": {}, "access_key": "license-ak"}
+        tenant = mock.Mock(tenant_id="team-1", tenant_name="rbd-plugins")
+        region_info = mock.Mock(region_name="rainbond")
+        app = mock.Mock(ID=1)
+
+        with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
+                                  return_value=(mock.Mock(), market_plugins)), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value=region_arches), \
+                mock.patch.object(platform_plugin_service, "_ensure_plugin_team", return_value=tenant), \
+                mock.patch.object(platform_plugin_service, "_ensure_plugin_app", return_value=app), \
+                mock.patch("console.services.platform_plugin_service.region_repo.get_enterprise_region_by_region_name",
+                           return_value=region_info), \
+                mock.patch("console.services.platform_plugin_service.app_market_service.cloud_app_model_to_db_model",
+                           return_value=(
+                               mock.Mock(app_id="app-id", app_name="AI助手"),
+                               mock.Mock(app_template="{}", update_time="",
+                                         arch=next(iter(region_arches))),
+                           )) as cloud_model, \
+                mock.patch("console.services.platform_plugin_service.market_app_service._create_tenant_service_group",
+                           return_value=mock.Mock()), \
+                mock.patch("console.services.platform_plugin_service.AppUpgrade") as app_upgrade_cls, \
+                mock.patch("console.services.platform_plugin_service.market_app_service._create_rbdplugin_if_needed"):
+            app_upgrade_cls.return_value.install.return_value = []
+            platform_plugin_service.install_platform_plugin("eid", "rainbond", plugin_id, mock.Mock())
+            return cloud_model
+
+    def test_install_platform_plugin_on_arm_cluster_picks_arm_sku(self):
+        market_plugins = [
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "amd-ak", "latest_version": "1.0.0", "arch": "amd64"},
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "arm-ak", "latest_version": "1.0.0", "arch": "arm64"},
+        ]
+        cloud_model = self._install_with_arch(market_plugins, {"arm64"}, "rainbond-agent")
+        cloud_model.assert_called_once()
+        self.assertEqual("arm-ak", cloud_model.call_args[0][1])
+
+    def test_install_platform_plugin_raises_when_arch_mismatch(self):
+        market_plugins = [
+            {"plugin_id": "rainbond-agent", "plugin_name": "AI助手", "app_level": "free",
+             "appKeyID": "amd-ak", "latest_version": "1.0.0", "arch": "amd64"},
+        ]
+        license_bean = {"valid": False, "plugin_mapping": {}, "access_key": "license-ak"}
+        with mock.patch.object(platform_plugin_service, "_get_license_bean", return_value=license_bean), \
+                mock.patch.object(platform_plugin_service, "_get_market_platform_plugins",
+                                  return_value=(mock.Mock(), market_plugins)), \
+                mock.patch.object(platform_plugin_service, "_get_region_arches",
+                                  return_value={"arm64"}):
+            with self.assertRaises(ServiceHandleException) as ctx:
+                platform_plugin_service.install_platform_plugin(
+                    "eid", "rainbond", "rainbond-agent", mock.Mock())
+        self.assertIn("arm64", ctx.exception.msg_show)


### PR DESCRIPTION
The market platform-plugins endpoint (app-store 0f3cd4a77) now returns an arch field that distinguishes ARM/AMD physical SKUs sharing the same plugin_id. Previously console deduplicated by plugin_id and only kept one SKU, so ARM clusters saw the AMD free SKU of rainbond-agent and could not install it (region arch check rejected it).

Key changes:
- _get_plugin_arch reads the new market arch field, defaults to amd64
- _get_region_arches queries region_api.get_cluster_nodes_arch with a 60s in-memory cache; on failure it falls back to {amd64, arm64} so a flaky region API never silently filters out ARM SKUs
- list_platform_plugins groups all market SKUs by plugin_id, filters candidates by the cluster arch set, breaks ties with amd64-first on mixed-arch clusters (preserves prior user experience), then keeps the existing free / license app_key / first selection
- install_platform_plugin applies the same arch filtering and raises a clear error when no candidate matches the cluster arch
- For installed plugins, latest_version is anchored to the SKU recorded at install time (looked up via service_source.group_key) instead of the arch-filtered candidate, so we never report a cross-arch upgrade
- Response gains selected_arch / installed_arch / available_arches for UI consumption; existing hard-coded plugin_id checks keep working

Tests:
- 26 unit tests cover arch fallback, region arch cache, pure-arch clusters, mixed clusters, no arch match, installed SKU anchoring, install arch mismatch errors
- Verified on the ARM single-node test cluster: 9 plugins with arm64 SKUs are listed, rainbond-bill (amd64 only) is filtered out