### PR TITLE
chore: remove leftover Python 2.7 references from tooling config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@
   rev: v1.4.0
   hooks:
     - id: reorder-python-imports
-      language_version: python2.7
+      language_version: python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ python_classes= *Tests
 python_functions=test_*
 
 [tox]
-envlist = py27
+envlist = py311
 skipsdist = true
 
 [testenv]
 commands =
-    pytest --cov=console
+    python scripts/run_pytest.py . -- --cov=console


### PR DESCRIPTION
## Summary

After the upgrade to Python 3.11 / Django 5.2 (`staging/console-optimize`), two tooling config files still referenced Python 2.7. This PR cleans up those leftover dead references. No application code is touched.

## Changes

- `.pre-commit-config.yaml`: `language_version: python2.7` → `python3.11` for the `reorder-python-imports` hook.
- `tox.ini`: `envlist = py27` → `py311`, and aligned the `[testenv]` command with the project's actual test entrypoint (`python scripts/run_pytest.py . -- --cov=console`) instead of the bare `pytest` call.

## Notes

- The repo's real pre-commit hook (`.githook/pre-commit` → `make check`) and CI (`pr-ci-build.yml`, `python:3.11-bookworm` + `scripts/run_pytest.py`) do not invoke tox or the pre-commit framework, so these files are not on the active path; kept them and only fixed the stale version references rather than deleting (conservative cleanup).
- The `[pytest]` section of `tox.ini` is still live config and is left unchanged.
- Verified YAML/INI syntax parses cleanly.

## Test plan

- [x] `yaml.safe_load(.pre-commit-config.yaml)` parses
- [x] `configparser` parses `tox.ini` (envlist = py311)
- [x] grep confirms no remaining `python2.7`/`py27` references in config/build files