### PR TITLE
fix(mcp): delete app components and attached resources in rainbond_delete_app

### DIFF
--- a/console/services/group_service.py
+++ b/console/services/group_service.py
@@ -723,6 +723,34 @@ class GroupService(object):
         """ get service source by group key"""
         return service_source_repo.get_service_sources_by_group_key(group_key)
 
+    def delete_app_with_resources(self, user, tenant, region_name, app):
+        """Delete an application along with all of its resources:
+        components, kubeblocks clusters, k8s resources, config groups and share records.
+        Returns the deleted components for callers that need them (e.g. operation log).
+        """
+        # avoid circular import
+        from console.services.k8s_resource import k8s_resource_service
+        from console.services.kubeblocks_service import kubeblocks_service
+
+        app_id = app.app_id
+        # delete services
+        services = self.batch_delete_app_services(user, tenant.tenant_id, region_name, app_id)
+        # delete kubeblocks cluster if service is kubeblocks cluster
+        service_ids = [service.service_id for service in services]
+        kubeblocks_service.delete_kubeblocks_cluster(service_ids, region_name)
+        # delete k8s resource
+        k8s_resources = k8s_resource_service.list_by_app_id(str(app_id))
+        resource_ids = [k8s_resource.ID for k8s_resource in k8s_resources]
+        k8s_resource_service.batch_delete_k8s_resource(user.enterprise_id, tenant.tenant_name, str(app_id), region_name,
+                                                       resource_ids)
+        # delete configs
+        app_config_group_service.batch_delete_config_group(region_name, tenant.tenant_name, app_id)
+        # delete records
+        self.delete_app_share_records(tenant.tenant_name, app_id)
+        # delete app
+        self.delete_app(tenant, region_name, app)
+        return services
+
     @transaction.atomic
     def delete_app(self, tenant, region_name, app):
         if app.app_type == AppType.helm.name:

--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -3988,7 +3988,7 @@ class MCPQueryService(object):
         if int(token_payload.get("app_id", 0)) != app_id:
             raise ServiceHandleException(msg="token app mismatch", msg_show="确认令牌与目标应用不匹配", status_code=400)
 
-        group_service.delete_app(tenant, app.region_name, app)
+        group_service.delete_app_with_resources(user, tenant, app.region_name, app)
 
         return {
             "requires_confirmation": False,

--- a/console/tests/group_service_test.py
+++ b/console/tests/group_service_test.py
@@ -60,6 +60,39 @@ class GroupServiceDeleteAppTestCase(TestCase):
         )
 
 
+# capability_id: console.app.delete-with-resources
+class GroupServiceDeleteAppWithResourcesTestCase(TestCase):
+    def test_delete_app_with_resources_deletes_components_and_attached_resources(self):
+        user = Obj(user_id=1001, enterprise_id="eid-1", nick_name="admin")
+        tenant = Obj(tenant_id="team-1", tenant_name="demo-team", enterprise_id="eid-1")
+        app = Obj(ID=42, app_id=42, app_type="rainbond", group_name="demo-app")
+        services = [Obj(service_id="svc-1"), Obj(service_id="svc-2")]
+        k8s_resources = [Obj(ID=7), Obj(ID=8)]
+
+        with mock.patch.object(group_service, "batch_delete_app_services",
+                               return_value=services) as batch_delete_mock, \
+                mock.patch("console.services.kubeblocks_service.kubeblocks_service.delete_kubeblocks_cluster"
+                           ) as delete_kubeblocks_mock, \
+                mock.patch("console.services.k8s_resource.k8s_resource_service.list_by_app_id",
+                           return_value=k8s_resources) as list_k8s_mock, \
+                mock.patch("console.services.k8s_resource.k8s_resource_service.batch_delete_k8s_resource"
+                           ) as delete_k8s_mock, \
+                mock.patch.object(group_service_module.app_config_group_service,
+                                  "batch_delete_config_group") as delete_config_group_mock, \
+                mock.patch.object(group_service, "delete_app_share_records") as delete_share_mock, \
+                mock.patch.object(group_service, "delete_app") as delete_app_mock:
+            result = group_service.delete_app_with_resources(user, tenant, "demo-region", app)
+
+        self.assertEqual(result, services)
+        batch_delete_mock.assert_called_once_with(user, "team-1", "demo-region", 42)
+        delete_kubeblocks_mock.assert_called_once_with(["svc-1", "svc-2"], "demo-region")
+        list_k8s_mock.assert_called_once_with("42")
+        delete_k8s_mock.assert_called_once_with("eid-1", "demo-team", "42", "demo-region", [7, 8])
+        delete_config_group_mock.assert_called_once_with("demo-region", "demo-team", 42)
+        delete_share_mock.assert_called_once_with("demo-team", 42)
+        delete_app_mock.assert_called_once_with(tenant, "demo-region", app)
+
+
 class GroupServiceAppStatusAggregationTests(TestCase):
     # capability_id: console.app-status.aggregate-rainbond-components
     def test_get_app_status_uses_component_aggregation_for_rainbond_apps(self):

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -5784,7 +5784,7 @@ class MCPQueryServiceDeleteAppTests(SimpleTestCase):
             creater=1002,
         )
 
