### PR TITLE
fix: make MCP-provided start command effective for image components

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -8,7 +8,7 @@ import re
 from django.core import signing
 from django.core.exceptions import ObjectDoesNotExist
 
-from console.constants import PluginCategoryConstants
+from console.constants import AppConstants, PluginCategoryConstants
 from console.models.main import PluginShareRecordEvent, ServiceShareRecordEvent
 from console.exception.exceptions import ExterpriseNotExistError, TenantNotExistError
 from console.exception.main import ServiceHandleException
@@ -1154,6 +1154,11 @@ class MCPQueryService(object):
     def _get_component_build_source_snapshot(self, team, app, service):
         build_infos = base_service.get_build_infos(team, [service.service_id])
         bean = dict(build_infos.get(service.service_id) or {})
+        # Hide the legacy docker_cmd column from agents: the effective start
+        # command for image components is `cmd` (what deploy sends to the
+        # builder). Exposing both led agents to treat an empty docker_cmd as
+        # "the command was not applied" and recreate healthy components.
+        bean.pop("docker_cmd", None)
         username = bean.pop("user", bean.pop("user_name", "")) or ""
         has_password = bool(bean.pop("password", ""))
         bean["username"] = username
@@ -1275,7 +1280,18 @@ class MCPQueryService(object):
                 service.version = version
             if "cmd" in arguments:
                 service.cmd = arguments.get("cmd", "") or ""
-            elif target_source != getattr(service, "service_source", ""):
+                # Keep the legacy docker_cmd column aligned so build-source
+                # snapshots don't show a stale/empty docker_cmd next to the
+                # effective cmd — agents misread that as "the command was
+                # not applied" and delete/recreate the component.
+                service.docker_cmd = service.cmd
+            elif getattr(service, "service_source", "") == AppConstants.SOURCE_CODE:
+                # Only wipe cmd when actually converting away from source
+                # code. The stored value for image components is always
+                # "docker_image" while callers pass "docker_run", so the
+                # previous `target_source != service.service_source` check
+                # silently erased the start command on every cmd-less
+                # image-side update.
                 service.cmd = ""
             if "server_type" in arguments:
                 service.server_type = arguments.get("server_type", "") or ""
@@ -1319,6 +1335,16 @@ class MCPQueryService(object):
         )
         if code != 200:
             raise ServiceHandleException(msg="service create fail", msg_show=msg_show, status_code=code)
+
+        if docker_cmd:
+            # create_docker_run_app only stores docker_cmd, which in the UI
+            # flow is parsed into service.cmd by the docker-run check stage.
+            # The MCP path deploys without that check, and both
+            # create_region_service (container_cmd) and deploy
+            # (image_info.cmd) read service.cmd — without this copy the
+            # start command the agent provided never reaches the container.
+            new_service.cmd = docker_cmd
+            new_service.save()
 
         if docker_password or docker_user_name:
             console_app_service.create_service_source_info(team, new_service, docker_user_name, docker_password)

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -2867,6 +2867,55 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
     @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
     @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.console_app_service.create_docker_run_app")
+    @patch("console.services.mcp_query_service.group_service.add_service_to_group")
+    @patch("console.services.mcp_query_service.console_app_service.create_region_service")
+    @patch("console.services.mcp_query_service.app_manage_service.deploy")
+    # capability_id: console.component.create-from-image
+    def test_create_component_copies_docker_cmd_into_cmd(
+            self,
+            mock_deploy,
+            mock_create_region_service,
+            mock_add_service_to_group,
+            mock_create_docker_run_app,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        # create_docker_run_app only persists docker_cmd; the MCP path skips
+        # the docker-run check stage that would parse it into service.cmd,
+        # while deploy only sends service.cmd to the builder. The handler
+        # must copy it over or the start command never reaches the container.
+        self.service.cmd = ""
+        self.service.docker_cmd = "bundle exec rails server -p 3000"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_create_docker_run_app.return_value = (200, "success", self.service)
+        mock_add_service_to_group.return_value = (200, "success")
+        mock_create_region_service.return_value = self.service
+        mock_deploy.return_value = (200, "success", "evt-1")
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_component",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_id": 12,
+                "service_cname": "component-1",
+                "image": "chatwoot/chatwoot:latest",
+                "docker_cmd": "bundle exec rails server -p 3000",
+                "is_deploy": True,
+            },
+        )
+
+        self.assertEqual(result["service_id"], "svc-1")
+        self.assertEqual(self.service.cmd, "bundle exec rails server -p 3000")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
     @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
     @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
     @patch("console.services.mcp_query_service.app_manage_service.delete")
@@ -3031,6 +3080,7 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
                 "build_strategy": "cnb",
                 "user": "git-user",
                 "password": "secret-token",
+                "docker_cmd": "",
             }
         }
         mock_get_arch.return_value = (None, {"list": ["amd64", "arm64", "amd64"]})
@@ -3051,6 +3101,7 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
         self.assertEqual(result["build_source"]["username"], "git-user")
         self.assertTrue(result["build_source"]["has_password"])
         self.assertNotIn("password", result["build_source"])
+        self.assertNotIn("docker_cmd", result["build_source"])
         self.assertEqual(sorted(result["build_source"]["arch_options"]), ["amd64", "arm64"])
 
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
@@ -3116,6 +3167,107 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
         self.assertEqual(source_record.user_name, "git-user")
         self.assertEqual(source_record.password, "git-pass")
         mock_update_affinity.assert_called_once_with("arm64", self.team, "rainbond", self.service)
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
+    @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
+    @patch.object(mcp_query_service, "_get_component_build_source_snapshot")
+    @patch("console.services.mcp_query_service.service_source_repo.get_service_source")
+    @patch("console.services.mcp_query_service.arch_service.update_affinity_by_arch")
+    # capability_id: console.component.build-source-update-image-cmd
+    def test_update_component_build_source_keeps_cmd_when_omitted_on_image_update(
+            self,
+            mock_update_affinity,
+            mock_get_service_source,
+            mock_snapshot,
+            mock_relations,
+            mock_get_service,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        # An image component already carrying a start command: an image-only
+        # update (no `cmd` argument) must not silently wipe it. The stored
+        # service_source is "docker_image" while callers pass "docker_run",
+        # so the old inequality check erased cmd on every such call.
+        self.service.service_source = "docker_image"
+        self.service.cmd = "bundle exec rails server -p 3000"
+        self.service.arch = "amd64"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_get_service.return_value = self.service
+        mock_relations.return_value = [Obj(service_id="svc-1")]
+        mock_get_service_source.return_value = None
+        mock_snapshot.return_value = {"service_source": "docker_image"}
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_update_component_build_source",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_id": 12,
+                "service_id": "svc-1",
+                "service_source": "docker_run",
+                "image": "chatwoot/chatwoot:v3.0",
+            },
+        )
+
+        self.assertTrue(result["updated"])
+        self.assertEqual(self.service.image, "chatwoot/chatwoot:v3.0")
+        self.assertEqual(self.service.cmd, "bundle exec rails server -p 3000")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
+    @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
+    @patch.object(mcp_query_service, "_get_component_build_source_snapshot")
+    @patch("console.services.mcp_query_service.service_source_repo.get_service_source")
+    @patch("console.services.mcp_query_service.arch_service.update_affinity_by_arch")
+    # capability_id: console.component.build-source-update-image-cmd
+    def test_update_component_build_source_sets_cmd_and_syncs_docker_cmd(
+            self,
+            mock_update_affinity,
+            mock_get_service_source,
+            mock_snapshot,
+            mock_relations,
+            mock_get_service,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        self.service.service_source = "docker_image"
+        self.service.cmd = ""
+        self.service.docker_cmd = ""
+        self.service.arch = "amd64"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_get_service.return_value = self.service
+        mock_relations.return_value = [Obj(service_id="svc-1")]
+        mock_get_service_source.return_value = None
+        mock_snapshot.return_value = {"service_source": "docker_image"}
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_update_component_build_source",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_id": 12,
+                "service_id": "svc-1",
+                "service_source": "docker_run",
+                "cmd": "bundle exec sidekiq -C config/sidekiq.yml",
+            },
+        )
+
+        self.assertTrue(result["updated"])
+        self.assertEqual(self.service.cmd, "bundle exec sidekiq -C config/sidekiq.yml")
+        self.assertEqual(self.service.docker_cmd, "bundle exec sidekiq -C config/sidekiq.yml")
 
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
     @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")

--- a/scripts/manage_test_manifest.py
+++ b/scripts/manage_test_manifest.py
@@ -13,7 +13,7 @@ def load_manifest(path):
 
 def save_manifest(path, manifest):
     with path.open("w", encoding="utf-8") as handle:
-        json.dump(manifest, handle, indent=2, ensure_ascii=True)
+        json.dump(manifest, handle, indent=2, ensure_ascii=False)
         handle.write("\n")
 
 
@@ -23,7 +23,7 @@ def update_manifest(path, update_fn):
         manifest = json.load(handle)
         result = update_fn(manifest)
         handle.seek(0)
-        json.dump(manifest, handle, indent=2, ensure_ascii=True)
+        json.dump(manifest, handle, indent=2, ensure_ascii=False)
         handle.write("\n")
         handle.truncate()
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
@@ -132,7 +132,7 @@ def cmd_show(args):
     if capability is None:
         print("capability not found: {0}".format(args.capability_id), file=sys.stderr)
         return 1
