### PR TITLE
perf(agent-access): use lightweight plugin probe with cache

### DIFF
--- a/console/services/agent_access_service.py
+++ b/console/services/agent_access_service.py
@@ -1,17 +1,21 @@
 # -*- coding: utf8 -*-
 import logging
 import os
+import time
 
 from console.enum.enterprise_enum import EnterpriseRolesEnum
+from console.exception.main import ServiceHandleException
 from console.models.main import EnterpriseUserPerm
 from console.repositories.enterprise_repo import enterprise_user_perm_repo
 from console.repositories.region_repo import region_repo
-from console.services.plugin_service import rbd_plugin_service
 from console.services.user_services import user_services
 from django.db import transaction
+from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import Users
 
 logger = logging.getLogger("default")
+
+region_api = RegionInvokeApi()
 
 ENTERPRISE_BASE_PLUGIN = "rainbond-enterprise-base"
 EDITION_OPEN_SOURCE = "open_source"
@@ -19,8 +23,16 @@ EDITION_ENTERPRISE = "enterprise"
 EDITION_SAAS = "saas"
 EDITION_ENTERPRISE_SAAS = "enterprise_saas"
 
+# Short in-process cache so the high-frequency agent access poll does not probe
+# every cluster on every request. TTL is configurable for slow environments.
+PLUGIN_CACHE_TTL = int(os.getenv("AGENT_ACCESS_PLUGIN_CACHE_TTL", "60"))
+
 
 class AgentAccessService(object):
+    def __init__(self):
+        # enterprise_id -> (expire_ts, has_enterprise_base)
+        self._enterprise_base_cache = {}
+
     def get_agent_access(self, user):
         if not user:
             return self._build_access(False, EDITION_OPEN_SOURCE, False, False, False, "not_authenticated")
@@ -60,6 +72,16 @@ class AgentAccessService(object):
         return EDITION_OPEN_SOURCE
 
     def has_enterprise_base_plugin(self, enterprise_id):
+        now = time.time()
+        cached = self._enterprise_base_cache.get(enterprise_id)
+        if cached and cached[0] > now:
+            return cached[1]
+
+        result = self._compute_has_enterprise_base_plugin(enterprise_id)
+        self._enterprise_base_cache[enterprise_id] = (now + PLUGIN_CACHE_TTL, result)
+        return result
+
+    def _compute_has_enterprise_base_plugin(self, enterprise_id):
         try:
             regions = region_repo.get_usable_regions(enterprise_id)
         except Exception as exc:
@@ -67,14 +89,32 @@ class AgentAccessService(object):
             return False
 
         for region in regions or []:
-            try:
-                plugins, _ = rbd_plugin_service.list_plugins(enterprise_id, region.region_name, official=True)
-            except Exception as exc:
-                logger.warning("failed to list plugins for agent access: region=%s error=%s", region.region_name, exc)
-                continue
-            for plugin in plugins or []:
-                if plugin.get("name") == ENTERPRISE_BASE_PLUGIN:
-                    return True
+            if self._region_has_enterprise_base(enterprise_id, region.region_name):
+                return True
+        return False
+
+    def _region_has_enterprise_base(self, enterprise_id, region_name):
+        try:
+            return region_api.cluster_plugin_exists(enterprise_id, region_name, ENTERPRISE_BASE_PLUGIN)
+        except ServiceHandleException as exc:
+            if exc.status_code == 404:
+                # Older region without the probe endpoint: fall back to listing.
+                return self._region_has_enterprise_base_fallback(enterprise_id, region_name)
+            logger.warning("failed to probe enterprise base plugin: region=%s error=%s", region_name, exc)
+            return False
+        except Exception as exc:
+            logger.warning("failed to probe enterprise base plugin: region=%s error=%s", region_name, exc)
+            return False
+
+    def _region_has_enterprise_base_fallback(self, enterprise_id, region_name):
+        try:
+            _, body = region_api.list_plugins(enterprise_id, region_name, True)
+        except Exception as exc:
+            logger.warning("failed to list plugins for agent access: region=%s error=%s", region_name, exc)
+            return False
+        for plugin in (body or {}).get("list") or []:
+            if plugin.get("name") == ENTERPRISE_BASE_PLUGIN:
+                return True
         return False
 
     def get_initial_enterprise_admin_marker(self, enterprise_id):

--- a/console/tests/agent_access_service_test.py
+++ b/console/tests/agent_access_service_test.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 
-from console.services.agent_access_service import agent_access_service
+from console.exception.main import ServiceHandleException
+from console.services.agent_access_service import AgentAccessService, agent_access_service
 
 
 class AgentAccessServiceTests(TestCase):
@@ -109,3 +110,45 @@ class AgentAccessServiceTests(TestCase):
         with mock.patch.dict("os.environ", {"USE_SAAS": "true"}, clear=True), \
                 mock.patch.object(agent_access_service, "has_enterprise_base_plugin", return_value=True):
             self.assertEqual("enterprise_saas", agent_access_service.get_platform_edition("eid"))