-    @patch("console.services.mcp_query_service.group_service.delete_app")
+    @patch("console.services.mcp_query_service.group_service.delete_app_with_resources")
     @patch("console.services.mcp_query_service.group_service_relation_repo.count_service_by_app_id")
     @patch("console.services.mcp_query_service.team_repo.get_user_tenant_by_name")
     @patch("console.services.mcp_query_service.enterprise_user_perm_repo.is_admin")
@@ -5830,7 +5830,7 @@ class MCPQueryServiceDeleteAppTests(SimpleTestCase):
 
         self.assertFalse(confirm_result.get("requires_confirmation"))
         self.assertTrue(confirm_result.get("deleted"))
-        mock_delete_app.assert_called_once_with(self.tenant, self.app.region_name, self.app)
+        mock_delete_app.assert_called_once_with(self.user, self.tenant, self.app.region_name, self.app)
 
     @patch("console.services.mcp_query_service.group_service_relation_repo.count_service_by_app_id")
     @patch("console.services.mcp_query_service.team_repo.get_user_tenant_by_name")

--- a/console/views/group.py
+++ b/console/views/group.py
@@ -11,7 +11,6 @@ from console.exception.bcode import ErrQualifiedName
 from console.repositories.app import service_repo
 from console.repositories.group import group_service_relation_repo, group_repo
 from console.repositories.region_app import region_app_repo
-from console.services.app_config_group import app_config_group_service
 from console.services.helm_app import helm_app_service
 from console.services.app_actions import app_manage_service
 from console.services.group_service import group_service
@@ -19,7 +18,6 @@ from console.services.application import application_service
 from console.services.market_app_service import market_app_service
 from console.services.k8s_resource import k8s_resource_service
 from console.services.operation_log import operation_log_service, Operation
-from console.services.kubeblocks_service import kubeblocks_service
 from console.utils.reqparse import parse_item
 from console.utils.validation import is_qualified_name
 from console.views.base import (ApplicationView, RegionTenantHeaderCloudEnterpriseCenterView, RegionTenantHeaderView,
@@ -237,23 +235,7 @@ class TenantGroupHandleView(ApplicationView):
         """
         删除应用及所有资源
         """
-        # delete services
-        services = group_service.batch_delete_app_services(self.user, self.tenant.tenant_id, self.region_name, app_id)
-        # delete kubeblocks cluster
-        service_ids = [service.service_id for service in services]
-        # delete kubeblocks cluster if service is kubeblocks cluster
-        kubeblocks_service.delete_kubeblocks_cluster(service_ids, self.region_name)
-        # delete k8s resource
-        k8s_resources = k8s_resource_service.list_by_app_id(str(app_id))
-        resource_ids = [k8s_resource.ID for k8s_resource in k8s_resources]
-        k8s_resource_service.batch_delete_k8s_resource(self.user.enterprise_id, self.tenant.tenant_name, str(app_id),
-                                                       self.region_name, resource_ids)
-        # delete configs
-        app_config_group_service.batch_delete_config_group(self.region_name, self.tenant.tenant_name, app_id)
-        # delete records
-        group_service.delete_app_share_records(self.tenant.tenant_name, app_id)
-        # delete app
-        group_service.delete_app(self.tenant, self.region_name, self.app)
+        services = group_service.delete_app_with_resources(self.user, self.tenant, self.region_name, self.app)
         component_names = []
         comment = ""
         old_information = list()

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -8807,6 +8807,24 @@
       ],
       "test_type": "unit",
       "status": "active"
+    },
+    {
+      "id": "console.app.delete-with-resources",
+      "title": "Delete application along with components and attached resources",
+      "title_zh": "\u5220\u9664\u5e94\u7528\u53ca\u5176\u7ec4\u4ef6\u4e0e\u5173\u8054\u8d44\u6e90",
+      "interface_type": "service_method",
+      "interface": "console.services.group_service.GroupService.delete_app_with_resources",
+      "code_paths": [
+        "console/services/group_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/group_service_test.py",
+          "selector": "GroupServiceDeleteAppWithResourcesTestCase"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The MCP `rainbond_delete_app` tool only called `group_service.delete_app`, which (for non-helm apps) just removes the application record on the console side and the region app metadata. Components under the app and their underlying Kubernetes resources (Deployments/Pods/PVCs, KubeBlocks clusters, custom k8s resources, config groups) were left orphaned.

The console UI endpoint `DELETE /console/teams/{team}/groups/{id}/handle` (`TenantGroupHandleView.delete`) performed the full cleanup sequence, so the two paths diverged.

## Fix

- Extract the full deletion sequence into `group_service.delete_app_with_resources(user, tenant, region_name, app)`: batch stop & delete components → delete KubeBlocks clusters → delete app-scoped k8s resources → delete config groups → delete share records → delete app.
- Reuse it from both `TenantGroupHandleView.delete` and the MCP `delete_app` tool, so the two paths cannot drift again. View behavior (operation log on deleted components) is unchanged.

## Test plan

- New unit test `GroupServiceDeleteAppWithResourcesTestCase` asserting each cleanup step and its arguments.
- Updated MCP `rainbond_delete_app` tests to assert the new call.
- Full pytest suite passes (`scripts/run_pytest.py . -- -q`), `make test-manifest-check` passes (new capability `console.app.delete-with-resources` added to the manifest).