### PR TITLE
fix: install openapi_client outside requirements.txt to unblock arm b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV PATH="/app/ui/py_venv/bin:$PATH"
 RUN python -m venv --copies /app/ui/py_venv && \
     python -m pip install --upgrade pip && pip install numpy==1.19.3 && \
     pip install -r requirements.txt $PYTHONPROXY && \
+    pip install git+https://gitee.com/zhangsetsail/appstore-sdk-python.git@python3 $PYTHONPROXY && \
     python manage.py collectstatic --noinput --ignore weavescope-src --ignore drf-yasg --ignore rest_framework
 
 RUN git clone --depth=1 -b main https://github.com/goodrain/rainbond-chart /app/ui/rainbond-chart && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,3 @@ alibabacloud-tea==0.3.10
 alibabacloud-tea-util==0.3.13
 alibabacloud-tea-xml==0.0.2
 volcengine
--e git+https://gitee.com/zhangsetsail/appstore-sdk-python.git@python3#egg=openapi_client


### PR DESCRIPTION
…uild

pip's new resolver fails to extract metadata for the editable VCS install (-e git+gitee...#egg=openapi_client) under arm/qemu buildx, marking the version as (unavailable) and then failing PyPI fallback resolution. Move the gitee install to a standalone non-editable pip step so the requirements resolve phase no longer touches it.