### PR TITLE
fix: resolve synthetic platform plugin market name in upgrade flow

### DIFF
--- a/console/repositories/app.py
+++ b/console/repositories/app.py
@@ -17,6 +17,15 @@ from www.models.main import (ServiceGroup, ServiceGroupRelation, ServiceWebhooks
 
 logger = logging.getLogger('default')
 
+# platform_plugin_service 安装平台插件时, 会把 service_source.extend_info.market_name
+# 标成下面这个合成名 (它代表"默认市场的 url/access_key + domain=enterprise" 组合,
+# 而不是 app_market 表里的一行真实记录). 所有按 market_name 查市场的上游 (升级管理
+# 应用模型列表, get_property_changes, _app_template 等) 必须能解析该合成名, 否则
+# 平台插件装好后, 走通用升级链路时一律会拿到 404 / 暂无数据.
+PLATFORM_PLUGIN_MARKET_NAME = "__platform_plugin__"
+PLATFORM_PLUGIN_MARKET_DOMAIN = "enterprise"
+PLATFORM_PLUGIN_DEFAULT_URL = "https://hub.grapps.cn"
+
 
 class TenantServiceInfoRepository(object):
     def list_by_svc_share_uuids(self, group_id, dep_uuids):
@@ -580,6 +589,9 @@ class AppMarketRepository(object):
 
     def get_app_market_by_name(self, enterprise_id, name, user_id=None, raise_exception=False):
         """根据名称获取应用市场，支持用户过滤"""
+        if name == PLATFORM_PLUGIN_MARKET_NAME:
+            return self._build_platform_plugin_market(enterprise_id, raise_exception=raise_exception)
+
         queryset = AppMarket.objects.filter(enterprise_id=enterprise_id, name=name)
 
         if os.getenv("USE_SAAS") and user_id:
@@ -590,6 +602,26 @@ class AppMarketRepository(object):
         if raise_exception and not market:
             raise ServiceHandleException(status_code=404, msg="no found app market", msg_show="应用商店不存在")
         return market
+
+    def _build_platform_plugin_market(self, enterprise_id, raise_exception=False):
+        """构造平台插件用的合成 AppMarket. 这是个内存中的实例, 不会保存到数据库.
+
+        平台插件在 hub.grapps.cn 上挂在 domain=enterprise 命名空间下, 默认市场 (RainbondMarket,
+        domain=rainbond) 通过 access_key + url 复用即可. 这里返回的 AppMarket 仅供消费方读取
+        url / domain / access_key, 不应该被 save() 或 delete().
+        """
+        default = AppMarket.objects.filter(enterprise_id=enterprise_id, is_personal=False).first()
+        if not default:
+            if raise_exception:
+                raise ServiceHandleException(status_code=404, msg="no found app market", msg_show="默认应用市场不存在")
+            return None
+        return AppMarket(
+            name=PLATFORM_PLUGIN_MARKET_NAME,
+            url=default.url or PLATFORM_PLUGIN_DEFAULT_URL,
+            domain=PLATFORM_PLUGIN_MARKET_DOMAIN,
+            access_key=default.access_key,
+            enterprise_id=enterprise_id,
+        )
 
     def get_app_market_by_domain_url(self, enterprise_id, domain, url, raise_exception=False):
         market = AppMarket.objects.filter(enterprise_id=enterprise_id, domain=domain, url=url).first()

--- a/console/services/platform_plugin_service.py
+++ b/console/services/platform_plugin_service.py
@@ -8,7 +8,12 @@ import time
 from console.appstore.appstore import app_store
 from console.exception.main import ServiceHandleException
 from console.models.main import AppMarket
-from console.repositories.app import app_market_repo
+from console.repositories.app import (
+    PLATFORM_PLUGIN_DEFAULT_URL,
+    PLATFORM_PLUGIN_MARKET_DOMAIN,
+    PLATFORM_PLUGIN_MARKET_NAME,
+    app_market_repo,
+)
 from console.repositories.group import group_repo, tenant_service_group_repo
 from console.repositories.region_app import region_app_repo
 from console.repositories.region_repo import region_repo
@@ -26,8 +31,10 @@ from www.models.main import Tenants
 region_api = RegionInvokeApi()
 logger = logging.getLogger("default")
 
-MARKET_HOST = "https://hub.grapps.cn"
-MARKET_DOMAIN = "enterprise"
+# 合成市场名 / domain / 兜底 URL 都从 repository 层导入, 跟通用升级链路的解析逻辑保持一致.
+# 这里给两个别名 (MARKET_HOST / MARKET_DOMAIN) 仅为兼容现有引用; 新代码请直接用 PLATFORM_PLUGIN_* 常量.
+MARKET_HOST = PLATFORM_PLUGIN_DEFAULT_URL
+MARKET_DOMAIN = PLATFORM_PLUGIN_MARKET_DOMAIN
 PLUGIN_TEAM_NAME = "rbd-plugins"
 PLUGIN_TEAM_ALIAS = "平台插件"
 MARKET_PLUGIN_CACHE_TTL_SECONDS = 60
@@ -202,7 +209,7 @@ class PlatformPluginService(object):
     def _build_platform_market(self, enterprise_id):
         default_market = self._get_default_market(enterprise_id)
         return AppMarket(
-            name="__platform_plugin__",
+            name=PLATFORM_PLUGIN_MARKET_NAME,
             url=default_market.url or MARKET_HOST,
             domain=MARKET_DOMAIN,
             access_key=default_market.access_key,
@@ -606,7 +613,7 @@ class PlatformPluginService(object):
                 raise ServiceHandleException(msg="no access_key in license", msg_show="授权信息中缺少 access_key")
             app_key = authorized_app_key
             market = AppMarket(
-                name="__platform_plugin__",
+                name=PLATFORM_PLUGIN_MARKET_NAME,
                 url=MARKET_HOST,
                 domain=MARKET_DOMAIN,
                 access_key=license_access_key,
@@ -652,7 +659,7 @@ class PlatformPluginService(object):
         app_upgrade = AppUpgrade(
             enterprise_id, tenant, region, user, app,
             latest_version, component_group, app_template,
-            True, "__platform_plugin__", is_deploy=True)
+            True, PLATFORM_PLUGIN_MARKET_NAME, is_deploy=True)
         app_upgrade.install()
 
         # 8. Create RBDPlugin CR if template has platform_plugin info

--- a/console/tests/app_market_repo_test.py
+++ b/console/tests/app_market_repo_test.py
@@ -1,0 +1,67 @@
+from unittest import TestCase, mock
+
+from console.exception.main import ServiceHandleException
+from console.repositories.app import (
+    PLATFORM_PLUGIN_DEFAULT_URL,
+    PLATFORM_PLUGIN_MARKET_DOMAIN,
+    PLATFORM_PLUGIN_MARKET_NAME,
+    app_market_repo,
+)
+
+
+class AppMarketRepoPlatformPluginMarketTests(TestCase):
+    """get_app_market_by_name 需要把 __platform_plugin__ 合成名解析成"默认市场 + domain=enterprise"
+    的内存 AppMarket 实例, 否则升级管理列表 / get_property_changes / 升级执行等
+    "按 market_name 查市场"的链路, 都会因为 app_market 表里没有这条记录而拿到 404, UI 表现为
+    "暂无数据". 这里覆盖正常 / 没有默认市场两种路径.
+    """
+
+    def test_synthetic_platform_plugin_name_returns_default_market_with_enterprise_domain(self):
+        default = mock.Mock()
+        default.url = "https://hub.example.com"
+        default.access_key = "default-ak"
+
+        queryset = mock.Mock()
+        queryset.first.return_value = default
+
+        with mock.patch("console.repositories.app.AppMarket.objects.filter", return_value=queryset) as filter_call:
+            market = app_market_repo.get_app_market_by_name("eid", PLATFORM_PLUGIN_MARKET_NAME, raise_exception=True)
+
+        filter_call.assert_called_once_with(enterprise_id="eid", is_personal=False)
+        self.assertEqual(PLATFORM_PLUGIN_MARKET_NAME, market.name)
+        self.assertEqual("https://hub.example.com", market.url)
+        self.assertEqual(PLATFORM_PLUGIN_MARKET_DOMAIN, market.domain)
+        self.assertEqual("default-ak", market.access_key)
+        self.assertEqual("eid", market.enterprise_id)
+
+    def test_synthetic_platform_plugin_name_falls_back_to_default_url_when_default_market_has_no_url(self):
+        default = mock.Mock()
+        default.url = ""
+        default.access_key = "default-ak"
+
+        queryset = mock.Mock()
+        queryset.first.return_value = default
+
+        with mock.patch("console.repositories.app.AppMarket.objects.filter", return_value=queryset):
+            market = app_market_repo.get_app_market_by_name("eid", PLATFORM_PLUGIN_MARKET_NAME)
+
+        self.assertEqual(PLATFORM_PLUGIN_DEFAULT_URL, market.url)
+
+    def test_synthetic_platform_plugin_name_returns_none_without_default_market_when_not_raising(self):
+        queryset = mock.Mock()
+        queryset.first.return_value = None
+
+        with mock.patch("console.repositories.app.AppMarket.objects.filter", return_value=queryset):
+            market = app_market_repo.get_app_market_by_name("eid", PLATFORM_PLUGIN_MARKET_NAME, raise_exception=False)
+
+        self.assertIsNone(market)
+
+    def test_synthetic_platform_plugin_name_raises_when_default_market_missing_and_raise_requested(self):
+        queryset = mock.Mock()
+        queryset.first.return_value = None
+
+        with mock.patch("console.repositories.app.AppMarket.objects.filter", return_value=queryset):
+            with self.assertRaises(ServiceHandleException) as ctx:
+                app_market_repo.get_app_market_by_name("eid", PLATFORM_PLUGIN_MARKET_NAME, raise_exception=True)
+
+        self.assertEqual(404, ctx.exception.status_code)


### PR DESCRIPTION
When a platform plugin is installed, platform_plugin_service stamps service_source.extend_info.market_name = "__platform_plugin__", a virtual name not present in the app_market table. Every "look up market by name" call site (upgrade management list, get_property_changes, _app_template, upgrade execution) raised 404 against this synthetic name, and GroupAppView swallowed the 404, leaving the upgrade page showing "no data" for any plugin installed via the platform-plugin flow.

Teach app_market_repo.get_app_market_by_name to recognize the synthetic name and return an in-memory AppMarket built from the default market's url/access_key with domain="enterprise" - the same shape that platform_plugin_service._build_platform_market already produces. This fixes the entire general upgrade chain (list -> diff -> execute) in one place.

Also replaces the literal "__platform_plugin__" strings and the duplicate MARKET_HOST/MARKET_DOMAIN definitions in platform_plugin_service with imports of the new repo-level constants, so the contract has one source of truth.

Adds regression tests covering happy path, URL fallback, and the missing-default-market case with and without raise_exception.