### PR TITLE
fix: persist dockerfile preference across check timeout and surface fallback

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -3462,6 +3462,11 @@ class MCPQueryService(object):
             self._require_string(arguments, "service_id"),
         )
         prefer_dockerfile_when_detected = bool(arguments.get("prefer_dockerfile_when_detected", False))
+        if not prefer_dockerfile_when_detected:
+            # The create call persists the preference when detection outlives
+            # its synchronous wait window, so the caller does not need to
+            # re-pass the flag on this follow-up call.
+            prefer_dockerfile_when_detected = source_component_service.load_dockerfile_preference(team, service)
         check_uuid = arguments.get("check_uuid") or service.check_uuid
         if not check_uuid:
             raise ServiceHandleException(msg="check_uuid required", msg_show="参数check_uuid无效", status_code=400)
@@ -3469,6 +3474,8 @@ class MCPQueryService(object):
         if code != 200:
             raise ServiceHandleException(msg="get check result error", msg_show=msg, status_code=code)
 
+        dockerfile_preference_applied = None
+        build_mode_note = None
         if service.create_status == "complete":
             service_info = data.get("service_info")
             if not (service_info is not None and len(service_info) > 1 and service_info[0].get("language") == "Java-maven"):
@@ -3487,10 +3494,17 @@ class MCPQueryService(object):
                         service_info_list[0], True
                     )
                     data["service_info"] = service_info_list
+                    selected_language = (service_info_list[0].get("language") or "").strip()
+                    dockerfile_preference_applied = selected_language == "dockerfile"
+                    if not dockerfile_preference_applied:
+                        build_mode_note = source_component_service.build_unapplied_preference_note(selected_language)
                 app_check_service.save_service_check_info(team, app.ID, service, data)
             check_brief_info = app_check_service.wrap_service_check_info(service, data)
 
         return {
+            "prefer_dockerfile_when_detected": prefer_dockerfile_when_detected,
+            "dockerfile_preference_applied": dockerfile_preference_applied,
+            "build_mode_note": build_mode_note,
             "app_id": app.ID,
             "service_id": service.service_id,
             "check_uuid": check_uuid,
@@ -6737,6 +6751,9 @@ class MCPQueryService(object):
                             "仅 MCP 使用。重新检测后若结果同时命中 Dockerfile 和语言型构建方式，"
                             "优先选择 Dockerfile（与 create 时同名参数一致）。用于恢复路径强制 Dockerfile，"
                             "避免 CNB 不支持的语言/版本（如 .NET 7）卡死。默认 false。"
+                            "若 create 时已传 prefer_dockerfile_when_detected=true 且检测超时，"
+                            "偏好已持久化并自动应用，无需重传。响应中的 dockerfile_preference_applied/build_mode_note "
+                            "会说明偏好是否生效。"
                         )
                     }
                 },

--- a/console/services/source_component_service.py
+++ b/console/services/source_component_service.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 import time
 
 from console.constants import SourceCodeType
 from console.exception.main import ServiceHandleException
+from console.repositories.app import service_source_repo
 from console.repositories.deploy_repo import deploy_repo
 from console.services.app import app_service as console_app_service
 from console.services.app_actions import app_manage_service
@@ -21,6 +23,56 @@ class SourceComponentService(object):
     MAX_CHECK_RETRIES = 30
     CHECK_POLL_INTERVAL = 2
     VALID_SERVER_TYPES = ("git", "svn", "oss")
