### PR TITLE
fix: install openapi-client via gitee tarball to avoid git auth promp…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,11 @@ ENV PATH="/app/ui/py_venv/bin:$PATH"
 RUN python -m venv --copies /app/ui/py_venv && \
     python -m pip install --upgrade pip && pip install numpy==1.19.3 && \
     pip install -r requirements.txt $PYTHONPROXY && \
-    pip install git+https://gitee.com/zhangsetsail/appstore-sdk-python.git@python3 $PYTHONPROXY && \
+    curl -fsSL https://gitee.com/zhangsetsail/appstore-sdk-python/repository/archive/python3.tar.gz -o /tmp/openapi-client.tar.gz && \
+    mkdir -p /tmp/openapi-client && \
+    tar xzf /tmp/openapi-client.tar.gz -C /tmp/openapi-client --strip-components=1 && \
+    pip install /tmp/openapi-client $PYTHONPROXY && \
+    rm -rf /tmp/openapi-client /tmp/openapi-client.tar.gz && \
     python manage.py collectstatic --noinput --ignore weavescope-src --ignore drf-yasg --ignore rest_framework
 
 RUN git clone --depth=1 -b main https://github.com/goodrain/rainbond-chart /app/ui/rainbond-chart && \


### PR DESCRIPTION
…t on arm

gitee.com rejects anonymous git clone from buildx/qemu arm builds and prompts for credentials. Switch to curl download of the branch tarball + local pip install so the build no longer relies on git's smart-http handshake.