### PR TITLE
fix(agent): keep existing api key when llm config saved without a new key

### DIFF
--- a/console/services/agent_llm_config_service.py
+++ b/console/services/agent_llm_config_service.py
@@ -29,11 +29,17 @@ class AgentLLMConfigService(object):
 
     def update_config(self, data, updated_by=""):
         data = data or {}
-        self._validate_update(data)
-        raw_api_key = data.get("openai_api_key")
+        existing = self._load_config()
+        existing_stored_key = existing.get("OPENAI_API_KEY", "")
+        has_existing_api_key = bool(self._decrypt_api_key(existing_stored_key))
+        self._validate_update(data, has_existing_api_key=has_existing_api_key)
+
+        raw_api_key = self._read_string(data.get("openai_api_key"))
+        # 留空表示保持当前密钥不变；仅当传入新密钥时才重新加密覆盖
+        stored_api_key = self._encrypt_api_key(raw_api_key) if raw_api_key else existing_stored_key
 
         next_config = {
-            "OPENAI_API_KEY": self._encrypt_api_key(str(raw_api_key).strip()),
+            "OPENAI_API_KEY": stored_api_key,
             "OPENAI_MODEL": self._read_string(data.get("openai_model")),
             "OPENAI_BASE_URL": self._read_string(data.get("openai_base_url")),
             "LLM_THINKING_ENABLED": self._read_bool(data.get("llm_thinking_enabled"),
@@ -101,10 +107,9 @@ class AgentLLMConfigService(object):
     def _serialize_config(self, config):
         return json.dumps(config or {}, ensure_ascii=False, sort_keys=True)
 
-    def _validate_update(self, data):
+    def _validate_update(self, data, has_existing_api_key=False):
         errors = []
         required_fields = (
-            ("openai_api_key", "OPENAI_API_KEY"),
             ("openai_model", "OPENAI_MODEL"),
             ("openai_base_url", "OPENAI_BASE_URL"),
             ("llm_reasoning_effort", "LLM_REASONING_EFFORT"),
@@ -112,6 +117,10 @@ class AgentLLMConfigService(object):
         for field, label in required_fields:
             if not self._read_string(data.get(field)):
                 errors.append("{} 不能为空".format(label))
+
+        # 已配置过密钥时允许留空（保持原密钥）；首次配置仍必填
+        if not has_existing_api_key and not self._read_string(data.get("openai_api_key")):
+            errors.append("OPENAI_API_KEY 不能为空")
 
         if data.get("llm_thinking_enabled") is None:
             errors.append("LLM_THINKING_ENABLED 不能为空")

--- a/console/tests/agent_llm_config_service_test.py
+++ b/console/tests/agent_llm_config_service_test.py
@@ -54,6 +54,39 @@ class AgentLLMConfigServiceTests(TestCase):
         self.assertEqual("true", runtime["LLM_THINKING_ENABLED"])
         self.assertEqual("medium", runtime["LLM_REASONING_EFFORT"])
 
+    def test_update_keeps_existing_api_key_when_blank(self):
+        existing = {
+            "OPENAI_API_KEY": agent_llm_config_service._encrypt_api_key("sk-existing-secret"),
+            "OPENAI_MODEL": "old-model",
+            "OPENAI_BASE_URL": "https://old.example/v1",
+            "LLM_THINKING_ENABLED": True,
+            "LLM_REASONING_EFFORT": "low",
+        }
+        existing_value = json.dumps(existing, ensure_ascii=False, sort_keys=True)
+
+        with mock.patch("console.services.agent_llm_config_service.ConsoleSysConfig.objects.get",
+                        return_value=self._config_obj(existing_value)):
+            masked = agent_llm_config_service.update_config({
+                "openai_api_key": "",
+                "openai_model": "new-model",
+                "openai_base_url": "https://new.example/v1",
+                "llm_thinking_enabled": False,
+                "llm_reasoning_effort": "high",
+            }, updated_by="admin")
+
+        self.assertTrue(masked["openai_api_key_set"])
+        self.assertEqual("new-model", masked["openai_model"])
+        stored = json.loads(self.saved["value"])
+        # 留空提交后，已存储的加密密钥应原样保留
+        self.assertEqual(existing["OPENAI_API_KEY"], stored["OPENAI_API_KEY"])
+        self.assertEqual("new-model", stored["OPENAI_MODEL"])
+
+        with mock.patch("console.services.agent_llm_config_service.ConsoleSysConfig.objects.get",
+                        return_value=self._config_obj(self.saved["value"])):
+            runtime = agent_llm_config_service.get_runtime_config()
+        self.assertEqual("sk-existing-secret", runtime["OPENAI_API_KEY"])
+        self.assertEqual("new-model", runtime["OPENAI_MODEL"])
+
     def test_update_requires_api_key_and_all_config_values(self):
         with self.assertRaises(Exception) as cm:
             agent_llm_config_service.update_config({


### PR DESCRIPTION
update_config now reuses the stored encrypted key when openai_api_key is blank, and only requires it on first-time setup. This lets admins update model/base_url/reasoning without re-sending the secret. Adds a test covering the blank-keeps-existing path.