+    DOCKERFILE_PREFERENCE_KEY = "prefer_dockerfile_when_detected"
+
+    def persist_dockerfile_preference(self, team, service):
+        """Persist the Dockerfile build preference in service_source.extend_info.
+
+        Called when detection has not finished inside the create call (the
+        timeout/pending path), so the follow-up check-result call can re-apply
+        the preference without the caller re-passing the flag. Persistence
+        failures must never break component creation, so errors are swallowed
+        after logging.
+        """
+        try:
+            extend_info = self._load_source_extend_info(team, service)
+            extend_info[self.DOCKERFILE_PREFERENCE_KEY] = True
+            service_source_repo.update_or_create_service_source(
+                team_id=team.tenant_id,
+                service_id=service.service_id,
+                extend_info=json.dumps(extend_info, ensure_ascii=False),
+            )
+        except Exception:
+            logger.warning(
+                "persist dockerfile preference failed, service_id=%s", service.service_id, exc_info=True)
+
+    def load_dockerfile_preference(self, team, service):
+        """Read back the persisted Dockerfile build preference (default False)."""
+        try:
+            return bool(self._load_source_extend_info(team, service).get(self.DOCKERFILE_PREFERENCE_KEY, False))
+        except Exception:
+            logger.warning(
+                "load dockerfile preference failed, service_id=%s", service.service_id, exc_info=True)
+            return False
+
+    @staticmethod
+    def _load_source_extend_info(team, service):
+        source = service_source_repo.get_service_source(team.tenant_id, service.service_id)
+        if not source or not source.extend_info:
+            return {}
+        try:
+            extend_info = json.loads(source.extend_info)
+        except ValueError:
+            return {}
+        return extend_info if isinstance(extend_info, dict) else {}
+
+    @classmethod
+    def build_unapplied_preference_note(cls, selected_language):
+        return (
+            "已请求 Dockerfile 构建（prefer_dockerfile_when_detected=true），但代码检测未在构建目录根路径发现 Dockerfile，"
+            "已回退为 {} 语言构建。如需 Dockerfile 构建，请通过 subdirectories 指向包含 Dockerfile 的目录，"
+            "或改用镜像方式部署。".format(selected_language or "检测到的")
+        )
 
     def auto_create_component(
             self,
@@ -98,7 +150,20 @@ class SourceComponentService(object):
             )
         except ServiceHandleException as exc:
             if getattr(exc, "msg", "") == "check timeout":
+                build_mode_note = None
+                if prefer_dockerfile_when_detected:
+                    # Detection outlived the synchronous wait window (large
+                    # repos take minutes to clone), so persist the preference;
+                    # get_component_check_result reads it back and applies it
+                    # before persisting the detection result.
+                    self.persist_dockerfile_preference(team, component)
+                    build_mode_note = (
+                        "Dockerfile 构建偏好已持久化，检测完成后调用 rainbond_get_component_check_result 会自动应用，"
+                        "无需重新传递 prefer_dockerfile_when_detected。"
+                    )
                 return {
+                    "prefer_dockerfile_when_detected": bool(prefer_dockerfile_when_detected),
+                    "build_mode_note": build_mode_note,
                     "service_id": component.service_id,
                     "service_alias": getattr(component, "service_alias", ""),
                     "service_cname": getattr(component, "service_cname", service_cname),
@@ -129,11 +194,17 @@ class SourceComponentService(object):
             )
         selected_language = None
         detected_language_raw = None
+        dockerfile_preference_applied = None
+        build_mode_note = None
         if service_info_list:
             selected_service_info = self._select_service_info(service_info_list[0], prefer_dockerfile_when_detected)
             detected_language_raw = service_info_list[0].get("language")
             selected_language = selected_service_info.get("language")
             service_info_list[0] = selected_service_info
+            if prefer_dockerfile_when_detected:
+                dockerfile_preference_applied = selected_language == "dockerfile"
+                if not dockerfile_preference_applied:
+                    build_mode_note = self.build_unapplied_preference_note(selected_language)
             app_check_service.save_service_check_info(team, app.ID, component, bean)
             self.apply_default_build_config(team, component, selected_service_info)
 
@@ -162,6 +233,8 @@ class SourceComponentService(object):
             "is_deploy": bool(is_deploy),
             "detected_language_raw": detected_language_raw,
             "selected_language": selected_language or getattr(component, "language", ""),
+            "dockerfile_preference_applied": dockerfile_preference_applied,
+            "build_mode_note": build_mode_note,
             "built": True,
         }
 

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -5689,6 +5689,117 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.group_service.get_app_by_id")
     @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
     @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
