### PR TITLE
feat(mcp): honor prefer_dockerfile_when_detected on get_component_che…

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -3120,6 +3120,7 @@ class MCPQueryService(object):
             self._require_int(arguments, "app_id"),
             self._require_string(arguments, "service_id"),
         )
+        prefer_dockerfile_when_detected = bool(arguments.get("prefer_dockerfile_when_detected", False))
         check_uuid = arguments.get("check_uuid") or service.check_uuid
         if not check_uuid:
             raise ServiceHandleException(msg="check_uuid required", msg_show="参数check_uuid无效", status_code=400)
@@ -3135,6 +3136,16 @@ class MCPQueryService(object):
         else:
             service_info_list = data.get("service_info") or []
             if service_info_list and len(service_info_list) < 2:
+                if prefer_dockerfile_when_detected:
+                    # Re-detect recovery path: apply the same Dockerfile preference
+                    # create_component_from_source uses, so a component whose
+                    # language is CNB-classified but ships a Dockerfile persists as
+                    # a Dockerfile build (build_strategy="") instead of dead-ending
+                    # on CNB (e.g. .NET 7 rejected by the CNB version policy).
+                    service_info_list[0] = source_component_service._select_service_info(
+                        service_info_list[0], True
+                    )
+                    data["service_info"] = service_info_list
                 app_check_service.save_service_check_info(team, app.ID, service, data)
             check_brief_info = app_check_service.wrap_service_check_info(service, data)
 
@@ -6337,7 +6348,15 @@ class MCPQueryService(object):
                     "region_name": {"type": "string"},
                     "app_id": {"type": "integer", "minimum": 1},
                     "service_id": {"type": "string"},
-                    "check_uuid": {"type": "string"}
+                    "check_uuid": {"type": "string"},
+                    "prefer_dockerfile_when_detected": {
+                        "type": "boolean",
+                        "description": (
+                            "仅 MCP 使用。重新检测后若结果同时命中 Dockerfile 和语言型构建方式，"
+                            "优先选择 Dockerfile（与 create 时同名参数一致）。用于恢复路径强制 Dockerfile，"
+                            "避免 CNB 不支持的语言/版本（如 .NET 7）卡死。默认 false。"
+                        )
+                    }
                 },
                 "required": ["team_name", "region_name", "app_id", "service_id"]
             }

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -5480,6 +5480,63 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.group_service.get_app_by_id")
     @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
     @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
+    @patch("console.services.mcp_query_service.app_check_service.get_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.save_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.wrap_service_check_info")
+    # capability_id: console.component.check-result
+    def test_get_component_check_result_prefer_dockerfile_forces_dockerfile(
+            self,
+            mock_wrap_check_info,
+            mock_save_check_info,
+            mock_get_check_info,
+            mock_relations,
+            mock_get_service,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        # Recovery path: a CNB-classified language (.NetCore) that ships a
+        # Dockerfile must persist as a Dockerfile build when the caller passes
+        # prefer_dockerfile_when_detected, so it does not dead-end on the CNB
+        # version policy (e.g. .NET 7).
+        self.service.service_source = "source_code"
+        self.service.create_status = "checked"  # != complete -> else branch
+        self.service.check_uuid = "chk-1"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_get_service.return_value = self.service
+        mock_relations.return_value = [Obj(service_id="svc-1")]
+        mock_get_check_info.return_value = (
+            200, "success",
+            {"check_status": "success", "error_infos": [],
+             "service_info": [{"language": ".NetCore", "dockerfiles": ["Dockerfile"]}]},
+        )
+        captured = {}
+
+        def cap_save(team, app_id, service, data):
+            captured["data"] = data
+            service.create_status = "checked"
+
+        mock_save_check_info.side_effect = cap_save
+        mock_wrap_check_info.return_value = {"check_status": "success", "error_infos": [], "service_info": []}
+
+        mcp_query_service.call_tool(
+            self.user,
+            "rainbond_get_component_check_result",
+            {"team_name": "demo-team", "region_name": "rainbond", "app_id": 12,
+             "service_id": "svc-1", "prefer_dockerfile_when_detected": True},
+        )
+
+        # _select_service_info rewrote the detected language to "dockerfile"
+        # before persistence, so build_strategy will resolve to non-CNB.
+        self.assertEqual(captured["data"]["service_info"][0]["language"], "dockerfile")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
+    @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
     @patch("console.services.mcp_query_service.console_app_service.create_region_service")
     @patch("console.services.mcp_query_service.arch_service.update_affinity_by_arch")
     @patch("console.services.mcp_query_service.app_manage_service.deploy")


### PR DESCRIPTION
…ck_result

The recovery path (update_component_build_source + check_component + get_component_check_result) could not re-apply the Dockerfile build preference, so a CNB-classified language that ships a Dockerfile (e.g. .NET 7) re-detected as CNB and dead-ended on the CNB version policy (dotnet 7.0 not allowed). prefer_dockerfile_when_detected was honored only at create_component_from_source.

Accept the same flag on get_component_check_result and reuse source_component_service._select_service_info before persisting the re-detection result, so the component lands as a Dockerfile build (build_strategy resolves to non-CNB) on the recovery path too.