-    print(json.dumps(capability, indent=2, ensure_ascii=True))
+    print(json.dumps(capability, indent=2, ensure_ascii=False))
     return 0
 
 

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5,7 +5,7 @@
     {
       "id": "console.app-backup.create",
       "title": "Create application backup",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u5907\u4efd",
+      "title_zh": "创建应用备份",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -24,7 +24,7 @@
     {
       "id": "console.app-backup.custom-volume-guard",
       "title": "Reject backup when app uses custom volume",
-      "title_zh": "\u7ec4\u4ef6\u4f7f\u7528\u81ea\u5b9a\u4e49\u5b58\u50a8\u65f6\u963b\u6b62\u5907\u4efd",
+      "title_zh": "组件使用自定义存储时阻止备份",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -42,7 +42,7 @@
     {
       "id": "console.app-backup.delete",
       "title": "Delete application backup",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u5907\u4efd",
+      "title_zh": "删除应用备份",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete",
       "code_paths": [
@@ -61,7 +61,7 @@
     {
       "id": "console.app-backup.delete-id-required",
       "title": "Require backup id before deleting app backup",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u5907\u4efd ID",
+      "title_zh": "删除应用备份前必须提供备份 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete",
       "code_paths": [
@@ -79,7 +79,7 @@
     {
       "id": "console.app-backup.delete-status-lookup-failure",
       "title": "Return error when backup status lookup fails during deletion",
-      "title_zh": "\u5220\u9664\u5907\u4efd\u65f6\u72b6\u6001\u67e5\u8be2\u5931\u8d25\u8fd4\u56de\u9519\u8bef",
+      "title_zh": "删除备份时状态查询失败返回错误",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete",
       "code_paths": [
@@ -97,7 +97,7 @@
     {
       "id": "console.app-backup.export",
       "title": "Export application backup",
-      "title_zh": "\u5bfc\u51fa\u5e94\u7528\u5907\u4efd",
+      "title_zh": "导出应用备份",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -116,7 +116,7 @@
     {
       "id": "console.app-backup.export-failure",
       "title": "Return error when exporting app backup fails",
-      "title_zh": "\u5e94\u7528\u5907\u4efd\u5bfc\u51fa\u5931\u8d25\u65f6\u8fd4\u56de\u9519\u8bef",
+      "title_zh": "应用备份导出失败时返回错误",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -134,7 +134,7 @@
     {
       "id": "console.app-backup.export-group-missing",
       "title": "Reject backup export when app group does not exist",
-      "title_zh": "\u5bfc\u51fa\u5907\u4efd\u65f6\u62e6\u622a\u4e0d\u5b58\u5728\u7684\u5e94\u7528\u7ec4",
+      "title_zh": "导出备份时拦截不存在的应用组",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -152,7 +152,7 @@
     {
       "id": "console.app-backup.export-group-required",
       "title": "Require group id before exporting app backup",
-      "title_zh": "\u5bfc\u51fa\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u7ec4 ID",
+      "title_zh": "导出应用备份前必须提供组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -170,7 +170,7 @@
     {
       "id": "console.app-backup.export-id-required",
       "title": "Require backup id before exporting backup",
-      "title_zh": "\u5bfc\u51fa\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u5907\u4efd ID",
+      "title_zh": "导出备份前必须提供备份 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -188,7 +188,7 @@
     {
       "id": "console.app-backup.export-team-missing",
       "title": "Reject backup export when team does not exist",
-      "title_zh": "\u5bfc\u51fa\u5907\u4efd\u65f6\u62e6\u622a\u4e0d\u5b58\u5728\u7684\u56e2\u961f",
+      "title_zh": "导出备份时拦截不存在的团队",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -206,7 +206,7 @@
     {
       "id": "console.app-backup.export-teamname-required",
       "title": "Require team name before exporting app backup",
-      "title_zh": "\u5bfc\u51fa\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u56e2\u961f\u540d",
+      "title_zh": "导出应用备份前必须提供团队名",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get",
       "code_paths": [
@@ -224,7 +224,7 @@
     {
       "id": "console.app-backup.force-bypass-guards",
       "title": "Allow forced backup to bypass pre-check guards",
-      "title_zh": "\u5f3a\u5236\u5907\u4efd\u65f6\u8df3\u8fc7\u524d\u7f6e\u6821\u9a8c",
+      "title_zh": "强制备份时跳过前置校验",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -242,7 +242,7 @@
     {
       "id": "console.app-backup.group-required",
       "title": "Require app group id before creating backup",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u7ec4 ID",
+      "title_zh": "创建应用备份前必须提供组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -260,7 +260,7 @@
     {
       "id": "console.app-backup.import",
       "title": "Import application backup",
-      "title_zh": "\u5bfc\u5165\u5e94\u7528\u5907\u4efd",
+      "title_zh": "导入应用备份",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupImportView.post",
       "code_paths": [
@@ -279,7 +279,7 @@
     {
       "id": "console.app-backup.import-failure",
       "title": "Return error when importing app backup fails",
-      "title_zh": "\u5e94\u7528\u5907\u4efd\u5bfc\u5165\u5931\u8d25\u65f6\u8fd4\u56de\u9519\u8bef",
+      "title_zh": "应用备份导入失败时返回错误",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupImportView.post",
       "code_paths": [
@@ -297,7 +297,7 @@
     {
       "id": "console.app-backup.import-file-required",
       "title": "Require backup file before importing backup",
-      "title_zh": "\u5bfc\u5165\u5907\u4efd\u524d\u5fc5\u987b\u4e0a\u4f20\u5907\u4efd\u6587\u4ef6",
+      "title_zh": "导入备份前必须上传备份文件",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupImportView.post",
       "code_paths": [
@@ -315,7 +315,7 @@
     {
       "id": "console.app-backup.import-file-size-guard",
       "title": "Reject oversized backup import file",
-      "title_zh": "\u62e6\u622a\u8d85\u5927\u5907\u4efd\u5bfc\u5165\u6587\u4ef6",
+      "title_zh": "拦截超大备份导入文件",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupImportView.post",
       "code_paths": [
@@ -333,7 +333,7 @@
     {
       "id": "console.app-backup.import-group-required",
       "title": "Require group id before importing app backup",
-      "title_zh": "\u5bfc\u5165\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u63d0\u4f9b\u7ec4 ID",
+      "title_zh": "导入应用备份前必须提供组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupImportView.post",
       "code_paths": [
@@ -351,7 +351,7 @@
     {
       "id": "console.app-backup.list-all",
       "title": "List all backups for team",
-      "title_zh": "\u67e5\u8be2\u56e2\u961f\u5168\u90e8\u5907\u4efd\u5217\u8868",
+      "title_zh": "查询团队全部备份列表",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.AllTeamGroupAppsBackupView.get",
       "code_paths": [
@@ -370,7 +370,7 @@
     {
       "id": "console.app-backup.list-by-app",
       "title": "List backups for one application",
-      "title_zh": "\u67e5\u8be2\u5355\u4e2a\u5e94\u7528\u5907\u4efd\u5217\u8868",
+      "title_zh": "查询单个应用备份列表",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.TeamGroupAppsBackupView.get",
       "code_paths": [
@@ -389,7 +389,7 @@
     {
       "id": "console.app-backup.list-by-app-group-required",
       "title": "Require group id when listing app backups",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5907\u4efd\u5217\u8868\u65f6\u5fc5\u987b\u63d0\u4f9b\u7ec4 ID",
+      "title_zh": "查询应用备份列表时必须提供组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.TeamGroupAppsBackupView.get",
       "code_paths": [
@@ -407,7 +407,7 @@
     {
       "id": "console.app-backup.list-status",
       "title": "List application backup statuses",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5907\u4efd\u72b6\u6001\u5217\u8868",
+      "title_zh": "查询应用备份状态列表",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get",
       "code_paths": [
@@ -426,7 +426,7 @@
     {
       "id": "console.app-backup.list-status-empty",
       "title": "Return success when backup status list is not found",
-      "title_zh": "\u5907\u4efd\u72b6\u6001\u5217\u8868\u4e0d\u5b58\u5728\u65f6\u8fd4\u56de\u6210\u529f\u7a7a\u7ed3\u679c",
+      "title_zh": "备份状态列表不存在时返回成功空结果",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get",
       "code_paths": [
@@ -444,7 +444,7 @@
     {
       "id": "console.app-backup.list-status-failure",
       "title": "Return error when backup status list query fails",
-      "title_zh": "\u5907\u4efd\u72b6\u6001\u5217\u8868\u67e5\u8be2\u5931\u8d25\u65f6\u8fd4\u56de\u9519\u8bef",
+      "title_zh": "备份状态列表查询失败时返回错误",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get",
       "code_paths": [
@@ -462,7 +462,7 @@
     {
       "id": "console.app-backup.list-status-group-required",
       "title": "Require group id when querying backup status list",
-      "title_zh": "\u67e5\u8be2\u5907\u4efd\u72b6\u6001\u5217\u8868\u65f6\u5fc5\u987b\u63d0\u4f9b\u7ec4 ID",
+      "title_zh": "查询备份状态列表时必须提供组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get",
       "code_paths": [
@@ -480,7 +480,7 @@
     {
       "id": "console.app-backup.mode-required",
       "title": "Require backup mode before creating app backup",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u9009\u62e9\u6a21\u5f0f",
+      "title_zh": "创建应用备份前必须选择模式",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -498,7 +498,7 @@
     {
       "id": "console.app-backup.note-required",
       "title": "Require backup note before creating app backup",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u5907\u4efd\u524d\u5fc5\u987b\u586b\u5199\u8bf4\u660e",
+      "title_zh": "创建应用备份前必须填写说明",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -516,7 +516,7 @@
     {
       "id": "console.app-backup.object-storage-unconfigured",
       "title": "Mark backup listing when object storage is unconfigured",
-      "title_zh": "\u5bf9\u8c61\u5b58\u50a8\u672a\u914d\u7f6e\u65f6\u6807\u8bb0\u5907\u4efd\u5217\u8868\u72b6\u6001",
+      "title_zh": "对象存储未配置时标记备份列表状态",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.TeamGroupAppsBackupView.get",
       "code_paths": [
@@ -534,7 +534,7 @@
     {
       "id": "console.app-backup.query-status",
       "title": "Query application backup status",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5907\u4efd\u72b6\u6001",
+      "title_zh": "查询应用备份状态",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.get",
       "code_paths": [
@@ -553,7 +553,7 @@
     {
       "id": "console.app-backup.query-status-failure",
       "title": "Return error when querying single backup status fails",
-      "title_zh": "\u67e5\u8be2\u5355\u4e2a\u5907\u4efd\u72b6\u6001\u5931\u8d25\u65f6\u8fd4\u56de\u9519\u8bef",
+      "title_zh": "查询单个备份状态失败时返回错误",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.get",
       "code_paths": [
@@ -571,7 +571,7 @@
     {
       "id": "console.app-backup.query-status-guard",
       "title": "Require backup id when querying backup status",
-      "title_zh": "\u67e5\u8be2\u5907\u4efd\u72b6\u6001\u65f6\u5fc5\u987b\u63d0\u4f9b\u5907\u4efd ID",
+      "title_zh": "查询备份状态时必须提供备份 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.get",
       "code_paths": [
@@ -589,7 +589,7 @@
     {
       "id": "console.app-backup.region-app-scope",
       "title": "Scope backup services to the current region app",
-      "title_zh": "\u6309\u5f53\u524d region \u5e94\u7528\u8303\u56f4\u9650\u5236\u5907\u4efd\u7ec4\u4ef6",
+      "title_zh": "按当前 region 应用范围限制备份组件",
       "interface_type": "service_method",
       "interface": "console.services.backup_service.GroupAppBackupService._get_effective_group_services",
       "code_paths": [
@@ -607,7 +607,7 @@
     {
       "id": "console.app-backup.state-service-guard",
       "title": "Reject backup while stateful services are still running",
-      "title_zh": "\u6709\u72b6\u6001\u7ec4\u4ef6\u672a\u5173\u95ed\u65f6\u963b\u6b62\u5907\u4efd",
+      "title_zh": "有状态组件未关闭时阻止备份",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupView.post",
       "code_paths": [
@@ -625,7 +625,7 @@
     {
       "id": "console.app-backup.status-sanitize",
       "title": "Hide internal backup server info in backup status list",
-      "title_zh": "\u9690\u85cf\u5907\u4efd\u72b6\u6001\u4e2d\u7684\u5185\u90e8\u670d\u52a1\u7aef\u4fe1\u606f",
+      "title_zh": "隐藏备份状态中的内部服务端信息",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get",
       "code_paths": [
@@ -643,7 +643,7 @@
     {
       "id": "console.app-config-group.create",
       "title": "Create app config group",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u914d\u7f6e\u7ec4",
+      "title_zh": "创建应用配置组",
       "interface_type": "workflow",
       "interface": "console.services.app_config_group.AppConfigGroupService.create_config_group",
       "code_paths": [
@@ -662,7 +662,7 @@
     {
       "id": "console.app-config-group.delete",
       "title": "Delete app config group",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u914d\u7f6e\u7ec4",
+      "title_zh": "删除应用配置组",
       "interface_type": "workflow",
       "interface": "console.services.app_config_group.AppConfigGroupService.delete_config_group",
       "code_paths": [
@@ -681,7 +681,7 @@
     {
       "id": "console.app-config-group.get",
       "title": "Get app config group detail",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u914d\u7f6e\u7ec4\u8be6\u60c5",
+      "title_zh": "查看应用配置组详情",
       "interface_type": "workflow",
       "interface": "console.services.app_config_group.AppConfigGroupService.get_config_group",
       "code_paths": [
@@ -700,7 +700,7 @@
     {
       "id": "console.app-config-group.list",
       "title": "List app config groups",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u914d\u7f6e\u7ec4\u5217\u8868",
+      "title_zh": "查询应用配置组列表",
       "interface_type": "workflow",
       "interface": "console.services.app_config_group.AppConfigGroupService.list_config_groups",
       "code_paths": [
@@ -719,7 +719,7 @@
     {
       "id": "console.app-config-group.update",
       "title": "Update app config group",
-      "title_zh": "\u66f4\u65b0\u5e94\u7528\u914d\u7f6e\u7ec4",
+      "title_zh": "更新应用配置组",
       "interface_type": "workflow",
       "interface": "console.services.app_config_group.AppConfigGroupService.update_config_group",
       "code_paths": [
@@ -738,7 +738,7 @@
     {
       "id": "console.app-export.query-status",
       "title": "Query application export status",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5bfc\u51fa\u72b6\u6001",
+      "title_zh": "查询应用导出状态",
       "interface_type": "workflow",
       "interface": "console.services.app_import_and_export_service.AppExportService.get_export_status",
       "code_paths": [
@@ -756,7 +756,7 @@
     {
       "id": "console.app-import.abandon",
       "title": "Abandon application import",
-      "title_zh": "\u653e\u5f03\u5e94\u7528\u5bfc\u5165",
+      "title_zh": "放弃应用导入",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppImportView.delete",
       "code_paths": [
@@ -775,7 +775,7 @@
     {
       "id": "console.app-import.create-dir",
       "title": "Create import directory",
-      "title_zh": "\u521b\u5efa\u5bfc\u5165\u76ee\u5f55",
+      "title_zh": "创建导入目录",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppTarballDirView.post",
       "code_paths": [
@@ -794,7 +794,7 @@
     {
       "id": "console.app-import.delete-dir",
       "title": "Delete import directory",
-      "title_zh": "\u5220\u9664\u5bfc\u5165\u76ee\u5f55",
+      "title_zh": "删除导入目录",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppTarballDirView.delete",
       "code_paths": [
@@ -813,7 +813,7 @@
     {
       "id": "console.app-import.init",
       "title": "Initialize application import",
-      "title_zh": "\u521d\u59cb\u5316\u5e94\u7528\u5bfc\u5165",
+      "title_zh": "初始化应用导入",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.EnterpriseAppImportInitView.post",
       "code_paths": [
@@ -832,7 +832,7 @@
     {
       "id": "console.app-import.list-dir",
       "title": "List imported application packages",
-      "title_zh": "\u67e5\u8be2\u5bfc\u5165\u76ee\u5f55\u4e2d\u7684\u5e94\u7528\u5305",
+      "title_zh": "查询导入目录中的应用包",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppTarballDirView.get",
       "code_paths": [
@@ -851,7 +851,7 @@
     {
       "id": "console.app-import.query-status",
       "title": "Query application import status",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5bfc\u5165\u72b6\u6001",
+      "title_zh": "查询应用导入状态",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppImportView.get",
       "code_paths": [
@@ -870,7 +870,7 @@
     {
       "id": "console.app-import.start",
       "title": "Start application import",
-      "title_zh": "\u5f00\u59cb\u5e94\u7528\u5bfc\u5165",
+      "title_zh": "开始应用导入",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.app_import.CenterAppImportView.post",
       "code_paths": [
@@ -889,7 +889,7 @@
     {
       "id": "console.app-migration.cleanup-group-missing",
       "title": "Reject cleanup when original backup group is missing",
-      "title_zh": "\u6e05\u7406\u65e7\u5e94\u7528\u65f6\u62e6\u622a\u5df2\u5220\u9664\u7684\u539f\u7ec4",
+      "title_zh": "清理旧应用时拦截已删除的原组",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -907,7 +907,7 @@
     {
       "id": "console.app-migration.cleanup-group-required",
       "title": "Require original group id before cleanup",
-      "title_zh": "\u6e05\u7406\u65e7\u5e94\u7528\u524d\u5fc5\u987b\u63d0\u4f9b\u539f\u7ec4 ID",
+      "title_zh": "清理旧应用前必须提供原组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -925,7 +925,7 @@
     {
       "id": "console.app-migration.cleanup-new-group-required",
       "title": "Require restored group id before cleanup",
-      "title_zh": "\u6e05\u7406\u65e7\u5e94\u7528\u524d\u5fc5\u987b\u63d0\u4f9b\u6062\u590d\u540e\u7684\u7ec4 ID",
+      "title_zh": "清理旧应用前必须提供恢复后的组 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -943,7 +943,7 @@
     {
       "id": "console.app-migration.cleanup-old-app",
       "title": "Cleanup old application data after restore",
-      "title_zh": "\u6062\u590d\u540e\u6e05\u7406\u65e7\u5e94\u7528\u6570\u636e",
+      "title_zh": "恢复后清理旧应用数据",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -962,7 +962,7 @@
     {
       "id": "console.app-migration.cleanup-same-group-noop",
       "title": "Skip cleanup when restored to the same group",
-      "title_zh": "\u6062\u590d\u5230\u5f53\u524d\u7ec4\u65f6\u8df3\u8fc7\u6e05\u7406",
+      "title_zh": "恢复到当前组时跳过清理",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -980,7 +980,7 @@
     {
       "id": "console.app-migration.cleanup-target-group-missing",
       "title": "Reject cleanup when restored group is missing",
-      "title_zh": "\u6e05\u7406\u65e7\u5e94\u7528\u65f6\u62e6\u622a\u4e0d\u5b58\u5728\u7684\u65b0\u7ec4",
+      "title_zh": "清理旧应用时拦截不存在的新组",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsView.delete",
       "code_paths": [
@@ -998,7 +998,7 @@
     {
       "id": "console.app-migration.query-status",
       "title": "Query application migration status",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u8fc1\u79fb\u72b6\u6001",
+      "title_zh": "查询应用迁移状态",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.get",
       "code_paths": [
@@ -1017,7 +1017,7 @@
     {
       "id": "console.app-migration.record-missing",
       "title": "Return not found when migration record is missing",
-      "title_zh": "\u8fc1\u79fb\u8bb0\u5f55\u4e0d\u5b58\u5728\u65f6\u8fd4\u56de\u672a\u627e\u5230",
+      "title_zh": "迁移记录不存在时返回未找到",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.get",
       "code_paths": [
@@ -1035,7 +1035,7 @@
     {
       "id": "console.app-migration.restore-id-required",
       "title": "Require restore id when querying migration status",
-      "title_zh": "\u67e5\u8be2\u8fc1\u79fb\u72b6\u6001\u65f6\u5fc5\u987b\u63d0\u4f9b\u6062\u590d ID",
+      "title_zh": "查询迁移状态时必须提供恢复 ID",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.get",
       "code_paths": [
@@ -1053,7 +1053,7 @@
     {
       "id": "console.app-migration.start",
       "title": "Start application migration",
-      "title_zh": "\u542f\u52a8\u5e94\u7528\u8fc1\u79fb",
+      "title_zh": "启动应用迁移",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.post",
       "code_paths": [
@@ -1072,7 +1072,7 @@
     {
       "id": "console.app-migration.target-region-guard",
       "title": "Reject migration target region without team access",
-      "title_zh": "\u62e6\u622a\u56e2\u961f\u65e0\u6743\u9650\u7684\u8fc1\u79fb\u76ee\u6807\u96c6\u7fa4",
+      "title_zh": "拦截团队无权限的迁移目标集群",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.post",
       "code_paths": [
@@ -1090,7 +1090,7 @@
     {
       "id": "console.app-migration.target-team-missing",
       "title": "Reject missing migration target team",
-      "title_zh": "\u62e6\u622a\u4e0d\u5b58\u5728\u7684\u8fc1\u79fb\u76ee\u6807\u56e2\u961f",
+      "title_zh": "拦截不存在的迁移目标团队",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.post",
       "code_paths": [
@@ -1108,7 +1108,7 @@
     {
       "id": "console.app-migration.team-required",
       "title": "Require target team before starting app migration",
-      "title_zh": "\u542f\u52a8\u5e94\u7528\u8fc1\u79fb\u524d\u5fc5\u987b\u6307\u5b9a\u76ee\u6807\u56e2\u961f",
+      "title_zh": "启动应用迁移前必须指定目标团队",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.post",
       "code_paths": [
@@ -1126,7 +1126,7 @@
     {
       "id": "console.app-migration.unfinished-record",
       "title": "Get unfinished application migration record",
-      "title_zh": "\u67e5\u8be2\u672a\u5b8c\u6210\u7684\u5e94\u7528\u8fc1\u79fb\u8bb0\u5f55",
+      "title_zh": "查询未完成的应用迁移记录",
       "interface_type": "workflow",
       "interface": "console.views.center_pool.groupapp_migration.MigrateRecordView.get",
       "code_paths": [
@@ -1145,7 +1145,7 @@
     {
       "id": "console.app-migration.unfinished-record-empty",
       "title": "Return finished state when no unfinished migration record exists",
-      "title_zh": "\u65e0\u672a\u5b8c\u6210\u8fc1\u79fb\u8bb0\u5f55\u65f6\u8fd4\u56de\u5df2\u5b8c\u6210\u72b6\u6001",
+      "title_zh": "无未完成迁移记录时返回已完成状态",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.MigrateRecordView.get",
       "code_paths": [
@@ -1163,7 +1163,7 @@
     {
       "id": "console.app-migration.unfinished-record-guard",
       "title": "Require group uuid when querying unfinished migration record",
-      "title_zh": "\u67e5\u8be2\u672a\u5b8c\u6210\u8fc1\u79fb\u8bb0\u5f55\u65f6\u5fc5\u987b\u63d0\u4f9b group_uuid",
+      "title_zh": "查询未完成迁移记录时必须提供 group_uuid",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.MigrateRecordView.get",
       "code_paths": [
@@ -1181,7 +1181,7 @@
     {
       "id": "console.app-migration.usable-region-guard",
       "title": "Reject migration when target team has no usable regions",
-      "title_zh": "\u76ee\u6807\u56e2\u961f\u65e0\u53ef\u7528\u96c6\u7fa4\u65f6\u963b\u6b62\u8fc1\u79fb",
+      "title_zh": "目标团队无可用集群时阻止迁移",
       "interface_type": "view_endpoint",
       "interface": "console.views.center_pool.groupapp_migration.GroupAppsMigrateView.post",
       "code_paths": [
@@ -1361,7 +1361,7 @@
     {
       "id": "console.app-status.aggregate-rainbond-components",
       "title": "Aggregate Rainbond app status from component statuses",
-      "title_zh": "\u6839\u636e\u7ec4\u4ef6\u72b6\u6001\u805a\u5408 Rainbond \u5e94\u7528\u72b6\u6001",
+      "title_zh": "根据组件状态聚合 Rainbond 应用状态",
       "interface_type": "service_method",
       "interface": "console.services.group_service.GroupService.get_app_status",
       "code_paths": [
@@ -1380,7 +1380,7 @@
     {
       "id": "console.app-status.closed-with-undeploy-components",
       "title": "Treat closed and undeployed components as a closed app",
-      "title_zh": "\u5c06\u5173\u95ed\u4e0e\u672a\u90e8\u7f72\u7ec4\u4ef6\u7ec4\u5408\u8bc6\u522b\u4e3a\u5e94\u7528\u5df2\u5173\u95ed",
+      "title_zh": "将关闭与未部署组件组合识别为应用已关闭",
       "interface_type": "service_method",
       "interface": "console.services.topological_services.TopologicalService.get_app_status",
       "code_paths": [
@@ -1398,7 +1398,7 @@
     {
       "id": "console.app-status.list-closed-with-undeploy-components",
       "title": "List app status as closed when components are closed or undeployed",
-      "title_zh": "\u5f53\u7ec4\u4ef6\u4e3a\u5173\u95ed\u6216\u672a\u90e8\u7f72\u65f6\u5c06\u5217\u8868\u5e94\u7528\u72b6\u6001\u805a\u5408\u4e3a\u5173\u95ed",
+      "title_zh": "当组件为关闭或未部署时将列表应用状态聚合为关闭",
       "interface_type": "service_method",
       "interface": "console.services.group_service.GroupService._add_component_status_to_apps",
       "code_paths": [
@@ -1417,7 +1417,7 @@
     {
       "id": "console.app-status.partial-abnormal-mixed-components",
       "title": "Treat mixed running and abnormal components as partially abnormal",
-      "title_zh": "\u5c06\u8fd0\u884c\u4e2d\u4e0e\u5f02\u5e38\u6df7\u5408\u7ec4\u4ef6\u8bc6\u522b\u4e3a\u90e8\u5206\u5f02\u5e38",
+      "title_zh": "将运行中与异常混合组件识别为部分异常",
       "interface_type": "service_method",
       "interface": "console.services.topological_services.TopologicalService.get_app_status",
       "code_paths": [
@@ -1435,7 +1435,7 @@
     {
       "id": "console.app-status.partial-abnormal-some-abnormal",
       "title": "Treat some_abnormal components as partially abnormal",
-      "title_zh": "\u5c06 some_abnormal \u7ec4\u4ef6\u8bc6\u522b\u4e3a\u90e8\u5206\u5f02\u5e38",
+      "title_zh": "将 some_abnormal 组件识别为部分异常",
       "interface_type": "service_method",
       "interface": "console.services.topological_services.TopologicalService.get_app_status",
       "code_paths": [
@@ -1489,7 +1489,7 @@
     {
       "id": "console.app-status.waiting-is-starting",
       "title": "Treat waiting components as an app starting state",
-      "title_zh": "\u5c06 waiting \u7ec4\u4ef6\u8bc6\u522b\u4e3a\u5e94\u7528\u542f\u52a8\u4e2d",
+      "title_zh": "将 waiting 组件识别为应用启动中",
       "interface_type": "service_method",
       "interface": "console.services.topological_services.TopologicalService.get_app_status",
       "code_paths": [
@@ -1597,7 +1597,7 @@
     {
       "id": "console.app-upgrade.info",
       "title": "Query application upgrade info",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u5347\u7ea7\u4fe1\u606f",
+      "title_zh": "查询应用升级信息",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_app_upgrade_info]",
       "code_paths": [
@@ -1652,7 +1652,7 @@
     {
       "id": "console.app-upgrade.record-status-summary",
       "title": "App upgrade record status summary",
-      "title_zh": "\u5e94\u7528\u5347\u7ea7\u8bb0\u5f55\u72b6\u6001\u6c47\u603b",
+      "title_zh": "应用升级记录状态汇总",
       "interface_type": "service_method",
       "interface": "console.services.upgrade_services.UpgradeService._update_app_record_status",
       "code_paths": [
@@ -1724,7 +1724,7 @@
     {
       "id": "console.app-version.component-diff-details",
       "title": "Build application version component diff details",
-      "title_zh": "\u751f\u6210\u5e94\u7528\u7248\u672c\u7ec4\u4ef6\u5dee\u5f02\u660e\u7ec6",
+      "title_zh": "生成应用版本组件差异明细",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service._build_component_diff_details",
       "code_paths": [
@@ -1764,7 +1764,7 @@
     {
       "id": "console.app-version.create-snapshot",
       "title": "Create app version snapshot",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "创建应用版本快照",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionSnapshotListView.post",
       "code_paths": [
@@ -1787,7 +1787,7 @@
     {
       "id": "console.app-version.delete-rollback-record",
       "title": "Delete app version rollback record",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u7248\u672c\u56de\u6eda\u8bb0\u5f55",
+      "title_zh": "删除应用版本回滚记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionRollbackRecordDetailView.delete",
       "code_paths": [
@@ -1806,7 +1806,7 @@
     {
       "id": "console.app-version.delete-snapshot",
       "title": "Delete app version snapshot",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "删除应用版本快照",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionSnapshotDetailView.delete",
       "code_paths": [
@@ -1825,7 +1825,7 @@
     {
       "id": "console.app-version.delete-snapshot-endpoint",
       "title": "Delete application version snapshot via endpoint",
-      "title_zh": "\u901a\u8fc7\u63a5\u53e3\u5220\u9664\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "通过接口删除应用版本快照",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionSnapshotDetailView.delete",
       "code_paths": [
@@ -1843,7 +1843,7 @@
     {
       "id": "console.app-version.diff-summary",
       "title": "Summarize application version differences",
-      "title_zh": "\u6c47\u603b\u5e94\u7528\u7248\u672c\u5dee\u5f02",
+      "title_zh": "汇总应用版本差异",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service._summarize_diff",
       "code_paths": [
@@ -1861,7 +1861,7 @@
     {
       "id": "console.app-version.hidden-template-cleanup",
       "title": "Clean hidden template records when deleting version template app",
-      "title_zh": "\u6e05\u7406\u5e94\u7528\u7248\u672c\u9690\u85cf\u6a21\u677f\u8bb0\u5f55",
+      "title_zh": "清理应用版本隐藏模板记录",
       "interface_type": "workflow",
       "interface": "console.services.market_app.market_app_service.delete_rainbond_app_all_info_by_id",
       "code_paths": [
@@ -1879,7 +1879,7 @@
     {
       "id": "console.app-version.hidden-template-create",
       "title": "Create hidden template app for version snapshots",
-      "title_zh": "\u521b\u5efa\u5e94\u7528\u7248\u672c\u9690\u85cf\u6a21\u677f",
+      "title_zh": "创建应用版本隐藏模板",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.get_or_create_hidden_template",
       "code_paths": [
@@ -1897,7 +1897,7 @@
     {
       "id": "console.app-version.overview",
       "title": "View application version overview",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u7248\u672c\u6982\u89c8",
+      "title_zh": "查看应用版本概览",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.get_overview",
       "code_paths": [
@@ -1928,7 +1928,7 @@
     {
       "id": "console.app-version.restore-builds",
       "title": "Generate rollback builds without source metadata",
-      "title_zh": "\u56de\u6eda\u540e\u751f\u6210\u6784\u5efa\u4efb\u52a1",
+      "title_zh": "回滚后生成构建任务",
       "interface_type": "workflow",
       "interface": "console.services.market_app.market_app.MarketApp._generate_builds",
       "code_paths": [
@@ -1946,7 +1946,7 @@
     {
       "id": "console.app-version.restore-component-without-source",
       "title": "Restore component without source metadata",
-      "title_zh": "\u65e0\u6765\u6e90\u4fe1\u606f\u65f6\u6062\u590d\u7ec4\u4ef6",
+      "title_zh": "无来源信息时恢复组件",
       "interface_type": "workflow",
       "interface": "console.services.market_app.app_restore.AppRestore._create_component",
       "code_paths": [
@@ -1964,7 +1964,7 @@
     {
       "id": "console.app-version.restore-k8s-attributes",
       "title": "Restore component k8s attributes during rollback",
-      "title_zh": "\u56de\u6eda\u65f6\u6062\u590d\u7ec4\u4ef6 K8s \u5c5e\u6027",
+      "title_zh": "回滚时恢复组件 K8s 属性",
       "interface_type": "workflow",
       "interface": "console.services.market_app.new_app.NewApp._save_components",
       "code_paths": [
@@ -1982,7 +1982,7 @@
     {
       "id": "console.app-version.restore-legacy-action-type",
       "title": "Keep legacy snapshot action type during rollback restore",
-      "title_zh": "\u517c\u5bb9\u65e7\u5feb\u7167\u4e2d\u7684\u64cd\u4f5c\u7c7b\u578b",
+      "title_zh": "兼容旧快照中的操作类型",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.AppVersionRollbackRestore._create_component",
       "code_paths": [
@@ -2000,7 +2000,7 @@
     {
       "id": "console.app-version.restore-update-service-sources",
       "title": "Restore component source metadata during rollback",
-      "title_zh": "\u56de\u6eda\u65f6\u6062\u590d\u7ec4\u4ef6\u6765\u6e90\u4fe1\u606f",
+      "title_zh": "回滚时恢复组件来源信息",
       "interface_type": "workflow",
       "interface": "console.services.market_app.new_app.NewApp._update_components",
       "code_paths": [
@@ -2018,7 +2018,7 @@
     {
       "id": "console.app-version.rollback-create-new-app",
       "title": "Build rollback target application from snapshot",
-      "title_zh": "\u6839\u636e\u5feb\u7167\u751f\u6210\u56de\u6eda\u76ee\u6807\u5e94\u7528",
+      "title_zh": "根据快照生成回滚目标应用",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.AppVersionRollbackRestore._create_new_app",
       "code_paths": [
@@ -2040,7 +2040,7 @@
     {
       "id": "console.app-version.rollback-plan",
       "title": "Build rollback component plan",
-      "title_zh": "\u751f\u6210\u56de\u6eda\u7ec4\u4ef6\u8ba1\u5212",
+      "title_zh": "生成回滚组件计划",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service._build_rollback_component_plan",
       "code_paths": [
@@ -2058,7 +2058,7 @@
     {
       "id": "console.app-version.rollback-record-detail",
       "title": "Get app version rollback record detail",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u7248\u672c\u56de\u6eda\u8bb0\u5f55\u8be6\u60c5",
+      "title_zh": "查询应用版本回滚记录详情",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionRollbackRecordDetailView.get",
       "code_paths": [
@@ -2077,7 +2077,7 @@
     {
       "id": "console.app-version.rollback-record-finished-delete",
       "title": "Delete finished rollback record",
-      "title_zh": "\u5220\u9664\u5df2\u5b8c\u6210\u7684\u56de\u6eda\u8bb0\u5f55",
+      "title_zh": "删除已完成的回滚记录",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.delete_rollback_record",
       "code_paths": [
@@ -2095,7 +2095,7 @@
     {
       "id": "console.app-version.rollback-record-guard",
       "title": "Prevent deleting unfinished rollback record",
-      "title_zh": "\u963b\u6b62\u5220\u9664\u8fdb\u884c\u4e2d\u7684\u56de\u6eda\u8bb0\u5f55",
+      "title_zh": "阻止删除进行中的回滚记录",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.delete_rollback_record",
       "code_paths": [
@@ -2113,7 +2113,7 @@
     {
       "id": "console.app-version.rollback-record-list",
       "title": "List app version rollback records",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u7248\u672c\u56de\u6eda\u8bb0\u5f55\u5217\u8868",
+      "title_zh": "查询应用版本回滚记录列表",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionRollbackRecordListView.get",
       "code_paths": [
@@ -2132,7 +2132,7 @@
     {
       "id": "console.app-version.rollback-record-query",
       "title": "Query rollback records for application version",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u7248\u672c\u56de\u6eda\u8bb0\u5f55",
+      "title_zh": "查询应用版本回滚记录",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.list_rollback_records",
       "code_paths": [
@@ -2150,7 +2150,7 @@
     {
       "id": "console.app-version.rollback-record-sync",
       "title": "Sync unfinished rollback record before returning detail",
-      "title_zh": "\u67e5\u8be2\u524d\u540c\u6b65\u8fdb\u884c\u4e2d\u7684\u56de\u6eda\u8bb0\u5f55",
+      "title_zh": "查询前同步进行中的回滚记录",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.get_rollback_record",
       "code_paths": [
@@ -2168,7 +2168,7 @@
     {
       "id": "console.app-version.rollback-record-update-ignore-missing",
       "title": "Ignore missing rollback record during status update",
-      "title_zh": "\u56de\u6eda\u8bb0\u5f55\u7f3a\u5931\u65f6\u5ffd\u7565\u72b6\u6001\u66f4\u65b0",
+      "title_zh": "回滚记录缺失时忽略状态更新",
       "interface_type": "workflow",
       "interface": "console.services.market_app.app_restore.AppRestore._update_rollback_record",
       "code_paths": [
@@ -2186,7 +2186,7 @@
     {
       "id": "console.app-version.rollback-restore-components",
       "title": "Restore missing components during app version rollback",
-      "title_zh": "\u5e94\u7528\u7248\u672c\u56de\u6eda\u65f6\u6062\u590d\u7f3a\u5931\u7ec4\u4ef6",
+      "title_zh": "应用版本回滚时恢复缺失组件",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.AppVersionRollbackRestore._create_new_app",
       "code_paths": [
@@ -2223,7 +2223,7 @@
     {
       "id": "console.app-version.rollback-vm-snapshot-guard",
       "title": "Reject VM app version snapshot rollback",
-      "title_zh": "\u7981\u6b62\u56de\u6eda\u865a\u62df\u673a\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "禁止回滚虚拟机应用版本快照",
       "interface_type": "service_method",
       "interface": "console.services.app_version_service.AppVersionService.rollback_snapshot",
       "code_paths": [
@@ -2241,7 +2241,7 @@
     {
       "id": "console.app-version.snapshot-delete-guard",
       "title": "Prevent deleting latest application version snapshot",
-      "title_zh": "\u963b\u6b62\u5220\u9664\u6700\u65b0\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "阻止删除最新应用版本快照",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.delete_snapshot",
       "code_paths": [
@@ -2259,7 +2259,7 @@
     {
       "id": "console.app-version.snapshot-delete-history",
       "title": "Delete historical application version snapshot",
-      "title_zh": "\u5220\u9664\u5386\u53f2\u5e94\u7528\u7248\u672c\u5feb\u7167",
+      "title_zh": "删除历史应用版本快照",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.delete_snapshot",
       "code_paths": [
@@ -2277,7 +2277,7 @@
     {
       "id": "console.app-version.snapshot-detail",
       "title": "View application version snapshot detail",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u7248\u672c\u5feb\u7167\u8be6\u60c5",
+      "title_zh": "查看应用版本快照详情",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service.get_snapshot_detail",
       "code_paths": [
@@ -2296,7 +2296,7 @@
     {
       "id": "console.app-version.snapshot-no-change",
       "title": "Skip creating snapshot when no changes exist",
-      "title_zh": "\u65e0\u53d8\u66f4\u65f6\u8df3\u8fc7\u521b\u5efa\u5feb\u7167",
+      "title_zh": "无变更时跳过创建快照",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_version.AppVersionSnapshotListView.post",
       "code_paths": [
@@ -2351,7 +2351,7 @@
     {
       "id": "console.app-version.view-diff",
       "title": "View app version diff details",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u7248\u672c\u5dee\u5f02\u8be6\u60c5",
+      "title_zh": "查看应用版本差异详情",
       "interface_type": "workflow",
       "interface": "console.services.app_version_service._build_component_diff_details",
       "code_paths": [
@@ -2373,7 +2373,7 @@
     {
       "id": "console.app.batch-component-operation",
       "title": "Batch operate app components",
-      "title_zh": "\u6279\u91cf\u64cd\u4f5c\u5e94\u7528\u7ec4\u4ef6",
+      "title_zh": "批量操作应用组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_operate_app]",
       "code_paths": [
@@ -2392,7 +2392,7 @@
     {
       "id": "console.app.check-yaml",
       "title": "Check app created from YAML",
-      "title_zh": "\u6821\u9a8c YAML \u521b\u5efa\u5e94\u7528",
+      "title_zh": "校验 YAML 创建应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_check_yaml_app]",
       "code_paths": [
@@ -2411,7 +2411,7 @@
     {
       "id": "console.app.close-all",
       "title": "Close all applications in team view",
-      "title_zh": "\u5173\u95ed\u56e2\u961f\u4e0b\u6240\u6709\u7ec4\u4ef6",
+      "title_zh": "关闭团队下所有组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_close_apps]",
       "code_paths": [
@@ -2430,7 +2430,7 @@
     {
       "id": "console.app.copy",
       "title": "Copy application components to target app",
-      "title_zh": "\u590d\u5236\u5e94\u7528\u7ec4\u4ef6\u5230\u76ee\u6807\u5e94\u7528",
+      "title_zh": "复制应用组件到目标应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_copy_app]",
       "code_paths": [
@@ -2448,7 +2448,7 @@
     {
       "id": "console.app.copy-info",
       "title": "Get application copy information",
-      "title_zh": "\u83b7\u53d6\u5e94\u7528\u590d\u5236\u4fe1\u606f",
+      "title_zh": "获取应用复制信息",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_copy_app_info]",
       "code_paths": [
@@ -2467,7 +2467,7 @@
     {
       "id": "console.app.copy-services-guard",
       "title": "Reject application copy when services payload is invalid",
-      "title_zh": "\u5e94\u7528\u590d\u5236\u65f6\u62e6\u622a\u65e0\u6548\u7684 services \u53c2\u6570",
+      "title_zh": "应用复制时拦截无效的 services 参数",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.copy_app",
       "code_paths": [
@@ -2485,7 +2485,7 @@
     {
       "id": "console.app.create",
       "title": "Create application",
-      "title_zh": "\u521b\u5efa\u5e94\u7528",
+      "title_zh": "创建应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_app]",
       "code_paths": [
@@ -2504,7 +2504,7 @@
     {
       "id": "console.app.create-from-yaml",
       "title": "Create application from YAML",
-      "title_zh": "\u4ece YAML \u521b\u5efa\u5e94\u7528",
+      "title_zh": "从 YAML 创建应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_app_from_yaml]",
       "code_paths": [
@@ -2541,7 +2541,7 @@
     {
       "id": "console.app.delete",
       "title": "Delete application and hidden snapshot template",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u53ca\u9690\u85cf\u5feb\u7167\u6a21\u677f",
+      "title_zh": "删除应用及隐藏快照模板",
       "interface_type": "workflow",
       "interface": "console.services.group_service._delete_app",
       "code_paths": [
@@ -2560,7 +2560,7 @@
     {
       "id": "console.app.delete-confirmation-guard",
       "title": "Reject invalid application deletion confirmation token",
-      "title_zh": "\u963b\u6b62\u65e0\u6548\u7684\u5e94\u7528\u5220\u9664\u786e\u8ba4",
+      "title_zh": "阻止无效的应用删除确认",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_app]",
       "code_paths": [
@@ -2578,7 +2578,7 @@
     {
       "id": "console.app.delete-with-confirmation",
       "title": "Delete application with confirmation",
-      "title_zh": "\u786e\u8ba4\u540e\u5220\u9664\u5e94\u7528",
+      "title_zh": "确认后删除应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_app]",
       "code_paths": [
@@ -2597,7 +2597,7 @@
     {
       "id": "console.app.detail",
       "title": "View app detail",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u8be6\u60c5",
+      "title_zh": "查看应用详情",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_app_detail]",
       "code_paths": [
@@ -2615,7 +2615,7 @@
     {
       "id": "console.app.export-metadata",
       "title": "Generate application export metadata",
-      "title_zh": "\u751f\u6210\u5e94\u7528\u5bfc\u51fa\u5143\u6570\u636e",
+      "title_zh": "生成应用导出元数据",
       "interface_type": "workflow",
       "interface": "console.services.app_import_and_export_service.AppExportService._AppExportService__get_app_metata",
       "code_paths": [
@@ -2633,7 +2633,7 @@
     {
       "id": "console.app.get-yaml-check-result",
       "title": "View YAML app check result",
-      "title_zh": "\u67e5\u770b YAML \u5e94\u7528\u6821\u9a8c\u7ed3\u679c",
+      "title_zh": "查看 YAML 应用校验结果",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_yaml_app_check_result]",
       "code_paths": [
@@ -2652,7 +2652,7 @@
     {
       "id": "console.app.install-from-market",
       "title": "Install application from market",
-      "title_zh": "\u4ece\u5e02\u573a\u5b89\u88c5\u5e94\u7528",
+      "title_zh": "从市场安装应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_install_app_by_market]",
       "code_paths": [
@@ -2671,7 +2671,7 @@
     {
       "id": "console.app.list-team-apps",
       "title": "List team applications",
-      "title_zh": "\u67e5\u8be2\u56e2\u961f\u5e94\u7528\u5217\u8868",
+      "title_zh": "查询团队应用列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_team_apps]",
       "code_paths": [
@@ -2690,7 +2690,7 @@
     {
       "id": "console.app.monitor-range",
       "title": "Query application monitor range",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u76d1\u63a7\u533a\u95f4\u6570\u636e",
+      "title_zh": "查询应用监控区间数据",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_app_monitor_range]",
       "code_paths": [
@@ -2708,7 +2708,7 @@
     {
       "id": "console.app.monitor-range-default-step",
       "title": "Default monitor range step to 60 seconds",
-      "title_zh": "\u76d1\u63a7\u533a\u95f4\u67e5\u8be2\u9ed8\u8ba4\u6b65\u957f\u4e3a 60 \u79d2",
+      "title_zh": "监控区间查询默认步长为 60 秒",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.query_app_monitor_range",
       "code_paths": [
@@ -2726,7 +2726,7 @@
     {
       "id": "console.app.monitor-summary",
       "title": "Query application monitor summary",
-      "title_zh": "\u67e5\u8be2\u5e94\u7528\u76d1\u63a7\u6982\u89c8",
+      "title_zh": "查询应用监控概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_app_monitor]",
       "code_paths": [
@@ -2744,7 +2744,7 @@
     {
       "id": "console.app.monitor-summary-outer-only",
       "title": "Filter app monitor summary to services with public ports",
-      "title_zh": "\u5e94\u7528\u76d1\u63a7\u6982\u89c8\u4ec5\u7edf\u8ba1\u5bf9\u5916\u7aef\u53e3\u7ec4\u4ef6",
+      "title_zh": "应用监控概览仅统计对外端口组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.query_app_monitor",
       "code_paths": [
@@ -2762,7 +2762,7 @@
     {
       "id": "console.app.upgrade",
       "title": "Upgrade application from market versions",
-      "title_zh": "\u5347\u7ea7\u5e94\u7528\u7248\u672c",
+      "title_zh": "升级应用版本",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_upgrade_app]",
       "code_paths": [
@@ -2781,7 +2781,7 @@
     {
       "id": "console.cache.capacity-guard",
       "title": "Refuse or reuse cache slots when in-memory cache reaches capacity",
-      "title_zh": "\u5185\u5b58\u7f13\u5b58\u8fbe\u5230\u5bb9\u91cf\u4e0a\u9650\u65f6\u62d2\u7edd\u6216\u590d\u7528\u7f13\u5b58\u69fd\u4f4d",
+      "title_zh": "内存缓存达到容量上限时拒绝或复用缓存槽位",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._memory_set",
       "code_paths": [
@@ -2799,7 +2799,7 @@
     {
       "id": "console.cache.expired-eviction",
       "title": "Evict expired in-memory cache entries on access",
-      "title_zh": "\u5728\u8bbf\u95ee\u65f6\u6e05\u7406\u5df2\u8fc7\u671f\u7684\u5185\u5b58\u7f13\u5b58\u9879",
+      "title_zh": "在访问时清理已过期的内存缓存项",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._memory_get",
       "code_paths": [
@@ -2817,7 +2817,7 @@
     {
       "id": "console.cache.expired-eviction-count",
       "title": "Return the number of expired cache entries removed during cleanup",
-      "title_zh": "\u8fd4\u56de\u6e05\u7406\u8fc7\u671f\u7f13\u5b58\u65f6\u79fb\u9664\u7684\u6761\u76ee\u6570\u91cf",
+      "title_zh": "返回清理过期缓存时移除的条目数量",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._remove_expired_key",
       "code_paths": [
@@ -2835,7 +2835,7 @@
     {
       "id": "console.cache.memory-store-and-expire",
       "title": "Return cached values before expiration in memory mode",
-      "title_zh": "\u5728\u5185\u5b58\u6a21\u5f0f\u4e0b\u4e8e\u8fc7\u671f\u524d\u8fd4\u56de\u7f13\u5b58\u503c",
+      "title_zh": "在内存模式下于过期前返回缓存值",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache.get",
       "code_paths": [
@@ -2853,7 +2853,7 @@
     {
       "id": "console.cache.redis-backend-read-write",
       "title": "Delegate cache reads and writes to redis when enabled",
-      "title_zh": "\u542f\u7528 redis \u65f6\u5c06\u7f13\u5b58\u8bfb\u5199\u59d4\u6258\u7ed9 redis \u540e\u7aef",
+      "title_zh": "启用 redis 时将缓存读写委托给 redis 后端",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache.get",
       "code_paths": [
@@ -2871,7 +2871,7 @@
     {
       "id": "console.cache.redis-client-config",
       "title": "Initialize redis cache clients from environment configuration",
-      "title_zh": "\u6839\u636e\u73af\u5883\u914d\u7f6e\u521d\u59cb\u5316 redis \u7f13\u5b58\u5ba2\u6237\u7aef",
+      "title_zh": "根据环境配置初始化 redis 缓存客户端",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache.__init__",
       "code_paths": [
@@ -2889,7 +2889,7 @@
     {
       "id": "console.cache.redis-enabled-flag",
       "title": "Enable redis cache mode when REDIS_HOST is present",
-      "title_zh": "\u5728\u5b58\u5728 REDIS_HOST \u65f6\u542f\u7528 redis \u7f13\u5b58\u6a21\u5f0f",
+      "title_zh": "在存在 REDIS_HOST 时启用 redis 缓存模式",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache.enable_redis",
       "code_paths": [
@@ -2907,7 +2907,7 @@
     {
       "id": "console.cache.redis-read-error",
       "title": "Swallow redis read exceptions and fall back to empty results",
-      "title_zh": "\u541e\u6389 redis \u8bfb\u53d6\u5f02\u5e38\u5e76\u56de\u843d\u4e3a\u7a7a\u7ed3\u679c",
+      "title_zh": "吞掉 redis 读取异常并回落为空结果",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._redis_get",
       "code_paths": [
@@ -2925,7 +2925,7 @@
     {
       "id": "console.cache.redis-write-error",
       "title": "Swallow redis write exceptions without breaking callers",
-      "title_zh": "\u541e\u6389 redis \u5199\u5165\u5f02\u5e38\u4e14\u4e0d\u6253\u65ad\u8c03\u7528\u65b9",
+      "title_zh": "吞掉 redis 写入异常且不打断调用方",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._redis_set",
       "code_paths": [
@@ -2943,7 +2943,7 @@
     {
       "id": "console.cache.update-existing-at-capacity",
       "title": "Update existing cache entries even when the in-memory cache is full",
-      "title_zh": "\u5373\u4f7f\u5185\u5b58\u7f13\u5b58\u5df2\u6ee1\u4e5f\u5141\u8bb8\u66f4\u65b0\u5df2\u6709\u7f13\u5b58\u9879",
+      "title_zh": "即使内存缓存已满也允许更新已有缓存项",
       "interface_type": "workflow",
       "interface": "console.utils.cache.Cache._memory_set",
       "code_paths": [
@@ -2961,7 +2961,7 @@
     {
       "id": "console.cert.expired-reject",
       "title": "Reject expired certificates during certificate effectiveness checks",
-      "title_zh": "\u5728\u8bc1\u4e66\u6709\u6548\u6027\u68c0\u67e5\u4e2d\u62d2\u7edd\u5df2\u8fc7\u671f\u8bc1\u4e66",
+      "title_zh": "在证书有效性检查中拒绝已过期证书",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.cert_is_effective",
       "code_paths": [
@@ -2979,7 +2979,7 @@
     {
       "id": "console.cert.invalid-private-key",
       "title": "Reject invalid private keys during certificate verification",
-      "title_zh": "\u5728\u8bc1\u4e66\u6821\u9a8c\u4e2d\u62d2\u7edd\u65e0\u6548\u79c1\u94a5",
+      "title_zh": "在证书校验中拒绝无效私钥",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.cert_is_effective",
       "code_paths": [
@@ -2997,7 +2997,7 @@
     {
       "id": "console.cert.key-match",
       "title": "Verify that certificates and private keys match and are effective",
-      "title_zh": "\u6821\u9a8c\u8bc1\u4e66\u4e0e\u79c1\u94a5\u662f\u5426\u5339\u914d\u4e14\u6709\u6548",
+      "title_zh": "校验证书与私钥是否匹配且有效",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.cert_is_effective",
       "code_paths": [
@@ -3015,7 +3015,7 @@
     {
       "id": "console.cert.san-parse",
       "title": "Parse certificate subject alternative names from extension strings",
-      "title_zh": "\u4ece\u6269\u5c55\u5b57\u7b26\u4e32\u4e2d\u89e3\u6790\u8bc1\u4e66\u7684 SAN \u57df\u540d\u4e0e IP",
+      "title_zh": "从扩展字符串中解析证书的 SAN 域名与 IP",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.parse_subject_alt_names",
       "code_paths": [
@@ -3033,7 +3033,7 @@
     {
       "id": "console.cert.summary",
       "title": "Summarize certificate SANs issuer and expiration info",
-      "title_zh": "\u6c47\u603b\u8bc1\u4e66 SAN\u3001\u7b7e\u53d1\u65b9\u4e0e\u8fc7\u671f\u4fe1\u606f",
+      "title_zh": "汇总证书 SAN、签发方与过期信息",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.analyze_cert",
       "code_paths": [
@@ -3051,7 +3051,7 @@
     {
       "id": "console.cert.utc-to-local",
       "title": "Convert certificate UTC timestamps to local time strings",
-      "title_zh": "\u5c06\u8bc1\u4e66 UTC \u65f6\u95f4\u6233\u8f6c\u6362\u4e3a\u672c\u5730\u65f6\u95f4\u5b57\u7b26\u4e32",
+      "title_zh": "将证书 UTC 时间戳转换为本地时间字符串",
       "interface_type": "workflow",
       "interface": "console.utils.certutil.utc2local",
       "code_paths": [
@@ -3069,7 +3069,7 @@
     {
       "id": "console.cnb-build.auto-set-build-type",
       "title": "Auto set CNB build type from build parameters",
-      "title_zh": "\u6839\u636e\u6784\u5efa\u53c2\u6570\u81ea\u52a8\u8bbe\u7f6e CNB \u6784\u5efa\u7c7b\u578b",
+      "title_zh": "根据构建参数自动设置 CNB 构建类型",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.has_cnb_build_params",
       "code_paths": [
@@ -3087,7 +3087,7 @@
     {
       "id": "console.cnb-build.detect-build-params",
       "title": "Detect CNB build parameters from build envs",
-      "title_zh": "\u8bc6\u522b CNB \u6784\u5efa\u53c2\u6570",
+      "title_zh": "识别 CNB 构建参数",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.has_cnb_build_params",
       "code_paths": [
@@ -3117,7 +3117,7 @@
     {
       "id": "console.cnb-build.detect-supported-language",
       "title": "Detect languages supported by CNB build",
-      "title_zh": "\u8bc6\u522b\u652f\u6301 CNB \u7684\u6784\u5efa\u8bed\u8a00",
+      "title_zh": "识别支持 CNB 的构建语言",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.is_cnb_language",
       "code_paths": [
@@ -3139,7 +3139,7 @@
     {
       "id": "console.cnb-build.framework-output-contract",
       "title": "Generate framework output contract for CNB static builds",
-      "title_zh": "\u751f\u6210\u6846\u67b6\u8f93\u51fa\u76ee\u5f55\u7ea6\u5b9a",
+      "title_zh": "生成框架输出目录约定",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.extract_cnb_envs_from_runtime_info",
       "code_paths": [
@@ -3157,7 +3157,7 @@
     {
       "id": "console.cnb-build.generate-runtime-envs",
       "title": "Generate CNB runtime envs from detected runtime info",
-      "title_zh": "\u6839\u636e\u8fd0\u884c\u65f6\u8bc6\u522b\u7ed3\u679c\u751f\u6210 CNB \u73af\u5883\u53d8\u91cf",
+      "title_zh": "根据运行时识别结果生成 CNB 环境变量",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.extract_cnb_envs_from_runtime_info",
       "code_paths": [
@@ -3179,7 +3179,7 @@
     {
       "id": "console.cnb-build.ignore-unsupported-runtime-info",
       "title": "Ignore unsupported runtime info for CNB env generation",
-      "title_zh": "\u5ffd\u7565\u4e0d\u652f\u6301\u8bed\u8a00\u7684 CNB \u8fd0\u884c\u65f6\u4fe1\u606f",
+      "title_zh": "忽略不支持语言的 CNB 运行时信息",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.extract_cnb_envs_from_runtime_info",
       "code_paths": [
@@ -3201,7 +3201,7 @@
     {
       "id": "console.cnb-build.keep-non-cnb-build-type",
       "title": "Avoid auto-setting CNB build type for unsupported languages",
-      "title_zh": "\u5bf9\u4e0d\u652f\u6301\u8bed\u8a00\u4e0d\u81ea\u52a8\u8bbe\u7f6e CNB \u6784\u5efa\u7c7b\u578b",
+      "title_zh": "对不支持语言不自动设置 CNB 构建类型",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.has_cnb_build_params",
       "code_paths": [
@@ -3219,7 +3219,7 @@
     {
       "id": "console.cnb-build.preserve-supported-envs",
       "title": "Preserve supported CNB envs for node and static builds",
-      "title_zh": "\u4fdd\u7559\u652f\u6301\u8bed\u8a00\u7684 CNB \u73af\u5883\u53d8\u91cf",
+      "title_zh": "保留支持语言的 CNB 环境变量",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.sanitize_build_env_dict_for_language",
       "code_paths": [
@@ -3249,7 +3249,7 @@
     {
       "id": "console.cnb-build.reject-unsupported-language",
       "title": "Reject unsupported languages for CNB build",
-      "title_zh": "\u62d2\u7edd\u4e0d\u652f\u6301 CNB \u7684\u6784\u5efa\u8bed\u8a00",
+      "title_zh": "拒绝不支持 CNB 的构建语言",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.is_cnb_language",
       "code_paths": [
@@ -3271,7 +3271,7 @@
     {
       "id": "console.cnb-build.sanitize-unsupported-envs",
       "title": "Strip stale CNB envs for unsupported languages",
-      "title_zh": "\u6e05\u7406\u975e\u652f\u6301\u8bed\u8a00\u4e2d\u7684\u9648\u65e7 CNB \u73af\u5883\u53d8\u91cf",
+      "title_zh": "清理非支持语言中的陈旧 CNB 环境变量",
       "interface_type": "workflow",
       "interface": "console.utils.cnb_build.sanitize_build_env_dict_for_language",
       "code_paths": [
@@ -3297,7 +3297,7 @@
     {
       "id": "console.component.autoscaler-summary",
       "title": "View component autoscaler summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u4f38\u7f29\u6982\u89c8",
+      "title_zh": "查看组件伸缩概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_autoscaler]",
       "code_paths": [
@@ -3316,7 +3316,7 @@
     {
       "id": "console.component.build",
       "title": "Build component after successful check",
-      "title_zh": "\u68c0\u6d4b\u6210\u529f\u540e\u6784\u5efa\u7ec4\u4ef6",
+      "title_zh": "检测成功后构建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_build_component]",
       "code_paths": [
@@ -3447,7 +3447,7 @@
     {
       "id": "console.component.change-image",
       "title": "Change component image",
-      "title_zh": "\u4fee\u6539\u7ec4\u4ef6\u955c\u50cf",
+      "title_zh": "修改组件镜像",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_change_component_image]",
       "code_paths": [
@@ -3466,7 +3466,7 @@
     {
       "id": "console.component.check-result",
       "title": "Get component build check result",
-      "title_zh": "\u83b7\u53d6\u7ec4\u4ef6\u6784\u5efa\u68c0\u6d4b\u7ed3\u679c",
+      "title_zh": "获取组件构建检测结果",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_component_check_result]",
       "code_paths": [
@@ -3485,7 +3485,7 @@
     {
       "id": "console.component.check-start",
       "title": "Start component check",
-      "title_zh": "\u542f\u52a8\u7ec4\u4ef6\u68c0\u6d4b",
+      "title_zh": "启动组件检测",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_check_component]",
       "code_paths": [
@@ -3504,7 +3504,7 @@
     {
       "id": "console.component.connection-env-create",
       "title": "Create component connection environment variable",
-      "title_zh": "\u521b\u5efa\u7ec4\u4ef6\u8fde\u63a5\u73af\u5883\u53d8\u91cf",
+      "title_zh": "创建组件连接环境变量",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_connection_envs#create]",
       "code_paths": [
@@ -3523,7 +3523,7 @@
     {
       "id": "console.component.connection-env-summary",
       "title": "View component connection environments",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u8fde\u63a5\u73af\u5883\u53d8\u91cf",
+      "title_zh": "查看组件连接环境变量",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_connection_envs#summary]",
       "code_paths": [
@@ -3542,7 +3542,7 @@
     {
       "id": "console.component.create-from-image",
       "title": "Create component from image",
-      "title_zh": "\u4ece\u955c\u50cf\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "从镜像创建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_component]",
       "code_paths": [
@@ -3561,7 +3561,7 @@
     {
       "id": "console.component.create-from-image-direct",
       "title": "Create component from image entrypoint",
-      "title_zh": "\u901a\u8fc7\u955c\u50cf\u5165\u53e3\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "通过镜像入口创建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_component_from_image",
       "code_paths": [
@@ -3579,7 +3579,7 @@
     {
       "id": "console.component.create-from-package",
       "title": "Create component from package upload",
-      "title_zh": "\u4ece\u5236\u54c1\u5305\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "从制品包创建组件",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -3597,7 +3597,7 @@
     {
       "id": "console.component.create-from-package-upload",
       "title": "Create component from uploaded package",
-      "title_zh": "\u901a\u8fc7\u4e0a\u4f20\u5236\u54c1\u5305\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "通过上传制品包创建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_component_from_package",
       "code_paths": [
@@ -3615,7 +3615,7 @@
     {
       "id": "console.component.create-from-source",
       "title": "Create component from source repository",
-      "title_zh": "\u4ece\u6e90\u7801\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "从源码创建组件",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -3633,7 +3633,7 @@
     {
       "id": "console.component.create-from-source-generic-git",
       "title": "Create component from generic git source",
-      "title_zh": "\u901a\u8fc7\u901a\u7528 Git \u6e90\u7801\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "通过通用 Git 源码创建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_component_from_source",
       "code_paths": [
@@ -3651,7 +3651,7 @@
     {
       "id": "console.component.create-from-source-guided",
       "title": "Create component from guided source configuration",
-      "title_zh": "\u901a\u8fc7\u5f15\u5bfc\u5f0f\u6e90\u7801\u914d\u7f6e\u521b\u5efa\u7ec4\u4ef6",
+      "title_zh": "通过引导式源码配置创建组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_component_from_source",
       "code_paths": [
@@ -3687,7 +3687,7 @@
     {
       "id": "console.component.delete",
       "title": "Delete component",
-      "title_zh": "\u5220\u9664\u7ec4\u4ef6",
+      "title_zh": "删除组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_component]",
       "code_paths": [
@@ -3706,7 +3706,7 @@
     {
       "id": "console.component.dependency-add",
       "title": "Add component dependency",
-      "title_zh": "\u6dfb\u52a0\u7ec4\u4ef6\u4f9d\u8d56",
+      "title_zh": "添加组件依赖",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add]",
       "code_paths": [
@@ -3729,7 +3729,7 @@
     {
       "id": "console.component.dependency-add-batch",
       "title": "Add batch component dependencies",
-      "title_zh": "\u6279\u91cf\u6dfb\u52a0\u7ec4\u4ef6\u4f9d\u8d56",
+      "title_zh": "批量添加组件依赖",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add-batch]",
       "code_paths": [
@@ -3748,7 +3748,7 @@
     {
       "id": "console.component.dependency-add-reverse",
       "title": "Add reverse component dependencies",
-      "title_zh": "\u6dfb\u52a0\u53cd\u5411\u7ec4\u4ef6\u4f9d\u8d56",
+      "title_zh": "添加反向组件依赖",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add_reverse]",
       "code_paths": [
@@ -3767,7 +3767,7 @@
     {
       "id": "console.component.dependency-delete",
       "title": "Delete component dependency",
-      "title_zh": "\u5220\u9664\u7ec4\u4ef6\u4f9d\u8d56",
+      "title_zh": "删除组件依赖",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#delete]",
       "code_paths": [
@@ -3786,7 +3786,7 @@
     {
       "id": "console.component.dependency-summary",
       "title": "View component dependency summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u4f9d\u8d56\u6982\u89c8",
+      "title_zh": "查看组件依赖概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency]",
       "code_paths": [
@@ -3805,7 +3805,7 @@
     {
       "id": "console.component.detail",
       "title": "Get component detail",
-      "title_zh": "\u67e5\u8be2\u7ec4\u4ef6\u8be6\u60c5",
+      "title_zh": "查询组件详情",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_component_detail]",
       "code_paths": [
@@ -3824,7 +3824,7 @@
     {
       "id": "console.component.env-batch-guard",
       "title": "Reject invalid payload when batch saving component envs",
-      "title_zh": "\u6279\u91cf\u4fdd\u5b58\u7ec4\u4ef6\u73af\u5883\u53d8\u91cf\u65f6\u62e6\u622a\u65e0\u6548\u53c2\u6570",
+      "title_zh": "批量保存组件环境变量时拦截无效参数",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.update_component_envs",
       "code_paths": [
@@ -3842,7 +3842,7 @@
     {
       "id": "console.component.env-batch-save",
       "title": "Batch save component environment variables",
-      "title_zh": "\u6279\u91cf\u4fdd\u5b58\u7ec4\u4ef6\u73af\u5883\u53d8\u91cf",
+      "title_zh": "批量保存组件环境变量",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.update_component_envs",
       "code_paths": [
@@ -3860,7 +3860,7 @@
     {
       "id": "console.component.env-create",
       "title": "Create component environment variable",
-      "title_zh": "\u521b\u5efa\u7ec4\u4ef6\u73af\u5883\u53d8\u91cf",
+      "title_zh": "创建组件环境变量",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_envs#create]",
       "code_paths": [
@@ -3879,7 +3879,7 @@
     {
       "id": "console.component.env-scope-default",
       "title": "Default invalid env scope to inner scope",
-      "title_zh": "\u5c06\u73af\u5883\u53d8\u91cf\u4f5c\u7528\u57df\u9ed8\u8ba4\u5f52\u4e00\u4e3a\u5185\u7f51",
+      "title_zh": "将环境变量作用域默认归一为内网",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service._normalize_env_scope",
       "code_paths": [
@@ -3897,7 +3897,7 @@
     {
       "id": "console.component.env-summary",
       "title": "View component environment summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u73af\u5883\u53d8\u91cf\u6982\u89c8",
+      "title_zh": "查看组件环境变量概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_envs]",
       "code_paths": [
@@ -3916,7 +3916,7 @@
     {
       "id": "console.component.env-update",
       "title": "Bulk update component environment variables",
-      "title_zh": "\u6279\u91cf\u66f4\u65b0\u7ec4\u4ef6\u73af\u5883\u53d8\u91cf",
+      "title_zh": "批量更新组件环境变量",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_envs#upsert]",
       "code_paths": [
@@ -3953,7 +3953,7 @@
     {
       "id": "console.component.events",
       "title": "Get component events",
-      "title_zh": "\u67e5\u8be2\u7ec4\u4ef6\u4e8b\u4ef6",
+      "title_zh": "查询组件事件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_component_events]",
       "code_paths": [
@@ -3972,7 +3972,7 @@
     {
       "id": "console.component.horizontal-scale",
       "title": "Horizontally scale component",
-      "title_zh": "\u6c34\u5e73\u4f38\u7f29\u7ec4\u4ef6",
+      "title_zh": "水平伸缩组件",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_horizontal_scale_component]",
       "code_paths": [
@@ -3991,7 +3991,7 @@
     {
       "id": "console.component.list",
       "title": "List components in application",
-      "title_zh": "\u67e5\u770b\u5e94\u7528\u7ec4\u4ef6\u5217\u8868",
+      "title_zh": "查看应用组件列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_components]",
       "code_paths": [
@@ -4009,7 +4009,7 @@
     {
       "id": "console.component.logs",
       "title": "View component logs",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u65e5\u5fd7",
+      "title_zh": "查看组件日志",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_component_logs]",
       "code_paths": [
@@ -4027,7 +4027,7 @@
     {
       "id": "console.component.logs-console-shape",
       "title": "Support console-style pod shape when reading logs",
-      "title_zh": "\u517c\u5bb9\u63a7\u5236\u53f0\u98ce\u683c\u5b9e\u4f8b\u7ed3\u6784\u8bfb\u53d6\u65e5\u5fd7",
+      "title_zh": "兼容控制台风格实例结构读取日志",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.get_component_logs console pod shape fallback",
       "code_paths": [
@@ -4045,7 +4045,7 @@
     {
       "id": "console.component.logs-container",
       "title": "Read logs from explicit container target",
-      "title_zh": "\u6309\u6307\u5b9a\u5bb9\u5668\u8bfb\u53d6\u7ec4\u4ef6\u65e5\u5fd7",
+      "title_zh": "按指定容器读取组件日志",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.get_component_logs[action=container]",
       "code_paths": [
@@ -4063,7 +4063,7 @@
     {
       "id": "console.component.logs-fallback",
       "title": "Fallback to first pod container when reading component logs",
-      "title_zh": "\u8bfb\u53d6\u7ec4\u4ef6\u65e5\u5fd7\u65f6\u81ea\u52a8\u56de\u9000\u5230\u5b9e\u4f8b\u5bb9\u5668",
+      "title_zh": "读取组件日志时自动回退到实例容器",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.get_component_logs fallback selection",
       "code_paths": [
@@ -4081,7 +4081,7 @@
     {
       "id": "console.component.logs-no-instance",
       "title": "Reject log query when no runtime instance exists",
-      "title_zh": "\u65e0\u8fd0\u884c\u5b9e\u4f8b\u65f6\u62d2\u7edd\u67e5\u8be2\u7ec4\u4ef6\u65e5\u5fd7",
+      "title_zh": "无运行实例时拒绝查询组件日志",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.get_component_logs",
       "code_paths": [
@@ -4099,7 +4099,7 @@
     {
       "id": "console.component.logs-parse-sse",
       "title": "Parse component log SSE payload",
-      "title_zh": "\u89e3\u6790\u7ec4\u4ef6\u65e5\u5fd7 SSE \u6570\u636e",
+      "title_zh": "解析组件日志 SSE 数据",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service._parse_component_log_line",
       "code_paths": [
@@ -4117,7 +4117,7 @@
     {
       "id": "console.component.operation-aliases",
       "title": "Normalize component operation aliases",
-      "title_zh": "\u89c4\u8303\u5316\u7ec4\u4ef6\u64cd\u4f5c\u522b\u540d",
+      "title_zh": "规范化组件操作别名",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service._normalize_component_operation",
       "code_paths": [
@@ -4171,7 +4171,7 @@
     {
       "id": "console.component.port-list",
       "title": "List component ports",
-      "title_zh": "\u67e5\u8be2\u7ec4\u4ef6\u7aef\u53e3\u5217\u8868",
+      "title_zh": "查询组件端口列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_handle_component_ports#list]",
       "code_paths": [
@@ -4190,7 +4190,7 @@
     {
       "id": "console.component.port-open-inner",
       "title": "Open component inner port",
-      "title_zh": "\u5f00\u653e\u7ec4\u4ef6\u5185\u7f51\u7aef\u53e3",
+      "title_zh": "开放组件内网端口",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_inner]",
       "code_paths": [
@@ -4208,7 +4208,7 @@
     {
       "id": "console.component.port-open-outer-only",
       "title": "Open component public port only",
-      "title_zh": "\u4ec5\u5f00\u653e\u7ec4\u4ef6\u516c\u7f51\u7aef\u53e3",
+      "title_zh": "仅开放组件公网端口",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_outer_only]",
       "code_paths": [
@@ -4226,7 +4226,7 @@
     {
       "id": "console.component.port-open-public",
       "title": "Open component port to public access",
-      "title_zh": "\u6253\u5f00\u7ec4\u4ef6\u516c\u7f51\u7aef\u53e3",
+      "title_zh": "打开组件公网端口",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_handle_component_ports]",
       "code_paths": [
@@ -4245,7 +4245,7 @@
     {
       "id": "console.component.port-summary",
       "title": "View component port summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u7aef\u53e3\u6982\u89c8",
+      "title_zh": "查看组件端口概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_ports]",
       "code_paths": [
@@ -4263,7 +4263,7 @@
     {
       "id": "console.component.probe-summary",
       "title": "View component probe summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u63a2\u9488\u6982\u89c8",
+      "title_zh": "查看组件探针概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_probe]",
       "code_paths": [
@@ -4282,7 +4282,7 @@
     {
       "id": "console.component.storage-create-mount",
       "title": "Create component shared storage mount",
-      "title_zh": "\u521b\u5efa\u7ec4\u4ef6\u5171\u4eab\u5b58\u50a8\u6302\u8f7d",
+      "title_zh": "创建组件共享存储挂载",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_mnt]",
       "code_paths": [
@@ -4301,7 +4301,7 @@
     {
       "id": "console.component.storage-create-volume",
       "title": "Create component storage volume",
-      "title_zh": "\u521b\u5efa\u7ec4\u4ef6\u5b58\u50a8\u5377",
+      "title_zh": "创建组件存储卷",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume]",
       "code_paths": [
@@ -4324,7 +4324,7 @@
     {
       "id": "console.component.storage-custom-volume-filter",
       "title": "Filter built-in volume types from custom volume list",
-      "title_zh": "\u8fc7\u6ee4\u7ec4\u4ef6\u81ea\u5b9a\u4e49\u5377\u5217\u8868\u4e2d\u7684\u5185\u7f6e\u5377\u7c7b\u578b",
+      "title_zh": "过滤组件自定义卷列表中的内置卷类型",
       "interface_type": "workflow",
       "interface": "console.repositories.app_config.TenantServiceVolumnRepository.list_custom_volumes",
       "code_paths": [
@@ -4342,7 +4342,7 @@
     {
       "id": "console.component.extend-method-upsert",
       "title": "Upsert component extend method by service version",
-      "title_zh": "\u6309\u7ec4\u4ef6\u7248\u672c\u8986\u76d6\u4fdd\u5b58\u4f38\u7f29\u89c4\u5219\u914d\u7f6e",
+      "title_zh": "按组件版本覆盖保存伸缩规则配置",
       "interface_type": "workflow",
       "interface": "console.repositories.app_config.ServiceExtendRepository",
       "code_paths": [
@@ -4368,7 +4368,7 @@
     {
       "id": "console.component.storage-delete-mount",
       "title": "Delete component shared storage mount",
-      "title_zh": "\u5220\u9664\u7ec4\u4ef6\u5171\u4eab\u5b58\u50a8\u6302\u8f7d",
+      "title_zh": "删除组件共享存储挂载",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_mnt]",
       "code_paths": [
@@ -4387,7 +4387,7 @@
     {
       "id": "console.component.storage-delete-volume",
       "title": "Delete component storage volume",
-      "title_zh": "\u5220\u9664\u7ec4\u4ef6\u5b58\u50a8\u5377",
+      "title_zh": "删除组件存储卷",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_volume]",
       "code_paths": [
@@ -4410,7 +4410,7 @@
     {
       "id": "console.component.storage-summary",
       "title": "View component storage summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u5b58\u50a8\u6982\u89c8",
+      "title_zh": "查看组件存储概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_manage_component_storage]",
       "code_paths": [
@@ -4471,7 +4471,7 @@
     {
       "id": "console.component.summary",
       "title": "View component summary",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u6982\u89c8",
+      "title_zh": "查看组件概览",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_component_summary]",
       "code_paths": [
@@ -4507,7 +4507,7 @@
     {
       "id": "console.endpoint-address.reject-invalid-format",
       "title": "Reject malformed endpoint addresses that are neither IPs nor domains",
-      "title_zh": "\u62d2\u7edd\u65e2\u4e0d\u662f IP \u4e5f\u4e0d\u662f\u57df\u540d\u7684\u975e\u6cd5\u7aef\u70b9\u5730\u5740",
+      "title_zh": "拒绝既不是 IP 也不是域名的非法端点地址",
       "interface_type": "workflow",
       "interface": "console.utils.validation.validate_endpoint_address",
       "code_paths": [
@@ -4525,7 +4525,7 @@
     {
       "id": "console.endpoint-address.reject-special-ranges",
       "title": "Reject unspecified and loopback endpoint addresses",
-      "title_zh": "\u62d2\u7edd unspecified \u548c loopback \u7684\u7aef\u70b9\u5730\u5740",
+      "title_zh": "拒绝 unspecified 和 loopback 的端点地址",
       "interface_type": "workflow",
       "interface": "console.utils.validation.validate_endpoint_address",
       "code_paths": [
@@ -4543,7 +4543,7 @@
     {
       "id": "console.endpoint-list.normalize-scheme-port",
       "title": "Normalize endpoint schemes and ports before multi-endpoint validation",
-      "title_zh": "\u5728\u591a\u7aef\u70b9\u6821\u9a8c\u524d\u89c4\u8303\u5316\u534f\u8bae\u548c\u7aef\u53e3",
+      "title_zh": "在多端点校验前规范化协议和端口",
       "interface_type": "workflow",
       "interface": "console.utils.validation.validate_endpoints_info",
       "code_paths": [
@@ -4561,7 +4561,7 @@
     {
       "id": "console.endpoint-list.reject-duplicate",
       "title": "Reject duplicate endpoint addresses in multi-instance endpoint lists",
-      "title_zh": "\u5728\u591a\u5b9e\u4f8b\u7aef\u70b9\u5217\u8868\u4e2d\u62d2\u7edd\u91cd\u590d\u5730\u5740",
+      "title_zh": "在多实例端点列表中拒绝重复地址",
       "interface_type": "workflow",
       "interface": "console.utils.validation.validate_endpoints_info",
       "code_paths": [
@@ -4579,7 +4579,7 @@
     {
       "id": "console.enterprise-config.user-context",
       "title": "Resolve enterprise config service user context",
-      "title_zh": "\u89e3\u6790\u4f01\u4e1a\u914d\u7f6e\u670d\u52a1\u7528\u6237\u4e0a\u4e0b\u6587",
+      "title_zh": "解析企业配置服务用户上下文",
       "interface_type": "workflow",
       "interface": "console.services.config_service.EnterpriseConfigService.__init__",
       "code_paths": [
@@ -4601,7 +4601,7 @@
     {
       "id": "console.enterprise.region-component-list",
       "title": "List region control plane components",
-      "title_zh": "\u67e5\u770b\u96c6\u7fa4\u63a7\u5236\u9762\u7ec4\u4ef6\u5217\u8868",
+      "title_zh": "查看集群控制面组件列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_region_rbd_components]",
       "code_paths": [
@@ -4619,7 +4619,7 @@
     {
       "id": "console.enterprise.region-create",
       "title": "Create enterprise region",
-      "title_zh": "\u521b\u5efa\u4f01\u4e1a\u96c6\u7fa4",
+      "title_zh": "创建企业集群",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_region]",
       "code_paths": [
@@ -4637,7 +4637,7 @@
     {
       "id": "console.enterprise.region-delete",
       "title": "Delete enterprise region",
-      "title_zh": "\u5220\u9664\u4f01\u4e1a\u96c6\u7fa4",
+      "title_zh": "删除企业集群",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_region]",
       "code_paths": [
@@ -4655,7 +4655,7 @@
     {
       "id": "console.enterprise.region-detail",
       "title": "View enterprise region detail",
-      "title_zh": "\u67e5\u770b\u4f01\u4e1a\u96c6\u7fa4\u8be6\u60c5",
+      "title_zh": "查看企业集群详情",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_region_detail]",
       "code_paths": [
@@ -4673,7 +4673,7 @@
     {
       "id": "console.enterprise.region-list",
       "title": "List enterprise regions",
-      "title_zh": "\u67e5\u770b\u4f01\u4e1a\u96c6\u7fa4\u5217\u8868",
+      "title_zh": "查看企业集群列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_regions]",
       "code_paths": [
@@ -4699,7 +4699,7 @@
     {
       "id": "console.enterprise.region-list-authz",
       "title": "Authorize enterprise region listing",
-      "title_zh": "\u6821\u9a8c\u4f01\u4e1a\u96c6\u7fa4\u5217\u8868\u8bbf\u95ee\u6743\u9650",
+      "title_zh": "校验企业集群列表访问权限",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.query_regions",
       "code_paths": [
@@ -4721,7 +4721,7 @@
     {
       "id": "console.enterprise.region-node-detail",
       "title": "View region node detail",
-      "title_zh": "\u67e5\u770b\u96c6\u7fa4\u8282\u70b9\u8be6\u60c5",
+      "title_zh": "查看集群节点详情",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_get_region_node_detail]",
       "code_paths": [
@@ -4739,7 +4739,7 @@
     {
       "id": "console.enterprise.region-node-list",
       "title": "List region nodes",
-      "title_zh": "\u67e5\u770b\u96c6\u7fa4\u8282\u70b9\u5217\u8868",
+      "title_zh": "查看集群节点列表",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_query_region_nodes]",
       "code_paths": [
@@ -4757,7 +4757,7 @@
     {
       "id": "console.enterprise.region-update",
       "title": "Update enterprise region",
-      "title_zh": "\u66f4\u65b0\u4f01\u4e1a\u96c6\u7fa4",
+      "title_zh": "更新企业集群",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_update_region]",
       "code_paths": [
@@ -4775,7 +4775,7 @@
     {
       "id": "console.file-manage.region-request-timeout",
       "title": "Use selected container and longer timeout for file-manage region requests",
-      "title_zh": "\u6587\u4ef6\u7ba1\u7406\u533a\u57df\u8bf7\u6c42\u4f7f\u7528\u9009\u5b9a\u5bb9\u5668\u4e0e\u66f4\u957f\u8d85\u65f6",
+      "title_zh": "文件管理区域请求使用选定容器与更长超时",
       "interface_type": "workflow",
       "interface": "www.apiclient.regionapi.RegionInvokeApi.get_files",
       "code_paths": [
@@ -4793,7 +4793,7 @@
     {
       "id": "console.file-manage.selected-container-forwarding",
       "title": "Forward selected container name when listing managed files",
-      "title_zh": "\u5217\u51fa\u6587\u4ef6\u7ba1\u7406\u5185\u5bb9\u65f6\u900f\u4f20\u7528\u6237\u9009\u62e9\u7684\u5bb9\u5668\u540d",
+      "title_zh": "列出文件管理内容时透传用户选择的容器名",
       "interface_type": "service_method",
       "interface": "console.services.group_service.GroupService.get_file_and_dir",
       "code_paths": [
@@ -4848,7 +4848,7 @@
     {
       "id": "console.gateway.create-http-rule",
       "title": "Create HTTP gateway rule",
-      "title_zh": "\u521b\u5efa HTTP \u7f51\u5173\u89c4\u5219",
+      "title_zh": "创建 HTTP 网关规则",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules]",
       "code_paths": [
@@ -4868,7 +4868,7 @@
     {
       "id": "console.gateway.create-tcp-rule",
       "title": "Create TCP gateway rule",
-      "title_zh": "\u521b\u5efa TCP \u7f51\u5173\u89c4\u5219",
+      "title_zh": "创建 TCP 网关规则",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules]",
       "code_paths": [
@@ -4905,7 +4905,7 @@
     {
       "id": "console.gateway.http-port-not-open",
       "title": "Reject HTTP gateway rule when port is not open to public",
-      "title_zh": "\u5bf9\u5916\u7aef\u53e3\u672a\u5f00\u542f\u65f6\u62e6\u622a HTTP \u7f51\u5173\u521b\u5efa",
+      "title_zh": "对外端口未开启时拦截 HTTP 网关创建",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[http]",
       "code_paths": [
@@ -4923,7 +4923,7 @@
     {
       "id": "console.gateway.http-port-open-failure",
       "title": "Reject HTTP gateway rule when opening port fails",
-      "title_zh": "HTTP \u7f51\u5173\u5f00\u7aef\u53e3\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "HTTP 网关开端口失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[http]",
       "code_paths": [
@@ -4941,7 +4941,7 @@
     {
       "id": "console.gateway.http-required",
       "title": "Require HTTP payload when creating HTTP gateway rule",
-      "title_zh": "\u521b\u5efa HTTP \u7f51\u5173\u89c4\u5219\u65f6\u5fc5\u987b\u63d0\u4f9b http \u53c2\u6570",
+      "title_zh": "创建 HTTP 网关规则时必须提供 http 参数",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[http]",
       "code_paths": [
@@ -4959,7 +4959,7 @@
     {
       "id": "console.gateway.http-rule-guard",
       "title": "Reject duplicate HTTP gateway rule",
-      "title_zh": "\u62e6\u622a\u91cd\u590d\u7684 HTTP \u7f51\u5173\u89c4\u5219",
+      "title_zh": "拦截重复的 HTTP 网关规则",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[http]",
       "code_paths": [
@@ -4977,7 +4977,7 @@
     {
       "id": "console.gateway.http-third-party-guard",
       "title": "Reject HTTP gateway rule for unsupported third-party component",
-      "title_zh": "\u7b2c\u4e09\u65b9\u7ec4\u4ef6\u4e0d\u652f\u6301 HTTP \u7f51\u5173\u7b56\u7565\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "第三方组件不支持 HTTP 网关策略时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[http]",
       "code_paths": [
@@ -4995,7 +4995,7 @@
     {
       "id": "console.gateway.operation-schema",
       "title": "Expose component port management operation schema",
-      "title_zh": "\u66b4\u9732\u7ec4\u4ef6\u7aef\u53e3\u7ba1\u7406\u64cd\u4f5c\u679a\u4e3e",
+      "title_zh": "暴露组件端口管理操作枚举",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service._tool_manage_component_ports",
       "code_paths": [
@@ -5013,7 +5013,7 @@
     {
       "id": "console.gateway.port-action-schema",
       "title": "Expose component port action schema",
-      "title_zh": "\u66b4\u9732\u7ec4\u4ef6\u7aef\u53e3\u64cd\u4f5c\u679a\u4e3e",
+      "title_zh": "暴露组件端口操作枚举",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service._tool_handle_component_ports",
       "code_paths": [
@@ -5049,7 +5049,7 @@
     {
       "id": "console.gateway.protocol-guard",
       "title": "Reject unsupported gateway protocol",
-      "title_zh": "\u62e6\u622a\u4e0d\u652f\u6301\u7684\u7f51\u5173\u534f\u8bae",
+      "title_zh": "拦截不支持的网关协议",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules",
       "code_paths": [
@@ -5085,7 +5085,7 @@
     {
       "id": "console.gateway.tcp-port-open-failure",
       "title": "Reject TCP gateway rule when opening port fails",
-      "title_zh": "TCP \u7f51\u5173\u5f00\u7aef\u53e3\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "TCP 网关开端口失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[tcp]",
       "code_paths": [
@@ -5103,7 +5103,7 @@
     {
       "id": "console.gateway.tcp-required",
       "title": "Require TCP payload when creating TCP gateway rule",
-      "title_zh": "\u521b\u5efa TCP \u7f51\u5173\u89c4\u5219\u65f6\u5fc5\u987b\u63d0\u4f9b tcp \u53c2\u6570",
+      "title_zh": "创建 TCP 网关规则时必须提供 tcp 参数",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[tcp]",
       "code_paths": [
@@ -5121,7 +5121,7 @@
     {
       "id": "console.gateway.tcp-third-party-guard",
       "title": "Reject TCP gateway rule for unsupported third-party component",
-      "title_zh": "\u7b2c\u4e09\u65b9\u7ec4\u4ef6\u4e0d\u652f\u6301 TCP \u7f51\u5173\u7b56\u7565\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "第三方组件不支持 TCP 网关策略时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.create_gateway_rules[tcp]",
       "code_paths": [
@@ -5175,7 +5175,7 @@
     {
       "id": "console.helm-release.delete",
       "title": "Delete helm release and cleanup saved source",
-      "title_zh": "\u5220\u9664 Helm \u53d1\u5e03\u5e76\u6e05\u7406\u6765\u6e90\u8bb0\u5f55",
+      "title_zh": "删除 Helm 发布并清理来源记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleaseDetailView.delete",
       "code_paths": [
@@ -5193,7 +5193,7 @@
     {
       "id": "console.helm-release.detail",
       "title": "View Helm release detail",
-      "title_zh": "\u67e5\u770b Helm \u53d1\u5e03\u8be6\u60c5",
+      "title_zh": "查看 Helm 发布详情",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleaseDetailView.get",
       "code_paths": [
@@ -5211,7 +5211,7 @@
     {
       "id": "console.helm-release.history",
       "title": "View Helm release history",
-      "title_zh": "\u67e5\u770b Helm \u53d1\u5e03\u5386\u53f2",
+      "title_zh": "查看 Helm 发布历史",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleaseHistoryView.get",
       "code_paths": [
@@ -5229,7 +5229,7 @@
     {
       "id": "console.helm-release.install",
       "title": "Install helm release and persist source",
-      "title_zh": "\u5b89\u88c5 Helm \u53d1\u5e03\u5e76\u4fdd\u5b58\u6765\u6e90\u8bb0\u5f55",
+      "title_zh": "安装 Helm 发布并保存来源记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleasesView.post",
       "code_paths": [
@@ -5247,7 +5247,7 @@
     {
       "id": "console.helm-release.list",
       "title": "View Helm release list",
-      "title_zh": "\u67e5\u770b Helm \u53d1\u5e03\u5217\u8868",
+      "title_zh": "查看 Helm 发布列表",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleasesView.get",
       "code_paths": [
@@ -5265,7 +5265,7 @@
     {
       "id": "console.helm-release.resolve-store-source",
       "title": "Resolve helm store source metadata before operation",
-      "title_zh": "\u64cd\u4f5c\u524d\u89e3\u6790 Helm \u5546\u5e97\u6765\u6e90\u4fe1\u606f",
+      "title_zh": "操作前解析 Helm 商店来源信息",
       "interface_type": "workflow",
       "interface": "console.views.team_resources.Resolve store-backed helm source metadata",
       "code_paths": [
@@ -5283,7 +5283,7 @@
     {
       "id": "console.helm-release.rollback",
       "title": "Rollback helm release",
-      "title_zh": "\u56de\u6eda Helm \u53d1\u5e03",
+      "title_zh": "回滚 Helm 发布",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleaseRollbackView.post",
       "code_paths": [
@@ -5301,7 +5301,7 @@
     {
       "id": "console.helm-release.source-tracking",
       "title": "Track helm release source metadata",
-      "title_zh": "\u8ffd\u8e2a Helm \u53d1\u5e03\u6765\u6e90\u4fe1\u606f",
+      "title_zh": "追踪 Helm 发布来源信息",
       "interface_type": "workflow",
       "interface": "console.views.team_resources.Helm release source persistence lifecycle",
       "code_paths": [
@@ -5327,7 +5327,7 @@
     {
       "id": "console.helm-release.team-namespace-ops",
       "title": "Run helm release operations in team namespace",
-      "title_zh": "\u5728\u56e2\u961f\u547d\u540d\u7a7a\u95f4\u5185\u6267\u884c Helm \u64cd\u4f5c",
+      "title_zh": "在团队命名空间内执行 Helm 操作",
       "interface_type": "workflow",
       "interface": "console.views.team_resources.Helm release lifecycle uses tenant namespace",
       "code_paths": [
@@ -5357,7 +5357,7 @@
     {
       "id": "console.helm-release.upgrade",
       "title": "Upgrade helm release and persist source",
-      "title_zh": "\u5347\u7ea7 Helm \u53d1\u5e03\u5e76\u4fdd\u5b58\u6765\u6e90\u8bb0\u5f55",
+      "title_zh": "升级 Helm 发布并保存来源记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.HelmReleaseDetailView.put",
       "code_paths": [
@@ -5375,7 +5375,7 @@
     {
       "id": "console.helm.build",
       "title": "Build helm application template",
-      "title_zh": "\u6784\u5efa Helm \u5e94\u7528\u6a21\u677f",
+      "title_zh": "构建 Helm 应用模板",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_build_helm_app]",
       "code_paths": [
@@ -5394,7 +5394,7 @@
     {
       "id": "console.helm.check",
       "title": "Check helm application",
-      "title_zh": "\u68c0\u67e5 Helm \u5e94\u7528",
+      "title_zh": "检查 Helm 应用",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[rainbond_check_helm_app]",
       "code_paths": [
@@ -5413,7 +5413,7 @@
     {
       "id": "console.image.runner-detect",
       "title": "Detect runner images by their repository prefix",
-      "title_zh": "\u6839\u636e\u4ed3\u5e93\u524d\u7f00\u8bc6\u522b runner \u955c\u50cf",
+      "title_zh": "根据仓库前缀识别 runner 镜像",
       "interface_type": "workflow",
       "interface": "console.utils.runner_util.is_runner",
       "code_paths": [
@@ -5431,7 +5431,7 @@
     {
       "id": "console.image.slug-detect",
       "title": "Detect runner-based slug images for non-docker languages",
-      "title_zh": "\u4e3a\u975e docker \u7c7b\u8bed\u8a00\u8bc6\u522b\u57fa\u4e8e runner \u7684 slug \u955c\u50cf",
+      "title_zh": "为非 docker 类语言识别基于 runner 的 slug 镜像",
       "interface_type": "workflow",
       "interface": "console.utils.slug_util.is_slug",
       "code_paths": [
@@ -5449,7 +5449,7 @@
     {
       "id": "console.init-cluster.prefer-latest-pending",
       "title": "Prefer latest pending cluster during initialization",
-      "title_zh": "\u521d\u59cb\u5316\u65f6\u4f18\u5148\u9009\u62e9\u6700\u65b0\u5f85\u5904\u7406\u96c6\u7fa4",
+      "title_zh": "初始化时优先选择最新待处理集群",
       "interface_type": "workflow",
       "interface": "console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated",
       "code_paths": [
@@ -5467,7 +5467,7 @@
     {
       "id": "console.init-cluster.recycle-empty-interconnected",
       "title": "Recycle empty interconnected cluster for re-initialization",
-      "title_zh": "\u56de\u6536\u7a7a\u767d\u8054\u901a\u96c6\u7fa4\u7528\u4e8e\u91cd\u65b0\u521d\u59cb\u5316",
+      "title_zh": "回收空白联通集群用于重新初始化",
       "interface_type": "workflow",
       "interface": "console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated",
       "code_paths": [
@@ -5485,7 +5485,7 @@
     {
       "id": "console.k8s-namespace.normalize-user-prefix",
       "title": "Normalize user names into valid Kubernetes namespace names",
-      "title_zh": "\u5c06\u7528\u6237\u540d\u89c4\u8303\u5316\u4e3a\u5408\u6cd5\u7684 Kubernetes \u547d\u540d\u7a7a\u95f4\u540d",
+      "title_zh": "将用户名规范化为合法的 Kubernetes 命名空间名",
       "interface_type": "workflow",
       "interface": "console.utils.validation.normalize_name_for_k8s_namespace",
       "code_paths": [
@@ -5503,7 +5503,7 @@
     {
       "id": "console.kubeblocks.backup-repo.team-create",
       "title": "Create team KubeBlocks backup repo",
-      "title_zh": "\u521b\u5efa\u56e2\u961f KubeBlocks \u5907\u4efd\u4ed3\u5e93",
+      "title_zh": "创建团队 KubeBlocks 备份仓库",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.create_backup_repo",
       "code_paths": [
@@ -5525,7 +5525,7 @@
     {
       "id": "console.kubeblocks.backup-repo.team-list",
       "title": "List team KubeBlocks backup repos with live status",
-      "title_zh": "\u5217\u51fa\u56e2\u961f KubeBlocks \u5907\u4efd\u4ed3\u5e93\u5e76\u5408\u5e76\u5b9e\u65f6\u72b6\u6001",
+      "title_zh": "列出团队 KubeBlocks 备份仓库并合并实时状态",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.get_team_backup_repos",
       "code_paths": [
@@ -5547,7 +5547,7 @@
     {
       "id": "console.kubeblocks.backup-repo.team-ownership",
       "title": "Guard KubeBlocks backup repo team ownership",
-      "title_zh": "\u6821\u9a8c KubeBlocks \u5907\u4efd\u4ed3\u5e93\u56e2\u961f\u5f52\u5c5e",
+      "title_zh": "校验 KubeBlocks 备份仓库团队归属",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_belongs_to_team",
       "code_paths": [
@@ -5565,7 +5565,7 @@
     {
       "id": "console.kubeblocks.backup-repo.team-delete",
       "title": "Delete team KubeBlocks backup repo",
-      "title_zh": "\u5220\u9664\u56e2\u961f KubeBlocks \u5907\u4efd\u4ed3\u5e93",
+      "title_zh": "删除团队 KubeBlocks 备份仓库",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo",
       "code_paths": [
@@ -5583,7 +5583,7 @@
     {
       "id": "console.kubeblocks.cluster-resource-validation",
       "title": "Validate KubeBlocks cluster resource requests",
-      "title_zh": "\u6821\u9a8c KubeBlocks \u96c6\u7fa4\u8d44\u6e90\u8bf7\u6c42",
+      "title_zh": "校验 KubeBlocks 集群资源请求",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.validate_cluster_params",
       "code_paths": [
@@ -5601,7 +5601,7 @@
     {
       "id": "console.kubeblocks.create-no-credential-wait",
       "title": "Create KubeBlocks component without waiting for credentials",
-      "title_zh": "\u521b\u5efa KubeBlocks \u7ec4\u4ef6\u4e0d\u7b49\u5f85\u8fde\u63a5\u51ed\u636e",
+      "title_zh": "创建 KubeBlocks 组件不等待连接凭据",
       "interface_type": "service_method",
       "interface": "console.services.kubeblocks_service.KubeBlocksService.create_complete_kubeblocks_component",
       "code_paths": [
@@ -5619,7 +5619,7 @@
     {
       "id": "console.lang-version.proxy-upload",
       "title": "Proxy legacy language package upload endpoint",
-      "title_zh": "\u4ee3\u7406\u65e7\u7248\u8bed\u8a00\u5305\u4e0a\u4f20\u63a5\u53e3",
+      "title_zh": "代理旧版语言包上传接口",
       "interface_type": "view_endpoint",
       "interface": "console.views.enterprise.UploadLongVersion.post",
       "code_paths": [
@@ -5638,7 +5638,7 @@
     {
       "id": "console.market-app.install-default-storage-class",
       "title": "Use platform default storage class for marketplace installs",
-      "title_zh": "\u5e94\u7528\u5e02\u573a\u5b89\u88c5\u4f7f\u7528\u5e73\u53f0\u9ed8\u8ba4\u5b58\u50a8\u7c7b",
+      "title_zh": "应用市场安装使用平台默认存储类",
       "interface_type": "service_method",
       "interface": "console.services.market_app.new_components.NewComponents._template_to_volumes",
       "code_paths": [
@@ -5680,7 +5680,7 @@
     {
       "id": "console.market-app.vm-disk-imports-from-template",
       "title": "Market App VM Disk Imports From Template",
-      "title_zh": "\u5e02\u573a\u5e94\u7528\u5b89\u88c5\u4ece VM \u6a21\u677f\u751f\u6210\u78c1\u76d8\u5bfc\u5165\u914d\u7f6e",
+      "title_zh": "市场应用安装从 VM 模板生成磁盘导入配置",
       "interface_type": "service_method",
       "interface": "console.services.market_app.new_components.NewComponents._template_to_k8s_attributes",
       "code_paths": [
@@ -5698,7 +5698,7 @@
     {
       "id": "console.market-app.vm-runtime-status-guard",
       "title": "Reject VM template install when VM platform is unhealthy",
-      "title_zh": "\u865a\u62df\u673a\u5e73\u53f0\u5f02\u5e38\u65f6\u7981\u6b62\u5b89\u88c5\u865a\u62df\u673a\u6a21\u677f",
+      "title_zh": "虚拟机平台异常时禁止安装虚拟机模板",
       "interface_type": "service_method",
       "interface": "console.services.market_app_service.MarketAppService.install_app",
       "code_paths": [
@@ -5716,7 +5716,7 @@
     {
       "id": "console.market-app.create-template-scope-name",
       "title": "Scope market app template name duplicate checks",
-      "title_zh": "\u6309\u53d1\u5e03\u8303\u56f4\u548c\u56e2\u961f\u68c0\u67e5\u5e94\u7528\u5e02\u573a\u6a21\u677f\u91cd\u540d",
+      "title_zh": "按发布范围和团队检查应用市场模板重名",
       "interface_type": "service_method",
       "interface": "console.services.market_app_service.MarketAppService.create_rainbond_app",
       "code_paths": [
@@ -5734,7 +5734,7 @@
     {
       "id": "console.market-client.auth-missing",
       "title": "Translate 401 market API errors into missing-token service errors",
-      "title_zh": "\u5c06 401 \u5e94\u7528\u5e02\u573a\u9519\u8bef\u8f6c\u6362\u4e3a\u7f3a\u5c11 token \u7684\u670d\u52a1\u5f02\u5e38",
+      "title_zh": "将 401 应用市场错误转换为缺少 token 的服务异常",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5752,7 +5752,7 @@
     {
       "id": "console.market-client.bad-request",
       "title": "Translate generic 4xx market API errors into parameter error responses",
-      "title_zh": "\u5c06\u901a\u7528 4xx \u5e94\u7528\u5e02\u573a\u9519\u8bef\u8f6c\u6362\u4e3a\u53c2\u6570\u9519\u8bef\u54cd\u5e94",
+      "title_zh": "将通用 4xx 应用市场错误转换为参数错误响应",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5770,7 +5770,7 @@
     {
       "id": "console.market-client.default-host",
       "title": "Create market API clients with the default fallback host",
-      "title_zh": "\u4f7f\u7528\u9ed8\u8ba4\u56de\u9000 host \u521b\u5efa\u5e94\u7528\u5e02\u573a\u5ba2\u6237\u7aef",
+      "title_zh": "使用默认回退 host 创建应用市场客户端",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.get_market_client",
       "code_paths": [
@@ -5788,7 +5788,7 @@
     {
       "id": "console.market-client.deserialize-error",
       "title": "Translate market client deserialization failures into service exceptions",
-      "title_zh": "\u5c06\u5e94\u7528\u5e02\u573a\u5ba2\u6237\u7aef\u53cd\u5e8f\u5217\u5316\u5931\u8d25\u8f6c\u6362\u4e3a\u670d\u52a1\u5f02\u5e38",
+      "title_zh": "将应用市场客户端反序列化失败转换为服务异常",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5806,7 +5806,7 @@
     {
       "id": "console.market-client.host-config",
       "title": "Create market API clients with explicit hosts and auth headers",
-      "title_zh": "\u4f7f\u7528\u663e\u5f0f host \u548c\u8ba4\u8bc1\u5934\u521b\u5efa\u5e94\u7528\u5e02\u573a\u5ba2\u6237\u7aef",
+      "title_zh": "使用显式 host 和认证头创建应用市场客户端",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.get_market_client",
       "code_paths": [
@@ -5824,7 +5824,7 @@
     {
       "id": "console.market-client.not-found",
       "title": "Translate 404 market API errors into not-found service exceptions",
-      "title_zh": "\u5c06 404 \u5e94\u7528\u5e02\u573a\u9519\u8bef\u8f6c\u6362\u4e3a\u8d44\u6e90\u4e0d\u5b58\u5728\u5f02\u5e38",
+      "title_zh": "将 404 应用市场错误转换为资源不存在异常",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5842,7 +5842,7 @@
     {
       "id": "console.market-client.permission-denied",
       "title": "Translate 403 market API errors into store permission exceptions",
-      "title_zh": "\u5c06 403 \u5e94\u7528\u5e02\u573a\u9519\u8bef\u8f6c\u6362\u4e3a\u5546\u5e97\u6743\u9650\u5f02\u5e38",
+      "title_zh": "将 403 应用市场错误转换为商店权限异常",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5860,7 +5860,7 @@
     {
       "id": "console.market-client.server-error",
       "title": "Translate generic 5xx market API errors into fallback service errors",
-      "title_zh": "\u5c06\u901a\u7528 5xx \u5e94\u7528\u5e02\u573a\u9519\u8bef\u8f6c\u6362\u4e3a\u515c\u5e95\u670d\u52a1\u5f02\u5e38",
+      "title_zh": "将通用 5xx 应用市场错误转换为兜底服务异常",
       "interface_type": "workflow",
       "interface": "console.utils.restful_client.apiException",
       "code_paths": [
@@ -5968,7 +5968,7 @@
     {
       "id": "console.mcp.http-delete-session",
       "title": "Close MCP session over HTTP",
-      "title_zh": "\u901a\u8fc7 HTTP \u5173\u95ed MCP \u4f1a\u8bdd",
+      "title_zh": "通过 HTTP 关闭 MCP 会话",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQueryHTTPView.delete",
       "code_paths": [
@@ -5986,7 +5986,7 @@
     {
       "id": "console.mcp.http-initialize",
       "title": "Initialize MCP session over HTTP",
-      "title_zh": "\u901a\u8fc7 HTTP \u521d\u59cb\u5316 MCP \u4f1a\u8bdd",
+      "title_zh": "通过 HTTP 初始化 MCP 会话",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQueryHTTPView.post",
       "code_paths": [
@@ -6022,7 +6022,7 @@
     {
       "id": "console.mcp.http-tools-sse",
       "title": "Return tools list over SSE from HTTP endpoint",
-      "title_zh": "\u901a\u8fc7 HTTP \u7aef\u70b9\u4ee5 SSE \u8fd4\u56de\u5de5\u5177\u5217\u8868",
+      "title_zh": "通过 HTTP 端点以 SSE 返回工具列表",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQueryHTTPView.post",
       "code_paths": [
@@ -6040,7 +6040,7 @@
     {
       "id": "console.mcp.legacy-sse-endpoint",
       "title": "Open legacy SSE MCP endpoint",
-      "title_zh": "\u6253\u5f00\u517c\u5bb9\u6a21\u5f0f\u7684 SSE MCP \u7aef\u70b9",
+      "title_zh": "打开兼容模式的 SSE MCP 端点",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQuerySSEView.get",
       "code_paths": [
@@ -6058,7 +6058,7 @@
     {
       "id": "console.mcp.post-message",
       "title": "Post MCP message into SSE session",
-      "title_zh": "\u5411 SSE \u4f1a\u8bdd\u6295\u9012 MCP \u6d88\u606f",
+      "title_zh": "向 SSE 会话投递 MCP 消息",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQueryMessageView.post",
       "code_paths": [
@@ -6076,7 +6076,7 @@
     {
       "id": "console.mcp.serialize-nested-sdk-models",
       "title": "Serialize nested SDK models in MCP responses",
-      "title_zh": "MCP \u54cd\u5e94\u4e2d\u9012\u5f52\u5e8f\u5217\u5316\u5d4c\u5957 SDK \u6a21\u578b",
+      "title_zh": "MCP 响应中递归序列化嵌套 SDK 模型",
       "interface_type": "other",
       "interface": "console.services.mcp_query_service.MCPQueryService._serialize_model_item",
       "code_paths": [
@@ -6134,7 +6134,7 @@
     {
       "id": "console.ns-resource.update",
       "title": "Update namespaced resource from YAML",
-      "title_zh": "\u901a\u8fc7 YAML \u66f4\u65b0\u547d\u540d\u7a7a\u95f4\u8d44\u6e90",
+      "title_zh": "通过 YAML 更新命名空间资源",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.NsResourceDetailView.put",
       "code_paths": [
@@ -6157,7 +6157,7 @@
     {
       "id": "console.oauth.instance-create",
       "title": "Create OAuth helper instances and bind service user context",
-      "title_zh": "\u521b\u5efa OAuth helper \u5b9e\u4f8b\u5e76\u7ed1\u5b9a\u670d\u52a1\u4e0e\u7528\u6237\u4e0a\u4e0b\u6587",
+      "title_zh": "创建 OAuth helper 实例并绑定服务与用户上下文",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.oauth_types.get_oauth_instance",
       "code_paths": [
@@ -6175,7 +6175,7 @@
     {
       "id": "console.oauth.kind-flags",
       "title": "Report OAuth helper capability flags for base and git oauth types",
-      "title_zh": "\u8fd4\u56de\u57fa\u7840\u4e0e git OAuth helper \u7684\u80fd\u529b\u6807\u8bb0",
+      "title_zh": "返回基础与 git OAuth helper 的能力标记",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.base.git_oauth.GitOAuth2Interface.is_git_oauth",
       "code_paths": [
@@ -6193,7 +6193,7 @@
     {
       "id": "console.oauth.session-retry",
       "title": "Create OAuth sessions with retry-capable HTTP adapters",
-      "title_zh": "\u521b\u5efa\u5e26\u91cd\u8bd5 HTTP \u9002\u914d\u5668\u7684 OAuth \u4f1a\u8bdd",
+      "title_zh": "创建带重试 HTTP 适配器的 OAuth 会话",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.base.oauth.OAuth2Interface.set_session",
       "code_paths": [
@@ -6211,7 +6211,7 @@
     {
       "id": "console.oauth.supported-types",
       "title": "List supported OAuth server types",
-      "title_zh": "\u5217\u51fa\u652f\u6301\u7684 OAuth \u670d\u52a1\u7c7b\u578b",
+      "title_zh": "列出支持的 OAuth 服务类型",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.oauth_types.get_support_oauth_servers",
       "code_paths": [
@@ -6229,7 +6229,7 @@
     {
       "id": "console.oauth.token-update",
       "title": "Persist refreshed OAuth access and refresh tokens onto bound users",
-      "title_zh": "\u5c06\u5237\u65b0\u7684 OAuth access/refresh token \u6301\u4e45\u5316\u5230\u7ed1\u5b9a\u7528\u6237",
+      "title_zh": "将刷新的 OAuth access/refresh token 持久化到绑定用户",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.base.oauth.OAuth2Interface.update_access_token",
       "code_paths": [
@@ -6247,7 +6247,7 @@
     {
       "id": "console.oauth.unsupported-type",
       "title": "Reject unsupported OAuth server types",
-      "title_zh": "\u62d2\u7edd\u4e0d\u652f\u6301\u7684 OAuth \u670d\u52a1\u7c7b\u578b",
+      "title_zh": "拒绝不支持的 OAuth 服务类型",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.oauth_types.get_oauth_instance",
       "code_paths": [
@@ -6265,7 +6265,7 @@
     {
       "id": "console.oauth.user-binding",
       "title": "Bind OAuth service and user objects onto helper instances",
-      "title_zh": "\u5c06 OAuth \u670d\u52a1\u548c\u7528\u6237\u5bf9\u8c61\u7ed1\u5b9a\u5230 helper \u5b9e\u4f8b",
+      "title_zh": "将 OAuth 服务和用户对象绑定到 helper 实例",
       "interface_type": "workflow",
       "interface": "console.utils.oauth.base.oauth.OAuth2Interface.set_oauth_user",
       "code_paths": [
@@ -6283,7 +6283,7 @@
     {
       "id": "console.package-component.auto-create-flow",
       "title": "Run full package component auto-create flow",
-      "title_zh": "\u6267\u884c\u5236\u54c1\u5305\u7ec4\u4ef6\u81ea\u52a8\u521b\u5efa\u5168\u6d41\u7a0b",
+      "title_zh": "执行制品包组件自动创建全流程",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6301,7 +6301,7 @@
     {
       "id": "console.package-component.check-request-failure",
       "title": "Reject package component creation when check request fails",
-      "title_zh": "\u5236\u54c1\u5305\u7ec4\u4ef6\u68c0\u6d4b\u8bf7\u6c42\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "制品包组件检测请求失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6319,7 +6319,7 @@
     {
       "id": "console.package-component.deploy-failure",
       "title": "Reject package component creation when deploy fails",
-      "title_zh": "\u5236\u54c1\u5305\u7ec4\u4ef6\u90e8\u7f72\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "制品包组件部署失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6337,7 +6337,7 @@
     {
       "id": "console.package-component.duplicate-name-guard",
       "title": "Reject duplicate k8s component name during package component creation",
-      "title_zh": "\u5236\u54c1\u5305\u7ec4\u4ef6\u521b\u5efa\u65f6\u62e6\u622a\u91cd\u590d\u82f1\u6587\u540d",
+      "title_zh": "制品包组件创建时拦截重复英文名",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6355,7 +6355,7 @@
     {
       "id": "console.package-component.multi-service-guard",
       "title": "Reject multi-service package detection in single-component flow",
-      "title_zh": "\u5355\u7ec4\u4ef6\u6d41\u7a0b\u4e2d\u62e6\u622a\u591a\u7ec4\u4ef6\u5236\u54c1\u5305\u68c0\u6d4b\u7ed3\u679c",
+      "title_zh": "单组件流程中拦截多组件制品包检测结果",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6373,7 +6373,7 @@
     {
       "id": "console.package-component.require-upload-record",
       "title": "Require upload record before package component creation",
-      "title_zh": "\u521b\u5efa\u5236\u54c1\u5305\u7ec4\u4ef6\u524d\u5fc5\u987b\u5b58\u5728\u4e0a\u4f20\u8bb0\u5f55",
+      "title_zh": "创建制品包组件前必须存在上传记录",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6391,7 +6391,7 @@
     {
       "id": "console.package-component.upload-missing",
       "title": "Reject package component creation when uploaded package list is empty",
-      "title_zh": "\u5236\u54c1\u5305\u5217\u8868\u4e3a\u7a7a\u65f6\u62e6\u622a\u7ec4\u4ef6\u521b\u5efa",
+      "title_zh": "制品包列表为空时拦截组件创建",
       "interface_type": "workflow",
       "interface": "console.services.package_component_service.auto_create_component",
       "code_paths": [
@@ -6643,7 +6643,7 @@
     {
       "id": "console.platform-plugin.vm-access-url-fallback",
       "title": "Fallback official VM plugin access URL from frontend component",
-      "title_zh": "\u4ece\u524d\u7aef\u7ec4\u4ef6\u8bbf\u95ee\u5730\u5740\u56de\u586b\u5b98\u65b9\u865a\u62df\u673a\u63d2\u4ef6\u8bbf\u95ee\u524d\u7f00",
+      "title_zh": "从前端组件访问地址回填官方虚拟机插件访问前缀",
       "interface_type": "service_method",
       "interface": "console.services.plugin_service.RainbondPluginService.list_plugins",
       "code_paths": [
@@ -6661,7 +6661,7 @@
     {
       "id": "console.platform-plugin.vm-runtime-status-guard",
       "title": "Guard VM plugin runtime status",
-      "title_zh": "\u6821\u9a8c\u865a\u62df\u673a\u5e73\u53f0\u63d2\u4ef6\u8fd0\u884c\u72b6\u6001",
+      "title_zh": "校验虚拟机平台插件运行状态",
       "interface_type": "service_method",
       "interface": "console.services.platform_plugin_service.PlatformPluginService.ensure_vm_plugin_running",
       "code_paths": [
@@ -6741,7 +6741,7 @@
     {
       "id": "console.random.default-version",
       "title": "Generate default random version identifiers",
-      "title_zh": "\u751f\u6210\u9ed8\u8ba4\u968f\u673a\u7248\u672c\u6807\u8bc6",
+      "title_zh": "生成默认随机版本标识",
       "interface_type": "workflow",
       "interface": "console.utils.randomutil.make_default_version",
       "code_paths": [
@@ -6777,7 +6777,7 @@
     {
       "id": "console.region-api.domain-conflict-msg",
       "title": "Preserve upstream domain conflict as actionable 409",
-      "title_zh": "\u5c06\u4e0a\u6e38\u57df\u540d\u51b2\u7a81\u4fdd\u7559\u4e3a\u53ef\u64cd\u4f5c\u7684 409 \u9519\u8bef\u63d0\u793a",
+      "title_zh": "将上游域名冲突保留为可操作的 409 错误提示",
       "interface_type": "workflow",
       "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
       "code_paths": [
@@ -6795,7 +6795,7 @@
     {
       "id": "console.region-api.helm-resource-conflict-msg",
       "title": "Translate helm ownership conflict into actionable error",
-      "title_zh": "\u5c06 Helm \u8d44\u6e90\u5f52\u5c5e\u51b2\u7a81\u8f6c\u6362\u4e3a\u53ef\u64cd\u4f5c\u9519\u8bef\u63d0\u793a",
+      "title_zh": "将 Helm 资源归属冲突转换为可操作错误提示",
       "interface_type": "workflow",
       "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
       "code_paths": [
@@ -6813,7 +6813,7 @@
     {
       "id": "console.region-api.proxy-error-pass-through",
       "title": "Keep original upstream error message for non-helm conflicts",
-      "title_zh": "\u5bf9\u975e Helm \u51b2\u7a81\u4fdd\u7559\u539f\u59cb\u4e0a\u6e38\u9519\u8bef\u4fe1\u606f",
+      "title_zh": "对非 Helm 冲突保留原始上游错误信息",
       "interface_type": "workflow",
       "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
       "code_paths": [
@@ -6831,7 +6831,7 @@
     {
       "id": "console.request-args.bool-coercion",
       "title": "Coerce request boolean arguments from strings and booleans",
-      "title_zh": "\u5c06\u8bf7\u6c42\u4e2d\u7684\u5e03\u5c14\u53c2\u6570\u4ece\u5b57\u7b26\u4e32\u6216\u5e03\u5c14\u503c\u5b89\u5168\u8f6c\u6362",
+      "title_zh": "将请求中的布尔参数从字符串或布尔值安全转换",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.bool_argument",
       "code_paths": [
@@ -6849,7 +6849,7 @@
     {
       "id": "console.request-args.bool-default-false",
       "title": "Return a false default for missing boolean query parameters",
-      "title_zh": "\u7f3a\u5931\u5e03\u5c14\u67e5\u8be2\u53c2\u6570\u65f6\u8fd4\u56de false \u9ed8\u8ba4\u503c",
+      "title_zh": "缺失布尔查询参数时返回 false 默认值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6867,7 +6867,7 @@
     {
       "id": "console.request-args.bool-default-true",
       "title": "Use true as default boolean request arg",
-      "title_zh": "\u4e3a\u5e03\u5c14\u67e5\u8be2\u53c2\u6570\u4f7f\u7528 true \u9ed8\u8ba4\u503c",
+      "title_zh": "为布尔查询参数使用 true 默认值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6885,7 +6885,7 @@
     {
       "id": "console.request-args.bool-invalid",
       "title": "Reject invalid boolean request arg values",
-      "title_zh": "\u62d2\u7edd\u975e\u6cd5\u5e03\u5c14\u67e5\u8be2\u53c2\u6570\u503c",
+      "title_zh": "拒绝非法布尔查询参数值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6903,7 +6903,7 @@
     {
       "id": "console.request-args.bool-parse",
       "title": "Parse boolean request arg from query string",
-      "title_zh": "\u89e3\u6790\u5e03\u5c14\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "解析布尔查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6921,7 +6921,7 @@
     {
       "id": "console.request-args.data-parse",
       "title": "Parse request data payloads with defaults and required guards",
-      "title_zh": "\u89e3\u6790\u8bf7\u6c42 data \u8f7d\u8377\u5e76\u5904\u7406\u9ed8\u8ba4\u503c\u4e0e\u5fc5\u586b\u6821\u9a8c",
+      "title_zh": "解析请求 data 载荷并处理默认值与必填校验",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -6939,7 +6939,7 @@
     {
       "id": "console.request-args.default-type-error",
       "title": "Reject mismatched request arg default type",
-      "title_zh": "\u62d2\u7edd\u7c7b\u578b\u4e0d\u5339\u914d\u7684\u9ed8\u8ba4\u8bf7\u6c42\u53c2\u6570",
+      "title_zh": "拒绝类型不匹配的默认请求参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6957,7 +6957,7 @@
     {
       "id": "console.request-args.int-missing",
       "title": "Return none when integer request arg is missing",
-      "title_zh": "\u6574\u578b\u67e5\u8be2\u53c2\u6570\u7f3a\u5931\u65f6\u8fd4\u56de\u7a7a\u503c",
+      "title_zh": "整型查询参数缺失时返回空值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6975,7 +6975,7 @@
     {
       "id": "console.request-args.int-parse",
       "title": "Parse integer request arg from query string",
-      "title_zh": "\u89e3\u6790\u6574\u578b\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "解析整型查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -6993,7 +6993,7 @@
     {
       "id": "console.request-args.int-required",
       "title": "Require integer request arg",
-      "title_zh": "\u8981\u6c42\u63d0\u4f9b\u6574\u578b\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "要求提供整型查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7011,7 +7011,7 @@
     {
       "id": "console.request-args.int-required-missing",
       "title": "Reject missing required integer request arg",
-      "title_zh": "\u62d2\u7edd\u7f3a\u5931\u7684\u5fc5\u586b\u6574\u578b\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "拒绝缺失的必填整型查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7029,7 +7029,7 @@
     {
       "id": "console.request-args.list-default-fallback",
       "title": "Return list defaults for missing multi-value query parameters",
-      "title_zh": "\u7f3a\u5931\u591a\u503c\u67e5\u8be2\u53c2\u6570\u65f6\u8fd4\u56de\u5217\u8868\u9ed8\u8ba4\u503c",
+      "title_zh": "缺失多值查询参数时返回列表默认值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7047,7 +7047,7 @@
     {
       "id": "console.request-args.list-missing",
       "title": "Return none when list request arg is missing",
-      "title_zh": "\u5217\u8868\u67e5\u8be2\u53c2\u6570\u7f3a\u5931\u65f6\u8fd4\u56de\u7a7a\u503c",
+      "title_zh": "列表查询参数缺失时返回空值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7065,7 +7065,7 @@
     {
       "id": "console.request-args.list-parse",
       "title": "Parse repeated request arg values as list",
-      "title_zh": "\u5c06\u91cd\u590d\u67e5\u8be2\u53c2\u6570\u89e3\u6790\u4e3a\u5217\u8868",
+      "title_zh": "将重复查询参数解析为列表",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7083,7 +7083,7 @@
     {
       "id": "console.request-args.list-required",
       "title": "Require list request arg",
-      "title_zh": "\u8981\u6c42\u63d0\u4f9b\u5217\u8868\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "要求提供列表查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7101,7 +7101,7 @@
     {
       "id": "console.request-args.list-required-missing",
       "title": "Reject missing required list request arg",
-      "title_zh": "\u62d2\u7edd\u7f3a\u5931\u7684\u5fc5\u586b\u5217\u8868\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "拒绝缺失的必填列表查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7119,7 +7119,7 @@
     {
       "id": "console.request-args.parse-args-keep-falsy",
       "title": "Keep falsy query parameter values when parsing argument maps",
-      "title_zh": "\u89e3\u6790\u67e5\u8be2\u53c2\u6570\u6620\u5c04\u65f6\u4fdd\u7559 falsy \u503c",
+      "title_zh": "解析查询参数映射时保留 falsy 值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_args",
       "code_paths": [
@@ -7137,7 +7137,7 @@
     {
       "id": "console.request-args.parse-batch",
       "title": "Parse configured request query args in batch",
-      "title_zh": "\u6309\u914d\u7f6e\u6279\u91cf\u89e3\u6790\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "按配置批量解析查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_args",
       "code_paths": [
@@ -7155,7 +7155,7 @@
     {
       "id": "console.request-args.query-parse",
       "title": "Parse query string arguments into typed values",
-      "title_zh": "\u5c06\u67e5\u8be2\u5b57\u7b26\u4e32\u53c2\u6570\u89e3\u6790\u4e3a\u5e26\u7c7b\u578b\u7684\u503c",
+      "title_zh": "将查询字符串参数解析为带类型的值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7173,7 +7173,7 @@
     {
       "id": "console.request-args.string-parse",
       "title": "Parse string request arg from query string",
-      "title_zh": "\u89e3\u6790\u5b57\u7b26\u4e32\u67e5\u8be2\u53c2\u6570",
+      "title_zh": "解析字符串查询参数",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7191,7 +7191,7 @@
     {
       "id": "console.request-args.type-error",
       "title": "Reject unsupported request arg type",
-      "title_zh": "\u62d2\u7edd\u4e0d\u652f\u6301\u7684\u8bf7\u6c42\u53c2\u6570\u7c7b\u578b",
+      "title_zh": "拒绝不支持的请求参数类型",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_argument",
       "code_paths": [
@@ -7209,7 +7209,7 @@
     {
       "id": "console.request-data.dict-parse",
       "title": "Parse request item from plain dict payload",
-      "title_zh": "\u4ece\u5b57\u5178\u8bf7\u6c42\u4f53\u4e2d\u89e3\u6790\u5b57\u6bb5",
+      "title_zh": "从字典请求体中解析字段",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -7227,7 +7227,7 @@
     {
       "id": "console.request-data.item-parse",
       "title": "Parse single request data item",
-      "title_zh": "\u89e3\u6790\u5355\u4e2a\u8bf7\u6c42\u4f53\u5b57\u6bb5",
+      "title_zh": "解析单个请求体字段",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -7245,7 +7245,7 @@
     {
       "id": "console.request-data.item-required",
       "title": "Require single request data item",
-      "title_zh": "\u8981\u6c42\u63d0\u4f9b\u5355\u4e2a\u8bf7\u6c42\u4f53\u5b57\u6bb5",
+      "title_zh": "要求提供单个请求体字段",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -7263,7 +7263,7 @@
     {
       "id": "console.request-data.item-required-missing",
       "title": "Reject missing required request data item",
-      "title_zh": "\u62d2\u7edd\u7f3a\u5931\u7684\u5fc5\u586b\u8bf7\u6c42\u4f53\u5b57\u6bb5",
+      "title_zh": "拒绝缺失的必填请求体字段",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -7281,7 +7281,7 @@
     {
       "id": "console.request-data.parse-batch",
       "title": "Parse batch request data payload",
-      "title_zh": "\u6279\u91cf\u89e3\u6790\u8bf7\u6c42\u4f53\u6570\u636e",
+      "title_zh": "批量解析请求体数据",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_date",
       "code_paths": [
@@ -7299,7 +7299,7 @@
     {
       "id": "console.request-data.parse-date-keep-falsy",
       "title": "Keep falsy request data values when parsing payload maps",
-      "title_zh": "\u89e3\u6790\u8bf7\u6c42 data \u6620\u5c04\u65f6\u4fdd\u7559 falsy \u503c",
+      "title_zh": "解析请求 data 映射时保留 falsy 值",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_date",
       "code_paths": [
@@ -7317,7 +7317,7 @@
     {
       "id": "console.request-data.required-default-error",
       "title": "Raise the default required-field error for missing request data",
-      "title_zh": "\u7f3a\u5931\u8bf7\u6c42 data \u65f6\u629b\u51fa\u9ed8\u8ba4\u5fc5\u586b\u5b57\u6bb5\u9519\u8bef",
+      "title_zh": "缺失请求 data 时抛出默认必填字段错误",
       "interface_type": "workflow",
       "interface": "console.utils.reqparse.parse_item",
       "code_paths": [
@@ -7335,7 +7335,7 @@
     {
       "id": "console.resource-center.pod-logs",
       "title": "View resource center pod logs",
-      "title_zh": "\u67e5\u770b\u8d44\u6e90\u4e2d\u5fc3 Pod \u65e5\u5fd7",
+      "title_zh": "查看资源中心 Pod 日志",
       "interface_type": "view_endpoint",
       "interface": "console.views.team_resources.ResourceCenterPodLogsView.get",
       "code_paths": [
@@ -7366,7 +7366,7 @@
     {
       "id": "console.service-share.create-record",
       "title": "Create service share record",
-      "title_zh": "\u521b\u5efa\u7ec4\u4ef6\u5171\u4eab\u8bb0\u5f55",
+      "title_zh": "创建组件共享记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.service_share.ServiceShareRecordView.post",
       "code_paths": [
@@ -7385,7 +7385,7 @@
     {
       "id": "console.service-share.create-snapshot-record",
       "title": "Create snapshot-based service share record",
-      "title_zh": "\u521b\u5efa\u57fa\u4e8e\u5feb\u7167\u7684\u670d\u52a1\u5206\u4eab\u8bb0\u5f55",
+      "title_zh": "创建基于快照的服务分享记录",
       "interface_type": "view_endpoint",
       "interface": "console.views.service_share.ServiceShareRecordView.post",
       "code_paths": [
@@ -7404,7 +7404,7 @@
     {
       "id": "console.service-share.error-response",
       "title": "Return service share error response for unexpected failure",
-      "title_zh": "\u670d\u52a1\u5206\u4eab\u5f02\u5e38\u65f6\u8fd4\u56de\u9519\u8bef\u54cd\u5e94",
+      "title_zh": "服务分享异常时返回错误响应",
       "interface_type": "view_endpoint",
       "interface": "console.views.service_share.ServiceShareRecordView.post",
       "code_paths": [
@@ -7422,7 +7422,7 @@
     {
       "id": "console.service-share.local-app-versions",
       "title": "List team local app versions for service sharing",
-      "title_zh": "\u5217\u51fa\u56e2\u961f\u672c\u5730\u53ef\u5206\u4eab\u5e94\u7528\u7248\u672c",
+      "title_zh": "列出团队本地可分享应用版本",
       "interface_type": "workflow",
       "interface": "console.services.share_services.ShareService.get_team_local_apps_versions",
       "code_paths": [
@@ -7440,7 +7440,7 @@
     {
       "id": "console.service-share.resolve-last-shared-app",
       "title": "Resolve last shared app and preferred version",
-      "title_zh": "\u89e3\u6790\u6700\u8fd1\u4e00\u6b21\u5206\u4eab\u7684\u5e94\u7528\u7248\u672c",
+      "title_zh": "解析最近一次分享的应用版本",
       "interface_type": "workflow",
       "interface": "console.services.share_services.ShareService.get_last_shared_app_and_app_list",
       "code_paths": [
@@ -7458,7 +7458,7 @@
     {
       "id": "console.service-share.stopped-component-publish",
       "title": "Allow stopped component publish",
-      "title_zh": "\u5141\u8bb8\u5df2\u505c\u6b62\u7ec4\u4ef6\u53d1\u5e03",
+      "title_zh": "允许已停止组件发布",
       "interface_type": "service_method",
       "interface": "console.services.share_services.ShareService.check_service_source",
       "code_paths": [
@@ -7476,7 +7476,7 @@
     {
       "id": "console.service-share.view-info",
       "title": "View service share details",
-      "title_zh": "\u67e5\u770b\u7ec4\u4ef6\u5171\u4eab\u8be6\u60c5",
+      "title_zh": "查看组件共享详情",
       "interface_type": "view_endpoint",
       "interface": "console.views.service_share.ServiceShareInfoView.get",
       "code_paths": [
@@ -7495,7 +7495,7 @@
     {
       "id": "console.service-share.view-snapshot-info",
       "title": "View shared snapshot template payload",
-      "title_zh": "\u67e5\u770b\u5206\u4eab\u5feb\u7167\u8be6\u60c5",
+      "title_zh": "查看分享快照详情",
       "interface_type": "view_endpoint",
       "interface": "console.views.service_share.ServiceShareInfoView.get",
       "code_paths": [
@@ -7514,7 +7514,7 @@
     {
       "id": "console.service-share.vm-qcow2-publish",
       "title": "Publish VM root disk as qcow2 image source",
-      "title_zh": "\u5c06\u865a\u62df\u673a\u7cfb\u7edf\u76d8\u53d1\u5e03\u4e3a qcow2 \u955c\u50cf\u6e90",
+      "title_zh": "将虚拟机系统盘发布为 qcow2 镜像源",
       "interface_type": "workflow",
       "interface": "console.services.share_services.ShareService.sync_event",
       "code_paths": [
@@ -7545,7 +7545,7 @@
     {
       "id": "console.service-share.vm-shutdown-guard",
       "title": "VM publish shutdown guard",
-      "title_zh": "\u865a\u62df\u673a\u53d1\u5e03\u5173\u673a\u9650\u5236",
+      "title_zh": "虚拟机发布关机限制",
       "interface_type": "service_method",
       "interface": "console.services.share_services.ShareService.check_service_source",
       "code_paths": [
@@ -7563,7 +7563,7 @@
     {
       "id": "console.source-component.auto-create-flow",
       "title": "Run full source component auto-create flow",
-      "title_zh": "\u6267\u884c\u6e90\u7801\u7ec4\u4ef6\u81ea\u52a8\u521b\u5efa\u5168\u6d41\u7a0b",
+      "title_zh": "执行源码组件自动创建全流程",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7581,7 +7581,7 @@
     {
       "id": "console.source-component.build-config-error",
       "title": "Raise when applying default source build config fails",
-      "title_zh": "\u5e94\u7528\u9ed8\u8ba4\u6e90\u7801\u6784\u5efa\u914d\u7f6e\u5931\u8d25\u65f6\u629b\u9519",
+      "title_zh": "应用默认源码构建配置失败时抛错",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.apply_default_build_config",
       "code_paths": [
@@ -7599,7 +7599,7 @@
     {
       "id": "console.source-component.check-failure",
       "title": "Abort source component auto-create when detection fails",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u68c0\u6d4b\u5931\u8d25\u65f6\u4e2d\u6b62\u521b\u5efa",
+      "title_zh": "源码组件检测失败时中止创建",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7617,7 +7617,7 @@
     {
       "id": "console.source-component.check-poll-failure",
       "title": "Raise first check error when source component detection fails",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u68c0\u6d4b\u5931\u8d25\u65f6\u8fd4\u56de\u9996\u4e2a\u9519\u8bef",
+      "title_zh": "源码组件检测失败时返回首个错误",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service._wait_for_check_result",
       "code_paths": [
@@ -7635,7 +7635,7 @@
     {
       "id": "console.source-component.check-poll-success",
       "title": "Retry source component check until success",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u68c0\u6d4b\u8f6e\u8be2\u76f4\u5230\u6210\u529f",
+      "title_zh": "源码组件检测轮询直到成功",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service._wait_for_check_result",
       "code_paths": [
@@ -7653,7 +7653,7 @@
     {
       "id": "console.source-component.check-request-failure",
       "title": "Reject source component creation when check request fails",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u68c0\u6d4b\u8bf7\u6c42\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "源码组件检测请求失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7689,7 +7689,7 @@
     {
       "id": "console.source-component.deploy-failure",
       "title": "Reject source component creation when deploy fails",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u90e8\u7f72\u5931\u8d25\u65f6\u62e6\u622a\u521b\u5efa",
+      "title_zh": "源码组件部署失败时拦截创建",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7707,7 +7707,7 @@
     {
       "id": "console.source-component.detect-server-type",
       "title": "Detect source repository server type",
-      "title_zh": "\u8bc6\u522b\u6e90\u7801\u4ed3\u5e93\u670d\u52a1\u7c7b\u578b",
+      "title_zh": "识别源码仓库服务类型",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.infer_server_type",
       "code_paths": [
@@ -7725,7 +7725,7 @@
     {
       "id": "console.source-component.duplicate-name-guard",
       "title": "Reject duplicate k8s component name during source component creation",
-      "title_zh": "\u6e90\u7801\u7ec4\u4ef6\u521b\u5efa\u65f6\u62e6\u622a\u91cd\u590d\u82f1\u6587\u540d",
+      "title_zh": "源码组件创建时拦截重复英文名",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7743,7 +7743,7 @@
     {
       "id": "console.source-component.invalid-server-type",
       "title": "Reject unsupported source repository server type",
-      "title_zh": "\u62e6\u622a\u4e0d\u652f\u6301\u7684\u6e90\u7801\u4ed3\u5e93\u670d\u52a1\u7c7b\u578b",
+      "title_zh": "拦截不支持的源码仓库服务类型",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.infer_server_type",
       "code_paths": [
@@ -7761,7 +7761,7 @@
     {
       "id": "console.source-component.multi-service-guard",
       "title": "Reject multi-service source detection in single-component flow",
-      "title_zh": "\u5355\u7ec4\u4ef6\u6d41\u7a0b\u4e2d\u62e6\u622a\u591a\u7ec4\u4ef6\u6e90\u7801\u68c0\u6d4b\u7ed3\u679c",
+      "title_zh": "单组件流程中拦截多组件源码检测结果",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.auto_create_component",
       "code_paths": [
@@ -7779,7 +7779,7 @@
     {
       "id": "console.source-component.normalize-code-source",
       "title": "Normalize generic git source into supported code source",
-      "title_zh": "\u89c4\u8303\u5316\u6e90\u7801\u6765\u6e90\u7c7b\u578b",
+      "title_zh": "规范化源码来源类型",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.normalize_code_from",
       "code_paths": [
@@ -7797,7 +7797,7 @@
     {
       "id": "console.source-component.normalize-code-version",
       "title": "Normalize source code version by server type and version type",
-      "title_zh": "\u6309\u6765\u6e90\u7c7b\u578b\u89c4\u8303\u5316\u6e90\u7801\u7248\u672c",
+      "title_zh": "按来源类型规范化源码版本",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.normalize_code_version",
       "code_paths": [
@@ -7815,7 +7815,7 @@
     {
       "id": "console.source-component.normalize-git-url",
       "title": "Append source subdirectory to git url once",
-      "title_zh": "\u4e3a Git \u5730\u5740\u8ffd\u52a0\u4e00\u6b21\u5b50\u76ee\u5f55\u53c2\u6570",
+      "title_zh": "为 Git 地址追加一次子目录参数",
       "interface_type": "workflow",
       "interface": "console.services.source_component_service.normalize_git_url",
       "code_paths": [
@@ -7869,7 +7869,7 @@
     {
       "id": "console.timeutil.current-date-str",
       "title": "Return the current date formatted with the default date format",
-      "title_zh": "\u8fd4\u56de\u9ed8\u8ba4\u683c\u5f0f\u7684\u5f53\u524d\u65e5\u671f\u5b57\u7b26\u4e32",
+      "title_zh": "返回默认格式的当前日期字符串",
       "interface_type": "workflow",
       "interface": "console.utils.timeutil.current_time_to_str",
       "code_paths": [
@@ -7887,7 +7887,7 @@
     {
       "id": "console.timeutil.current-time",
       "title": "Return the current datetime object",
-      "title_zh": "\u8fd4\u56de\u5f53\u524d datetime \u5bf9\u8c61",
+      "title_zh": "返回当前 datetime 对象",
       "interface_type": "workflow",
       "interface": "console.utils.timeutil.current_time",
       "code_paths": [
@@ -7905,7 +7905,7 @@
     {
       "id": "console.timeutil.current-time-str",
       "title": "Return the current datetime formatted as a default timestamp string",
-      "title_zh": "\u8fd4\u56de\u683c\u5f0f\u5316\u7684\u5f53\u524d\u65f6\u95f4\u5b57\u7b26\u4e32",
+      "title_zh": "返回格式化的当前时间字符串",
       "interface_type": "workflow",
       "interface": "console.utils.timeutil.current_time_str",
       "code_paths": [
@@ -7923,7 +7923,7 @@
     {
       "id": "console.timeutil.format",
       "title": "Format datetime objects into configured strings",
-      "title_zh": "\u5c06 datetime \u5bf9\u8c61\u683c\u5f0f\u5316\u4e3a\u6307\u5b9a\u5b57\u7b26\u4e32",
+      "title_zh": "将 datetime 对象格式化为指定字符串",
       "interface_type": "workflow",
       "interface": "console.utils.timeutil.time_to_str",
       "code_paths": [
@@ -7941,7 +7941,7 @@
     {
       "id": "console.timeutil.parse",
       "title": "Parse formatted time strings into datetime objects",
-      "title_zh": "\u5c06\u683c\u5f0f\u5316\u65f6\u95f4\u5b57\u7b26\u4e32\u89e3\u6790\u4e3a datetime \u5bf9\u8c61",
+      "title_zh": "将格式化时间字符串解析为 datetime 对象",
       "interface_type": "workflow",
       "interface": "console.utils.timeutil.str_to_time",
       "code_paths": [
@@ -7959,7 +7959,7 @@
     {
       "id": "console.tool-visibility.enterprise-admin",
       "title": "Expose enterprise admin toolset",
-      "title_zh": "\u5411\u4f01\u4e1a\u7ba1\u7406\u5458\u66b4\u9732\u7ba1\u7406\u5de5\u5177\u96c6",
+      "title_zh": "向企业管理员暴露管理工具集",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.list_tools[enterprise_admin]",
       "code_paths": [
@@ -7977,7 +7977,7 @@
     {
       "id": "console.tool-visibility.standard-user",
       "title": "Hide enterprise admin tools from standard user",
-      "title_zh": "\u5411\u666e\u901a\u7528\u6237\u9690\u85cf\u4f01\u4e1a\u7ba1\u7406\u5de5\u5177",
+      "title_zh": "向普通用户隐藏企业管理工具",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.list_tools[standard_user]",
       "code_paths": [
@@ -7995,7 +7995,7 @@
     {
       "id": "console.url.path-legal",
       "title": "Validate whether paths satisfy the URL path legality rule",
-      "title_zh": "\u6821\u9a8c\u8def\u5f84\u662f\u5426\u6ee1\u8db3 URL \u8def\u5f84\u5408\u6cd5\u6027\u89c4\u5219",
+      "title_zh": "校验路径是否满足 URL 路径合法性规则",
       "interface_type": "workflow",
       "interface": "console.utils.urlutil.is_path_legal",
       "code_paths": [
@@ -8013,7 +8013,7 @@
     {
       "id": "console.url.query-build",
       "title": "Build GET URLs from a base path and ordered parameters",
-      "title_zh": "\u6839\u636e\u57fa\u7840\u8def\u5f84\u548c\u53c2\u6570\u6784\u5efa GET URL",
+      "title_zh": "根据基础路径和参数构建 GET URL",
       "interface_type": "workflow",
       "interface": "console.utils.urlutil.set_get_url",
       "code_paths": [
@@ -8031,7 +8031,7 @@
     {
       "id": "console.url.query-empty",
       "title": "Build GET URLs even when no query params are provided",
-      "title_zh": "\u5373\u4f7f\u6ca1\u6709\u67e5\u8be2\u53c2\u6570\u4e5f\u80fd\u6784\u5efa GET URL",
+      "title_zh": "即使没有查询参数也能构建 GET URL",
       "interface_type": "workflow",
       "interface": "console.utils.urlutil.set_get_url",
       "code_paths": [
@@ -8049,7 +8049,7 @@
     {
       "id": "console.user.current-profile",
       "title": "View current user profile and enterprise role",
-      "title_zh": "\u67e5\u770b\u5f53\u524d\u7528\u6237\u8eab\u4efd\u4fe1\u606f",
+      "title_zh": "查看当前用户身份信息",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.get_current_user",
       "code_paths": [
@@ -8067,7 +8067,7 @@
     {
       "id": "console.validation.display-name",
       "title": "Validate user-facing display names with Chinese alnum dash and underscore rules",
-      "title_zh": "\u6821\u9a8c\u7528\u6237\u5c55\u793a\u540d\u79f0\u7684\u4e2d\u82f1\u6587\u6570\u5b57\u4e0e\u8fde\u63a5\u7b26\u89c4\u5219",
+      "title_zh": "校验用户展示名称的中英文数字与连接符规则",
       "interface_type": "workflow",
       "interface": "console.utils.validation.validate_name",
       "code_paths": [
@@ -8085,7 +8085,7 @@
     {
       "id": "console.validation.k8s-qualified-name",
       "title": "Validate Kubernetes qualified resource names",
-      "title_zh": "\u6821\u9a8c Kubernetes \u5408\u6cd5\u8d44\u6e90\u540d\u79f0\u683c\u5f0f",
+      "title_zh": "校验 Kubernetes 合法资源名称格式",
       "interface_type": "workflow",
       "interface": "console.utils.validation.is_qualified_name",
       "code_paths": [
@@ -8103,7 +8103,7 @@
     {
       "id": "console.version.compare",
       "title": "Compare semantic-style version strings",
-      "title_zh": "\u6bd4\u8f83\u8bed\u4e49\u5316\u98ce\u683c\u7684\u7248\u672c\u5b57\u7b26\u4e32",
+      "title_zh": "比较语义化风格的版本字符串",
       "interface_type": "workflow",
       "interface": "console.utils.version.compare_version",
       "code_paths": [
@@ -8121,7 +8121,7 @@
     {
       "id": "console.version.newer-filter",
       "title": "Filter versions that are newer than the current version",
-      "title_zh": "\u7b5b\u9009\u51fa\u9ad8\u4e8e\u5f53\u524d\u7248\u672c\u7684\u65b0\u7248\u672c",
+      "title_zh": "筛选出高于当前版本的新版本",
       "interface_type": "workflow",
       "interface": "console.utils.version.get_new_versions",
       "code_paths": [
@@ -8139,7 +8139,7 @@
     {
       "id": "console.version.sort-desc",
       "title": "Sort version strings in descending order",
-      "title_zh": "\u6309\u964d\u5e8f\u6392\u5217\u7248\u672c\u5b57\u7b26\u4e32",
+      "title_zh": "按降序排列版本字符串",
       "interface_type": "workflow",
       "interface": "console.utils.version.sorted_versions",
       "code_paths": [
@@ -8157,7 +8157,7 @@
     {
       "id": "console.virtual-machine.platform-runtime-guard",
       "title": "Delegate VM platform runtime guard to platform plugin guard",
-      "title_zh": "\u865a\u62df\u673a\u5e73\u53f0\u8fd0\u884c\u72b6\u6001\u6821\u9a8c\u59d4\u6258\u5230\u5e73\u53f0\u63d2\u4ef6\u5b88\u536b",
+      "title_zh": "虚拟机平台运行状态校验委托到平台插件守卫",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.ensure_vm_platform_running",
       "code_paths": [
@@ -8175,7 +8175,7 @@
     {
       "id": "console.virtual-machine.registry-root-disk",
       "title": "Create VM with registry imported root disk",
-      "title_zh": "\u4f7f\u7528 registry \u5bfc\u5165\u7684\u7cfb\u7edf\u76d8\u521b\u5efa\u865a\u62df\u673a",
+      "title_zh": "使用 registry 导入的系统盘创建虚拟机",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.create_vm",
       "code_paths": [
@@ -8193,7 +8193,7 @@
     {
       "id": "console.vm-asset.delete-active-reference-guard",
       "title": "Delete VM asset only when active VM services reference it",
-      "title_zh": "\u4ec5\u5f53\u6d3b\u8dc3\u865a\u62df\u673a\u4ecd\u5f15\u7528\u65f6\u963b\u6b62\u5220\u9664\u955c\u50cf\u8d44\u4ea7",
+      "title_zh": "仅当活跃虚拟机仍引用时阻止删除镜像资产",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.delete_vm_image",
       "code_paths": [
@@ -8219,7 +8219,7 @@
     {
       "id": "console.vm-asset.incomplete-service-cleanup-preserves-ready-assets",
       "title": "Preserve ready VM assets when truncating incomplete VM services",
-      "title_zh": "\u5220\u9664\u672a\u5b8c\u6210\u865a\u62df\u673a\u7ec4\u4ef6\u65f6\u4fdd\u7559\u5df2\u5c31\u7eea\u955c\u50cf\u8d44\u4ea7",
+      "title_zh": "删除未完成虚拟机组件时保留已就绪镜像资产",
       "interface_type": "workflow",
       "interface": "console.services.app_actions.app_manage.AppManageService._truncate_service",
       "code_paths": [
@@ -8237,7 +8237,7 @@
     {
       "id": "console.vm-overview.vnc-url-plugin-fallback",
       "title": "Build VM overview VNC URL from plugin fallback",
-      "title_zh": "\u5728\u7f3a\u5c11\u67e5\u8be2\u53c2\u6570\u65f6\u4ece\u63d2\u4ef6\u56de\u586b\u865a\u62df\u673a\u6982\u89c8 VNC \u5730\u5740",
+      "title_zh": "在缺少查询参数时从插件回填虚拟机概览 VNC 地址",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_overview.AppDetailView.get",
       "code_paths": [
@@ -8273,7 +8273,7 @@
     {
       "id": "console.vm-run.platform-runtime-guard",
       "title": "Reject VM create when VM platform is unhealthy",
-      "title_zh": "\u865a\u62df\u673a\u5e73\u53f0\u5f02\u5e38\u65f6\u7981\u6b62\u521b\u5efa\u865a\u62df\u673a\u7ec4\u4ef6",
+      "title_zh": "虚拟机平台异常时禁止创建虚拟机组件",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_create.vm_run.VMRunCreateView.post",
       "code_paths": [
@@ -8291,7 +8291,7 @@
     {
       "id": "console.vm-storage-any-access-mode",
       "title": "Allow VM storage with any access mode",
-      "title_zh": "\u5141\u8bb8\u865a\u62df\u673a\u4f7f\u7528\u4efb\u610f\u8bbf\u95ee\u6a21\u5f0f\u7684\u5b58\u50a8",
+      "title_zh": "允许虚拟机使用任意访问模式的存储",
       "interface_type": "service_method",
       "interface": "console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings",
       "code_paths": [
@@ -8373,7 +8373,7 @@
     {
       "id": "rainbond-console.vm-disks.iso-installer-compat",
       "title": "Expose installer media for ISO VM disks when runtime hints are incomplete",
-      "title_zh": "\u5f53 VM \u8fd0\u884c\u65f6\u63d0\u793a\u4e0d\u5b8c\u6574\u65f6\u4ecd\u4e3a ISO \u865a\u62df\u673a\u78c1\u76d8\u5217\u8868\u8865\u51fa\u5b89\u88c5\u5149\u76d8",
+      "title_zh": "当 VM 运行时提示不完整时仍为 ISO 虚拟机磁盘列表补出安装光盘",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.list_vm_disks",
       "code_paths": [
@@ -8395,7 +8395,7 @@
     {
       "id": "rainbond-console.vm-run.disk-asset-create",
       "title": "Reuse ready runtime image when creating vm from existing disk asset",
-      "title_zh": "\u4ece\u73b0\u6709\u78c1\u76d8\u8d44\u4ea7\u521b\u5efa\u865a\u62df\u673a\u65f6\u590d\u7528\u5df2\u5c31\u7eea\u8fd0\u884c\u65f6\u955c\u50cf",
+      "title_zh": "从现有磁盘资产创建虚拟机时复用已就绪运行时镜像",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_create.vm_run.VMRunCreateView.post",
       "code_paths": [
@@ -8481,7 +8481,7 @@
     {
       "id": "console.app-version.create-app-from-snapshot-invalid-name",
       "title": "create_app_from_snapshot_version rejects illegal target app name",
-      "title_zh": "\u4ece\u5feb\u7167\u7248\u672c\u521b\u5efa\u5e94\u7528\u65f6\u62d2\u7edd\u975e\u6cd5\u76ee\u6807\u5e94\u7528\u540d",
+      "title_zh": "从快照版本创建应用时拒绝非法目标应用名",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name]",
       "code_paths": [
@@ -8499,7 +8499,7 @@
     {
       "id": "console.app-version.target-app-name-schema",
       "title": "create_app_from_snapshot_version tool exposes target app name constraints",
-      "title_zh": "create_app_from_snapshot_version \u5de5\u5177\u66b4\u9732\u76ee\u6807\u5e94\u7528\u540d\u7ea6\u675f",
+      "title_zh": "create_app_from_snapshot_version 工具暴露目标应用名约束",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema]",
       "code_paths": [
@@ -8517,7 +8517,7 @@
     {
       "id": "console.app.restart-component-operation",
       "title": "operate_app restart maps to batch action",
-      "title_zh": "operate_app \u91cd\u542f\u6620\u5c04\u5230\u6279\u91cf\u64cd\u4f5c",
+      "title_zh": "operate_app 重启映射到批量操作",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.app.restart-component-operation]",
       "code_paths": [
@@ -8535,7 +8535,7 @@
     {
       "id": "console.component.autoscaler-invalid-metrics",
       "title": "manage_component_autoscaler rejects incomplete metric before service call",
-      "title_zh": "manage_component_autoscaler \u5728\u8c03\u7528\u670d\u52a1\u524d\u62d2\u7edd\u4e0d\u5b8c\u6574\u6307\u6807",
+      "title_zh": "manage_component_autoscaler 在调用服务前拒绝不完整指标",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics]",
       "code_paths": [
@@ -8553,7 +8553,7 @@
     {
       "id": "console.component.default-resource-spec",
       "title": "Component creation tools expose default resource guidance",
-      "title_zh": "\u7ec4\u4ef6\u521b\u5efa\u5de5\u5177\u66b4\u9732\u9ed8\u8ba4\u8d44\u6e90\u89c4\u683c\u6307\u5f15",
+      "title_zh": "组件创建工具暴露默认资源规格指引",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.list_tools[console.component.default-resource-spec]",
       "code_paths": [
@@ -8571,7 +8571,7 @@
     {
       "id": "console.component.port-batch-add",
       "title": "manage_component_ports batch add delegates to batch service",
-      "title_zh": "manage_component_ports \u6279\u91cf\u65b0\u589e\u59d4\u6258\u7ed9\u6279\u91cf\u670d\u52a1",
+      "title_zh": "manage_component_ports 批量新增委托给批量服务",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-add]",
       "code_paths": [
@@ -8589,7 +8589,7 @@
     {
       "id": "console.component.port-batch-enable-inner",
       "title": "manage_component_ports batch enable inner loads context once",
-      "title_zh": "manage_component_ports \u6279\u91cf\u5f00\u542f\u5185\u7f51\u7aef\u53e3\u53ea\u52a0\u8f7d\u4e00\u6b21\u4e0a\u4e0b\u6587",
+      "title_zh": "manage_component_ports 批量开启内网端口只加载一次上下文",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner]",
       "code_paths": [
@@ -8607,7 +8607,7 @@
     {
       "id": "console.component.port-batch-enable-outer",
       "title": "manage_component_ports batch enable outer accepts integer items",
-      "title_zh": "manage_component_ports \u6279\u91cf\u5f00\u542f\u5916\u7f51\u7aef\u53e3\u63a5\u53d7\u6574\u6570\u9879",
+      "title_zh": "manage_component_ports 批量开启外网端口接受整数项",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer]",
       "code_paths": [
@@ -8625,7 +8625,7 @@
     {
       "id": "console.gateway.create-app-invalid-display-name",
       "title": "create_app returns structured details for illegal app name",
-      "title_zh": "create_app \u5bf9\u975e\u6cd5\u5e94\u7528\u540d\u8fd4\u56de\u7ed3\u6784\u5316\u9519\u8bef\u8be6\u60c5",
+      "title_zh": "create_app 对非法应用名返回结构化错误详情",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name]",
       "code_paths": [
@@ -8643,7 +8643,7 @@
     {
       "id": "console.package-upload.local-path-create-schema",
       "title": "create_component_from_local_package tool schema exposes server-side local path guidance",
-      "title_zh": "create_component_from_local_package \u5de5\u5177 schema \u66b4\u9732\u670d\u52a1\u7aef\u672c\u5730\u8def\u5f84\u6307\u5f15",
+      "title_zh": "create_component_from_local_package 工具 schema 暴露服务端本地路径指引",
       "interface_type": "workflow",
       "interface": "console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema]",
       "code_paths": [
@@ -8661,7 +8661,7 @@
     {
       "id": "console.mcp.http-expired-jwt",
       "title": "MCP HTTP endpoint returns 401 for expired JWT",
-      "title_zh": "MCP HTTP \u63a5\u53e3\u5bf9\u8fc7\u671f JWT \u8fd4\u56de 401",
+      "title_zh": "MCP HTTP 接口对过期 JWT 返回 401",
       "interface_type": "view_endpoint",
       "interface": "console.views.mcp_query.MCPQueryHTTPView.post",
       "code_paths": [
@@ -8679,7 +8679,7 @@
     {
       "id": "console.vm-root-disk-selected-storage-type",
       "title": "update_check_app uses selected storage type for new VM root disk",
-      "title_zh": "update_check_app \u4e3a\u65b0\u5efa\u865a\u62df\u673a\u6839\u76d8\u4f7f\u7528\u6240\u9009\u5b58\u50a8\u7c7b\u578b",
+      "title_zh": "update_check_app 为新建虚拟机根盘使用所选存储类型",
       "interface_type": "service_method",
       "interface": "console.services.app.AppService.update_check_app",
       "code_paths": [
@@ -8697,7 +8697,7 @@
     {
       "id": "rainbond-console.vm-live-migration-unique-disk-path",
       "title": "resolve_vm_volume_path allocates a unique disk path for VM live migration",
-      "title_zh": "resolve_vm_volume_path \u4e3a\u865a\u62df\u673a\u70ed\u8fc1\u79fb\u5206\u914d\u552f\u4e00\u78c1\u76d8\u8def\u5f84",
+      "title_zh": "resolve_vm_volume_path 为虚拟机热迁移分配唯一磁盘路径",
       "interface_type": "service_method",
       "interface": "console.services.app_config.volume_service.AppVolumeService.resolve_vm_volume_path",
       "code_paths": [
@@ -8719,7 +8719,7 @@
     {
       "id": "rainbond-console.vm-export.asset-ready-storage-status",
       "title": "VM asset readiness requires ready status and image url",
-      "title_zh": "\u865a\u62df\u673a\u8d44\u4ea7\u5c31\u7eea\u9700\u8981 ready \u72b6\u6001\u4e0e\u955c\u50cf\u5730\u5740",
+      "title_zh": "虚拟机资产就绪需要 ready 状态与镜像地址",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready",
       "code_paths": [
@@ -8736,7 +8736,7 @@
     {
       "id": "rainbond-console.vm-run.vm-export-ignore-stale-boot-mode",
       "title": "resolve_vm_boot_mode ignores stale asset boot mode for Windows ISO",
-      "title_zh": "resolve_vm_boot_mode \u5bf9 Windows ISO \u5ffd\u7565\u8fc7\u671f\u8d44\u4ea7\u542f\u52a8\u6a21\u5f0f",
+      "title_zh": "resolve_vm_boot_mode 对 Windows ISO 忽略过期资产启动模式",
       "interface_type": "service_method",
       "interface": "console.services.virtual_machine.VirtualMachineService.resolve_vm_boot_mode",
       "code_paths": [
@@ -8753,7 +8753,7 @@
     {
       "id": "rainbond-console.vm-run.vm-export-multi-disk-create",
       "title": "VM run create supports multi-disk asset instantiation",
-      "title_zh": "\u865a\u62df\u673a\u8fd0\u884c\u521b\u5efa\u652f\u6301\u591a\u78c1\u76d8\u8d44\u4ea7\u5b9e\u4f8b\u5316",
+      "title_zh": "虚拟机运行创建支持多磁盘资产实例化",
       "interface_type": "view_endpoint",
       "interface": "console.views.app_create.vm_run.VMRunCreateView.post",
       "code_paths": [
@@ -8770,7 +8770,7 @@
     {
       "id": "console.market-app.restore-preserves-volume-capacity-on-storage-fallback",
       "title": "Market restore preserves volume capacity when storage type falls back",
-      "title_zh": "\u5e02\u573a\u6062\u590d\u5728\u5b58\u50a8\u7c7b\u578b\u56de\u9000\u65f6\u4fdd\u7559\u5377\u5bb9\u91cf",
+      "title_zh": "市场恢复在存储类型回退时保留卷容量",
       "interface_type": "service_method",
       "interface": "console.services.market_app.new_components.NewComponents._template_to_volumes",
       "code_paths": [
@@ -8789,7 +8789,7 @@
     {
       "id": "console.market-app.restore-volume-capacity-helper",
       "title": "resolve_market_restore_volume_settings preserves capacity when storage type changes",
-      "title_zh": "resolve_market_restore_volume_settings \u5728\u5b58\u50a8\u7c7b\u578b\u53d8\u5316\u65f6\u4fdd\u7559\u5bb9\u91cf",
+      "title_zh": "resolve_market_restore_volume_settings 在存储类型变化时保留容量",
       "interface_type": "service_method",
       "interface": "console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings",
       "code_paths": [
@@ -8807,7 +8807,7 @@
     {
       "id": "console.package-upload.local-path-missing-details",
       "title": "_normalize_local_path raises structured details when path missing",
-      "title_zh": "_normalize_local_path \u5728\u8def\u5f84\u7f3a\u5931\u65f6\u629b\u51fa\u7ed3\u6784\u5316\u8be6\u60c5",
+      "title_zh": "_normalize_local_path 在路径缺失时抛出结构化详情",
       "interface_type": "service_method",
       "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
       "code_paths": [
@@ -8825,7 +8825,7 @@
     {
       "id": "console.package-upload.local-path-required-details",
       "title": "_normalize_local_path raises structured details when path empty",
-      "title_zh": "_normalize_local_path \u5728\u8def\u5f84\u4e3a\u7a7a\u65f6\u629b\u51fa\u7ed3\u6784\u5316\u8be6\u60c5",
+      "title_zh": "_normalize_local_path 在路径为空时抛出结构化详情",
       "interface_type": "service_method",
       "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
       "code_paths": [
@@ -8843,7 +8843,7 @@
     {
       "id": "console.enterprise-config.custom-fields-disabled-bool",
       "title": "get_custom_fields includes disabled bool fields",
-      "title_zh": "get_custom_fields \u5305\u542b\u88ab\u7981\u7528\u7684\u5e03\u5c14\u5b57\u6bb5",
+      "title_zh": "get_custom_fields 包含被禁用的布尔字段",
       "interface_type": "service_method",
       "interface": "console.services.config_service.EnterpriseConfigService.get_custom_fields",
       "code_paths": [
@@ -8861,7 +8861,7 @@
     {
       "id": "console.region-api.vm-snapshot-feature-gate-msg",
       "title": "_check_status translates VM snapshot feature gate error to actionable msg_show",
-      "title_zh": "_check_status \u5c06\u865a\u62df\u673a\u5feb\u7167\u529f\u80fd\u95e8\u7981\u9519\u8bef\u7ffb\u8bd1\u4e3a\u53ef\u64cd\u4f5c\u63d0\u793a",
+      "title_zh": "_check_status 将虚拟机快照功能门禁错误翻译为可操作提示",
       "interface_type": "service_method",
       "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
       "code_paths": [
@@ -8879,7 +8879,7 @@
     {
       "id": "console.vm-template-import.delete-abnormal-vm",
       "title": "delete allows abnormal VM to skip the running guard",
-      "title_zh": "delete \u5141\u8bb8\u5f02\u5e38\u72b6\u6001\u865a\u62df\u673a\u8df3\u8fc7\u8fd0\u884c\u4e2d\u6821\u9a8c",
+      "title_zh": "delete 允许异常状态虚拟机跳过运行中校验",
       "interface_type": "workflow",
       "interface": "console.services.app_actions.app_manage.AppManageService.delete",
       "code_paths": [
@@ -8949,7 +8949,7 @@
     {
       "id": "console.app.delete-with-resources",
       "title": "Delete application along with components and attached resources",
-      "title_zh": "\u5220\u9664\u5e94\u7528\u53ca\u5176\u7ec4\u4ef6\u4e0e\u5173\u8054\u8d44\u6e90",
+      "title_zh": "删除应用及其组件与关联资源",
       "interface_type": "service_method",
       "interface": "console.services.group_service.GroupService.delete_app_with_resources",
       "code_paths": [
@@ -8967,7 +8967,7 @@
     {
       "id": "console.test-manifest.ignore-worktrees",
       "title": "Ignore nested worktree tests during manifest validation",
-      "title_zh": "\u6d4b\u8bd5\u6e05\u5355\u6821\u9a8c\u5ffd\u7565\u5d4c\u5957 worktree \u6d4b\u8bd5",
+      "title_zh": "测试清单校验忽略嵌套 worktree 测试",
       "interface_type": "package_function",
       "interface": "scripts.validate_test_manifest.collect_marked_tests",
       "code_paths": [

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -3423,6 +3423,28 @@
       "status": "active"
     },
     {
+      "id": "console.component.build-source-update-image-cmd",
+      "title": "Component Build Source Update keeps/sets image start command",
+      "title_zh": "构建源更新保留/设置镜像启动命令",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.component.build-source-update-image-cmd]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_update_component_build_source_keeps_cmd_when_omitted_on_image_update"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_update_component_build_source_sets_cmd_and_syncs_docker_cmd"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.change-image",
       "title": "Change component image",
       "title_zh": "\u4fee\u6539\u7ec4\u4ef6\u955c\u50cf",


### PR DESCRIPTION
## 问题

rainagent 通过 MCP 创建/更新镜像组件时，启动命令不生效，agent 被迫删除重建组件（线上反馈：chatwoot 部署会话浪费 20+ 分钟反复试错）。

## 根因（三个叠加缺陷）

1. **创建时命令丢失**：MCP `create_component` 只把启动命令写入 `tenant_service.docker_cmd`。UI 流程靠 docker-run 检测阶段将其解析回填到 `service.cmd`，但 MCP 路径跳过检测直接部署，而 `create_region_service`（container_cmd）和 `deploy`（image_info.cmd）只读 `service.cmd` → 命令从未到达容器。线上可复现：经 MCP 创建的组件 `docker_cmd` 有值而 `cmd=NULL`。
2. **更新时静默清空**：`update_component_build_source` 中 `target_source != service.service_source` 时清空 cmd，但调用方传 `docker_run` 而库里存 `docker_image`，永不相等 → 任何不带 `cmd` 的镜像侧更新都会清掉启动命令。
3. **双字段误导 agent**：构建源 snapshot 同时返回 `cmd` 与 `docker_cmd`，agent 看到 `docker_cmd` 为空误判命令未生效，触发删建组件。

## 修复

- `create_component`：创建后将 `docker_cmd` 复制进 `service.cmd`
- `update_component_build_source`：仅在从 `source_code` 转出时清 cmd；显式传 `cmd` 时同步 `docker_cmd` 保持一致
- MCP 构建源 snapshot 隐藏 legacy `docker_cmd` 字段
- 新增 4 个回归测试并注册 test-manifest

## 测试

- [x] `console/tests/mcp_query_service_test.py` 162 passed（含 4 个新用例）
- [x] `scripts/validate_test_manifest.py` 校验通过
- [x] flake8 对改动行无新增告警