+    @patch("console.services.mcp_query_service.app_check_service.get_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.save_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.wrap_service_check_info")
+    @patch("console.services.mcp_query_service.source_component_service.load_dockerfile_preference")
+    # capability_id: console.component.check-result
+    def test_get_component_check_result_applies_persisted_dockerfile_preference(
+            self,
+            mock_load_preference,
+            mock_wrap_check_info,
+            mock_save_check_info,
+            mock_get_check_info,
+            mock_relations,
+            mock_get_service,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        # The create call timed out on detection and persisted the Dockerfile
+        # preference; the follow-up check-result call must auto-apply it even
+        # when the caller does not re-pass prefer_dockerfile_when_detected.
+        self.service.service_source = "source_code"
+        self.service.create_status = "checked"
+        self.service.check_uuid = "chk-1"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_get_service.return_value = self.service
+        mock_relations.return_value = [Obj(service_id="svc-1")]
+        mock_load_preference.return_value = True
+        mock_get_check_info.return_value = (
+            200, "success",
+            {"check_status": "success", "error_infos": [],
+             "service_info": [{"language": "Go", "dockerfiles": ["Dockerfile"]}]},
+        )
+        captured = {}
+
+        def cap_save(team, app_id, service, data):
+            captured["data"] = data
+            service.create_status = "checked"
+
+        mock_save_check_info.side_effect = cap_save
+        mock_wrap_check_info.return_value = {"check_status": "success", "error_infos": [], "service_info": []}
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_get_component_check_result",
+            {"team_name": "demo-team", "region_name": "rainbond", "app_id": 12, "service_id": "svc-1"},
+        )
+
+        self.assertEqual(captured["data"]["service_info"][0]["language"], "dockerfile")
+        self.assertTrue(result["prefer_dockerfile_when_detected"])
+        self.assertTrue(result["dockerfile_preference_applied"])
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
+    @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
+    @patch("console.services.mcp_query_service.app_check_service.get_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.save_service_check_info")
+    @patch("console.services.mcp_query_service.app_check_service.wrap_service_check_info")
+    # capability_id: console.component.check-result
+    def test_get_component_check_result_reports_unapplied_dockerfile_preference(
+            self,
+            mock_wrap_check_info,
+            mock_save_check_info,
+            mock_get_check_info,
+            mock_relations,
+            mock_get_service,
+            mock_get_app,
+            mock_get_region,
+            mock_get_team,
+    ):
+        # The caller asked for a Dockerfile build but detection found no
+        # Dockerfile at the build root: the preference silently no-ops in
+        # _select_service_info, so the response must surface that fallback.
+        self.service.service_source = "source_code"
+        self.service.create_status = "checked"
+        self.service.check_uuid = "chk-1"
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_get_app.return_value = self.app
+        mock_get_service.return_value = self.service
+        mock_relations.return_value = [Obj(service_id="svc-1")]
+        mock_get_check_info.return_value = (
+            200, "success",
+            {"check_status": "success", "error_infos": [], "service_info": [{"language": "Go"}]},
+        )
+
+        def mark_checked(team, app_id, service, data):
+            service.create_status = "checked"
+
+        mock_save_check_info.side_effect = mark_checked
+        mock_wrap_check_info.return_value = {"check_status": "success", "error_infos": [], "service_info": []}
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_get_component_check_result",
+            {"team_name": "demo-team", "region_name": "rainbond", "app_id": 12,
+             "service_id": "svc-1", "prefer_dockerfile_when_detected": True},
+        )
+
+        self.assertTrue(result["prefer_dockerfile_when_detected"])
+        self.assertFalse(result["dockerfile_preference_applied"])
+        self.assertTrue(result["build_mode_note"])
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_service.get_app_by_id")
+    @patch("console.services.mcp_query_service.service_repo.get_service_by_service_id")
+    @patch("console.services.mcp_query_service.group_service_relation_repo.get_services_by_group")
     @patch("console.services.mcp_query_service.console_app_service.create_region_service")
     @patch("console.services.mcp_query_service.arch_service.update_affinity_by_arch")
     @patch("console.services.mcp_query_service.app_manage_service.deploy")

--- a/console/tests/source_component_service_test.py
+++ b/console/tests/source_component_service_test.py
@@ -699,3 +699,230 @@ class SourceComponentServiceTests(SimpleTestCase):
         self.assertEqual(result["next_action"], "rainbond_get_component_check_result")
         self.assertEqual(result["check_uuid"], "chk-1")
         self.assertEqual(result["service_id"], "svc-1")