+
+
+class HasEnterpriseBasePluginTests(TestCase):
+    def setUp(self):
+        self.service = AgentAccessService()
+        self.region = mock.Mock()
+        self.region.region_name = "rg"
+
+    def test_region_probe_true_short_circuits(self):
+        with mock.patch("console.services.agent_access_service.region_repo.get_usable_regions",
+                        return_value=[self.region]), \
+                mock.patch("console.services.agent_access_service.region_api.cluster_plugin_exists",
+                           return_value=True) as probe:
+            self.assertTrue(self.service.has_enterprise_base_plugin("eid"))
+        probe.assert_called_once_with("eid", "rg", "rainbond-enterprise-base")
+
+    def test_region_probe_404_falls_back_to_listing(self):
+        body = {"list": [{"name": "rainbond-enterprise-base"}]}
+        with mock.patch("console.services.agent_access_service.region_repo.get_usable_regions",
+                        return_value=[self.region]), \
+                mock.patch("console.services.agent_access_service.region_api.cluster_plugin_exists",
+                           side_effect=ServiceHandleException(msg="not found", status_code=404)), \
+                mock.patch("console.services.agent_access_service.region_api.list_plugins",
+                           return_value=(None, body)) as list_plugins:
+            self.assertTrue(self.service.has_enterprise_base_plugin("eid"))
+        list_plugins.assert_called_once_with("eid", "rg", True)
+
+    def test_region_probe_transport_error_returns_false(self):
+        with mock.patch("console.services.agent_access_service.region_repo.get_usable_regions",
+                        return_value=[self.region]), \
+                mock.patch("console.services.agent_access_service.region_api.cluster_plugin_exists",
+                           side_effect=ServiceHandleException(msg="unreachable", status_code=400)):
+            self.assertFalse(self.service.has_enterprise_base_plugin("eid"))
+
+    def test_result_is_cached_within_ttl(self):
+        with mock.patch("console.services.agent_access_service.region_repo.get_usable_regions",
+                        return_value=[self.region]), \
+                mock.patch("console.services.agent_access_service.region_api.cluster_plugin_exists",
+                           return_value=True) as probe:
+            self.assertTrue(self.service.has_enterprise_base_plugin("eid"))
+            self.assertTrue(self.service.has_enterprise_base_plugin("eid"))
+        probe.assert_called_once()

--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -2804,6 +2804,23 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
         res, body = self._get(url, self.default_headers, region=region_name, timeout=10)
         return res, body
 
+    def cluster_plugin_exists(self, enterprise_id, region_name, plugin_name):
+        """Lightweight probe for whether an official plugin exists in a cluster.
+
+        Uses short timeouts and no retries so an unreachable cluster fails fast
+        instead of stacking the default connect/read timeouts. Raises on
+        transport errors or a missing endpoint (404 on older regions); callers
+        decide how to react.
+        """
+        region_info = self.get_enterprise_region_info(enterprise_id, region_name)
+        if not region_info:
+            raise ServiceHandleException("region not found")
+        url = region_info.url + "/v2/cluster/plugins/exists?name={0}".format(plugin_name)
+        _, body = self._get(
+            url, self.default_headers, region=region_name, timeout=3, connect_timeout=2, retries=0)
+        bean = (body or {}).get("bean") or {}
+        return bool(bean.get("exist"))
+
     def create_rbdplugin(self, enterprise_id, region_name, plugin_data):
         region_info = self.get_enterprise_region_info(enterprise_id, region_name)
         if not region_info:

--- a/www/apiclient/regionapibaseclient.py
+++ b/www/apiclient/regionapibaseclient.py
@@ -239,6 +239,7 @@ class RegionApiBaseHttpClient(object):
         region_name = kwargs.get("region")
         retries = kwargs.get("retries", 2)
         d_connect, d_red = self.get_default_timeout_conifg()
+        d_connect = kwargs.get("connect_timeout", d_connect)
         timeout = kwargs.get("timeout", d_red)
         preload_content = kwargs.get("preload_content")
         if kwargs.get("for_test"):


### PR DESCRIPTION
## 背景

`/console/agent/access` 在部分环境下需要 ~15s 才响应。

调用链：`AgentAccessView.get` → `get_agent_access` → `get_platform_edition` → `has_enterprise_base_plugin`。后者为判断 `rainbond-enterprise-base` 插件是否存在，对**每个可用集群**调用了重量级的 `rbd_plugin_service.list_plugins(official=True)`：

- 每个集群一次 region HTTP 调用，读超时 10s、connect 5s、retries=2 —— 单个不可达集群的 connect 超时会叠加到 ~15s；
- 还附带云市场元数据拉取、多次 console DB 查询、URL 富化等重活，结果几乎全被丢弃（只用到插件名）；
- 该接口被前端高频轮询，每次都重跑全部逻辑，无缓存。

## 改动（方向 1+2+3）

1. **轻量探测**：改用 `region_api.cluster_plugin_exists` 调用 region 新增的 `/v2/cluster/plugins/exists` 接口，不再走重量级 list + 富化。
2. **快速失败**：探测使用短超时（read 3s / connect 2s）+ `retries=0`，不可达集群从 ~15s 降到 ~2s；为此给 region base client 增加 `connect_timeout` 逐调用覆盖能力。
3. **短缓存**：按 enterprise 缓存结果，TTL 由 `AGENT_ACCESS_PLUGIN_CACHE_TTL` 控制（默认 60s），高频轮询不再每次打集群。

## 兼容性

双向兼容、无强制部署顺序：

- 旧 region 无探测接口（404）→ 回退到原 `list` 接口按名字判断；
- 其它传输错误 → 当作"无插件"快速返回。

## 验证

`console/tests/agent_access_service_test.py` 共 **11 passed**（Docker python:3.6 harness），其中新增 4 例：探测命中短路 / 404 回退 / 传输错误返回 False / TTL 缓存仅探测一次。

## 配套 PR

region 侧：goodrain/rainbond#2602