+
+    # capability_id: console.source-component.check-timeout-pending
+    @patch("console.services.source_component_service.service_source_repo.update_or_create_service_source")
+    @patch("console.services.source_component_service.service_source_repo.get_service_source")
+    @patch("console.services.source_component_service.group_service.add_service_to_group")
+    @patch("console.services.source_component_service.app_check_service.check_service")
+    @patch("console.services.source_component_service.console_app_service.create_source_code_app")
+    @patch("console.services.source_component_service.console_app_service.is_k8s_component_name_duplicate")
+    def test_auto_create_component_persists_dockerfile_preference_on_check_timeout(
+            self,
+            mock_name_duplicate,
+            mock_create_source,
+            mock_check_service,
+            mock_add_to_group,
+            mock_get_service_source,
+            mock_update_service_source,
+    ):
+        import json
+
+        from console.services.source_component_service import source_component_service
+
+        user = Obj(user_id=1, pk=1, nick_name="admin")
+        team = Obj(tenant_id="team-1", tenant_name="demo-team", enterprise_id="eid-1")
+        app = Obj(ID=12, region_name="rainbond", group_name="demo-app")
+        service = Obj(
+            service_id="svc-1",
+            service_alias="alias-1",
+            service_cname="component-1",
+            service_region="rainbond",
+            service_source="source_code",
+            create_status="checking",
+            arch="amd64",
+            check_uuid="chk-1",
+        )
+        service.to_dict = lambda: {"service_id": "svc-1", "service_alias": "alias-1"}
+        service.save = lambda: None
+
+        mock_name_duplicate.return_value = False
+        mock_create_source.return_value = (200, "success", service)
+        mock_add_to_group.return_value = (200, "success")
+        mock_check_service.return_value = (200, "success", {"check_uuid": "chk-1"})
+        mock_get_service_source.return_value = None
+
+        with patch.object(
+                source_component_service,
+                "_wait_for_check_result",
+                side_effect=ServiceHandleException(msg="check timeout", msg_show="代码检测超时", status_code=500),
+        ):
+            result = source_component_service.auto_create_component(
+                team=team,
+                app=app,
+                user=user,
+                service_cname="component-1",
+                code_from="git",
+                git_url="https://git.example.com/demo.git",
+                prefer_dockerfile_when_detected=True,
+            )
+
+        self.assertFalse(result["built"])
+        self.assertTrue(result["prefer_dockerfile_when_detected"])
+        self.assertTrue(result["build_mode_note"])
+        mock_update_service_source.assert_called_once()
+        persisted = mock_update_service_source.call_args[1]
+        self.assertEqual(persisted["team_id"], "team-1")
+        self.assertEqual(persisted["service_id"], "svc-1")
+        extend_info = json.loads(persisted["extend_info"])
+        self.assertTrue(extend_info["prefer_dockerfile_when_detected"])
+
+    # capability_id: console.source-component.check-timeout-pending
+    @patch("console.services.source_component_service.service_source_repo.update_or_create_service_source")
+    @patch("console.services.source_component_service.group_service.add_service_to_group")
+    @patch("console.services.source_component_service.app_check_service.check_service")
+    @patch("console.services.source_component_service.console_app_service.create_source_code_app")
+    @patch("console.services.source_component_service.console_app_service.is_k8s_component_name_duplicate")
+    def test_auto_create_component_skips_preference_persistence_when_not_requested(
+            self,
+            mock_name_duplicate,
+            mock_create_source,
+            mock_check_service,
+            mock_add_to_group,
+            mock_update_service_source,
+    ):
+        from console.services.source_component_service import source_component_service
+
+        user = Obj(user_id=1, pk=1, nick_name="admin")
+        team = Obj(tenant_id="team-1", tenant_name="demo-team", enterprise_id="eid-1")
+        app = Obj(ID=12, region_name="rainbond", group_name="demo-app")
+        service = Obj(
+            service_id="svc-1",
+            service_alias="alias-1",
+            service_cname="component-1",
+            service_region="rainbond",
+            service_source="source_code",
+            create_status="checking",
+            arch="amd64",
+            check_uuid="chk-1",
+        )
+        service.to_dict = lambda: {"service_id": "svc-1", "service_alias": "alias-1"}
+        service.save = lambda: None
+
+        mock_name_duplicate.return_value = False
+        mock_create_source.return_value = (200, "success", service)
+        mock_add_to_group.return_value = (200, "success")
+        mock_check_service.return_value = (200, "success", {"check_uuid": "chk-1"})
+
+        with patch.object(
+                source_component_service,
+                "_wait_for_check_result",
+                side_effect=ServiceHandleException(msg="check timeout", msg_show="代码检测超时", status_code=500),
+        ):
+            result = source_component_service.auto_create_component(
+                team=team,
+                app=app,
+                user=user,
+                service_cname="component-1",
+                code_from="git",
+                git_url="https://git.example.com/demo.git",
+            )
+
+        self.assertFalse(result["built"])
+        self.assertFalse(result["prefer_dockerfile_when_detected"])
+        mock_update_service_source.assert_not_called()
+
+    # capability_id: console.source-component.prefer-dockerfile-from-dockerfiles-flag
+    @patch("console.services.source_component_service.deploy_repo.create_deploy_relation_by_service_id")
+    @patch("console.services.source_component_service.app_manage_service.deploy")
+    @patch("console.services.source_component_service.arch_service.update_affinity_by_arch")
+    @patch("console.services.source_component_service.console_app_service.create_region_service")
+    @patch("console.services.source_component_service.app_manage_service.change_lang_and_package_tool")
+    @patch("console.services.source_component_service.app_check_service.save_service_check_info")
+    @patch("console.services.source_component_service.region_api.get_service_check_info")
+    @patch("console.services.source_component_service.app_check_service.check_service")
+    @patch("console.services.source_component_service.group_service.add_service_to_group")
+    @patch("console.services.source_component_service.console_app_service.create_service_source_info")
+    @patch("console.services.source_component_service.console_app_service.create_source_code_app")
+    @patch("console.services.source_component_service.console_app_service.is_k8s_component_name_duplicate")
+    def test_auto_create_component_reports_unapplied_dockerfile_preference(
+            self,
+            mock_name_duplicate,
+            mock_create_source,
+            mock_create_source_info,
+            mock_add_to_group,
+            mock_check_service,
+            mock_get_check_info,
+            mock_save_check_info,
+            mock_change_lang_and_package_tool,
+            mock_create_region_service,
+            mock_update_affinity,
+            mock_deploy,
+            mock_create_deploy_relation,
+    ):
+        from console.services.source_component_service import source_component_service
+
+        user = Obj(user_id=1, pk=1, nick_name="admin")
+        team = Obj(tenant_id="team-1", tenant_name="demo-team", enterprise_id="eid-1")
+        app = Obj(ID=12, region_name="rainbond", group_name="demo-app")
+        service = Obj(
+            service_id="svc-1",
+            service_alias="alias-1",
+            service_cname="component-1",
+            service_region="rainbond",
+            service_source="source_code",
+            create_status="creating",
+            arch="amd64",
+            check_uuid="chk-1",
+            check_event_id="evt-check-1",
+        )
+        service.to_dict = lambda: {"service_id": "svc-1", "service_alias": "alias-1"}
+        service.save = lambda: None
+        built_service = Obj(service_id="svc-1", create_status="complete", arch="amd64")
+
+        mock_name_duplicate.return_value = False
+        mock_create_source.return_value = (200, "success", service)
+        mock_add_to_group.return_value = (200, "success")
+        mock_check_service.return_value = (200, "success", {"check_uuid": "chk-1"})
+        # Detection found a CNB language but no Dockerfile at the build root,
+        # so the requested Dockerfile preference cannot be applied.
+        mock_get_check_info.return_value = (
+            None,
+            {"bean": {"check_status": "success", "error_infos": [], "service_info": [{
+                "language": "Go",
+            }]}}
+        )
+        mock_create_region_service.return_value = built_service
+        mock_deploy.return_value = (200, "success", "evt-1")
+
+        def save_check_info(team_obj, app_id, service_obj, data):
+            service_obj.create_status = "checked"
+
+        mock_save_check_info.side_effect = save_check_info
+
+        result = source_component_service.auto_create_component(
+            team=team,
+            app=app,
+            user=user,
+            service_cname="component-1",
+            code_from="git",
+            git_url="https://git.example.com/demo.git",
+            prefer_dockerfile_when_detected=True,
+        )
+
+        self.assertTrue(result["built"])
+        self.assertEqual(result["selected_language"], "Go")
+        self.assertFalse(result["dockerfile_preference_applied"])
+        self.assertTrue(result["build_mode_note"])
+
+    # capability_id: console.source-component.prefer-dockerfile-from-dockerfiles-flag
+    def test_load_dockerfile_preference_reads_persisted_flag(self):
+        from console.services.source_component_service import source_component_service
+
+        team = Obj(tenant_id="team-1", tenant_name="demo-team")
+        service = Obj(service_id="svc-1")
+
+        with patch(
+                "console.services.source_component_service.service_source_repo.get_service_source"
+        ) as mock_get_source:
+            mock_get_source.return_value = Obj(extend_info='{"prefer_dockerfile_when_detected": true}')
+            self.assertTrue(source_component_service.load_dockerfile_preference(team, service))
+
+            mock_get_source.return_value = Obj(extend_info='{"install_from_cloud": true}')
+            self.assertFalse(source_component_service.load_dockerfile_preference(team, service))
+
+            mock_get_source.return_value = Obj(extend_info="not-json")
+            self.assertFalse(source_component_service.load_dockerfile_preference(team, service))
+
+            mock_get_source.return_value = None
+            self.assertFalse(source_component_service.load_dockerfile_preference(team, service))


### PR DESCRIPTION
prefer_dockerfile_when_detected was only applied when source detection finished inside the synchronous wait window of create. Large repos always hit the timeout path, which dropped the flag, so the follow-up get_component_check_result persisted the CNB language and the build dead-ended on CNB version policy (e.g. Go 1.26).

- persist the preference in service_source.extend_info on check timeout and auto-apply it in get_component_check_result without re-passing
- report dockerfile_preference_applied/build_mode_note in both create and check-result responses so callers can see when the preference silently fell back to a language build (no Dockerfile at the build root)