### PR TITLE
fix: correct latent service-layer bugs surfaced by mypy

### DIFF
--- a/console/repositories/plugin/service_plugin_repo.py
+++ b/console/repositories/plugin/service_plugin_repo.py
@@ -73,7 +73,7 @@ class AppPluginRelationRepo(object):
 
     def delete_by_sid(self, sid: str) -> None:
         # .objects exists at runtime via ModelBase metaclass; stub gap (model not in app registry)
-        TenantServicePluginRelation.objects.filter(service_id=sid)  # type: ignore[attr-defined]
+        TenantServicePluginRelation.objects.filter(service_id=sid).delete()  # type: ignore[attr-defined]
 
     def bulk_create(self, plugin_relations: List[TenantServicePluginRelation]) -> None:
         # .objects exists at runtime via ModelBase metaclass; stub gap (model not in app registry)

--- a/console/repositories/share_repo.py
+++ b/console/repositories/share_repo.py
@@ -87,13 +87,6 @@ class ShareRepo(object):
         result = conn.query(sql)
         return result
 
-    def create_service(self, **kwargs: Any) -> Any:
-        # NOTE: ServiceInfo is undefined in this module (pre-existing latent
-        # NameError if this method is ever called); flagged, not fixed here.
-        service = ServiceInfo(**kwargs)  # type: ignore[name-defined]
-        service.save()
-        return service
-
     def create_tenant_service(self, **kwargs: Any) -> TenantServiceInfo:
         tenant_service = TenantServiceInfo(**kwargs)
         tenant_service.save()

--- a/console/services/backup_data_service.py
+++ b/console/services/backup_data_service.py
@@ -53,7 +53,7 @@ class PlatformDataBackupServices(object):
             f.write(settings.VERSION)
 
     def version_than(self, backup_path: str) -> None:
-        with open(os.path.join(backup_path, 'version'), 'w') as f:
+        with open(os.path.join(backup_path, 'version'), 'r') as f:
             if f.read() != settings.VERSION:
                 raise ServiceHandleException(
                     msg="The data version is inconsistent with the code version.", msg_show="数据版本不同，不能导入")

--- a/console/services/backup_service.py
+++ b/console/services/backup_service.py
@@ -202,7 +202,7 @@ class GroupAppBackupService(object):
         if not backup_record:
             raise ErrBackupRecordNotFound
         if backup_record.status == "starting":
-            return ErrBackupInProgress  # type: ignore[return-value]  # NOTE: original code returns exception class instead of raising; preserving runtime behavior
+            raise ErrBackupInProgress
 
         try:
             region_api.delete_backup_by_backup_id(region, tenant.tenant_name, backup_id)

--- a/console/services/plugin/app_plugin.py
+++ b/console/services/plugin/app_plugin.py
@@ -690,8 +690,8 @@ class AppPluginService(object):
                 dep_service_key = component_id_key_map.get(config["dest_service_id"])
                 dest_service = app_service.get_service_by_service_key(service, dep_service_key)  # type: ignore[arg-type]  # NOTE: dep_service_key may be None if key missing from map
                 if dest_service:
-                    dest_service_id = dest_service.get("service_id", "")  # type: ignore[attr-defined]  # NOTE: legacy code treats TenantServiceInfo as dict here
-                    dest_service_alias = dest_service.get("service_alias", "")  # type: ignore[attr-defined]
+                    dest_service_id = dest_service.service_id
+                    dest_service_alias = dest_service.service_alias
 
             config_list.append(
                 ServicePluginConfigVar(

--- a/console/services/user_services.py
+++ b/console/services/user_services.py
@@ -80,9 +80,7 @@ class UserService(object):
         user.delete()
 
     def get_users_by_user_ids(self, user_ids: List[str]) -> QuerySet[Users]:
-        # NOTE: user_repo has no get_users_by_user_ids (only get_by_user_ids) -> AttributeError
-        # at runtime; live path via role_prems view. HIGH-priority bug, behavior left unchanged.
-        return user_repo.get_users_by_user_ids(user_ids)  # type: ignore[attr-defined]
+        return user_repo.get_by_user_ids(user_ids)
 
     def get_user_tenants(self, user_id: str) -> QuerySet:
         tenant_id_list = PermRelTenant.objects.filter(user_id=user_id).values_list("tenant_id", flat=True)

--- a/console/tests/app_plugin_downstream_port_test.py
+++ b/console/tests/app_plugin_downstream_port_test.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.services.plugin import app_plugin as app_plugin_module  # noqa: E402
+from console.services.plugin.app_plugin import AppPluginService  # noqa: E402
+from www.models.plugin import ServicePluginConfigVar  # noqa: E402
+
+
+# capability_id: console.plugin.downstream-port-config
+class CreatePluginCfg4MarketsvcDownstreamPortTest(TestCase):
+    def setUp(self):
+        self.svc = AppPluginService()
+        self.service = SimpleNamespace(service_id="src-service-id")
+
+    def test_downstream_port_reads_dest_service_attributes(self):
+        # dest_service is an ORM model object: has .service_id / .service_alias
+        # attributes but NO .get method (it is not a dict).
+        dest_service = SimpleNamespace(service_id="dst-id", service_alias="dst-alias")
+
+        components = [{"service_id": "dst-component-id", "service_share_uuid": "share-uuid"}]
+        service_plugin_config_vars = [{
+            "service_meta_type": "downstream_port",
+            "injection": "auto",
+            "dest_service_id": "dst-component-id",
+            "container_port": 8080,
+            "attrs": "{}",
+            "protocol": "http",
+        }]
+
+        captured = {}
+
+        def fake_bulk_create(config_list):
+            captured["config_list"] = config_list
+
+        with mock.patch.object(app_plugin_module, "app_service") as mock_app_service, \
+                mock.patch.object(ServicePluginConfigVar.objects, "bulk_create", side_effect=fake_bulk_create):
+            mock_app_service.get_service_by_service_key.return_value = dest_service
+            self.svc.create_plugin_cfg_4marketsvc(
+                tenant=mock.MagicMock(),
+                service=self.service,
+                version="v1",
+                plugin_id="plugin-id",
+                build_version="build-1",
+                components=components,
+                service_plugin_config_vars=service_plugin_config_vars,
+            )
+
+        config_list = captured["config_list"]
+        self.assertEqual(len(config_list), 1)
+        self.assertEqual(config_list[0].dest_service_id, "dst-id")
+        self.assertEqual(config_list[0].dest_service_alias, "dst-alias")

--- a/console/tests/backup_data_service_version_than_test.py
+++ b/console/tests/backup_data_service_version_than_test.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+import tempfile
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.main import ServiceHandleException  # noqa: E402
+from console.services.backup_data_service import PlatformDataBackupServices  # noqa: E402
+
+
+# capability_id: console.app-backup.version-check
+class VersionThanTests(TestCase):
+    def setUp(self):
+        self.service = PlatformDataBackupServices()
+
+    def _write_version(self, backup_path, content):
+        with open(os.path.join(backup_path, "version"), "w") as f:
+            f.write(content)
+
+    def test_matching_version_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as backup_path:
+            self._write_version(backup_path, "v1.2.3")
+            with mock.patch("console.services.backup_data_service.settings") as settings_mock:
+                settings_mock.VERSION = "v1.2.3"
+                # Should not raise.
+                self.assertIsNone(self.service.version_than(backup_path))
+
+    def test_mismatched_version_raises_service_handle_exception(self):
+        with tempfile.TemporaryDirectory() as backup_path:
+            self._write_version(backup_path, "v0.0.1")
+            with mock.patch("console.services.backup_data_service.settings") as settings_mock:
+                settings_mock.VERSION = "v9.9.9"
+                with self.assertRaises(ServiceHandleException):
+                    self.service.version_than(backup_path)

--- a/console/tests/backup_service_test.py
+++ b/console/tests/backup_service_test.py
@@ -21,6 +21,7 @@ django.setup()
 
 from console.services import backup_service as backup_service_module  # noqa: E402
 from console.services.backup_service import GroupAppBackupService  # noqa: E402
+from console.services.exception import ErrBackupInProgress  # noqa: E402
 
 
 class Obj(object):
@@ -120,3 +121,16 @@ class GroupAppBackupServiceScopeTests(TestCase):
             )
 
         self.assertIs(result, backup_record)
+
+
+# capability_id: console.app-backup.delete-in-progress
+class GroupAppBackupServiceDeleteInProgressTests(TestCase):
+    def test_delete_group_backup_raises_when_backup_in_progress(self):
+        tenant = Obj(tenant_id="team-1", tenant_name="demo-team")
+        with mock.patch.object(
+                backup_service_module.backup_record_repo,
+                "get_record_by_backup_id",
+                return_value=Obj(status="starting"),
+        ):
+            with self.assertRaises(ErrBackupInProgress.__class__):
+                GroupAppBackupService().delete_group_backup_by_backup_id(tenant, "region", "bid")

--- a/console/tests/service_plugin_repo_delete_by_sid_test.py
+++ b/console/tests/service_plugin_repo_delete_by_sid_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.repositories.plugin import service_plugin_repo as repo_module  # noqa: E402
+
+
+# capability_id: console.plugin.delete-by-sid
+class DeleteBySidTest(TestCase):
+    def test_delete_by_sid_deletes_matching_relations(self):
+        repo = repo_module.AppPluginRelationRepo()
+        with mock.patch.object(repo_module, "TenantServicePluginRelation") as mocked:
+            repo.delete_by_sid("svc-1")
+
+            mocked.objects.filter.assert_called_once_with(service_id="svc-1")
+            mocked.objects.filter.return_value.delete.assert_called_once()

--- a/console/tests/user_services_get_by_ids_test.py
+++ b/console/tests/user_services_get_by_ids_test.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.services import user_services as user_services_module  # noqa: E402
+from console.services.user_services import UserService  # noqa: E402
+
+
+# capability_id: console.user.get-users-by-ids
+class GetUsersByUserIdsTest(TestCase):
+    def test_delegates_to_repo_get_by_user_ids(self):
+        sentinel = object()
+        with mock.patch.object(user_services_module, "user_repo") as mock_repo:
+            mock_repo.get_by_user_ids.return_value = sentinel
+            result = UserService().get_users_by_user_ids(["u1", "u2"])
+        self.assertIs(result, sentinel)
+        mock_repo.get_by_user_ids.assert_called_once_with(["u1", "u2"])

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -605,6 +605,24 @@
       "status": "active"
     },
     {
+      "id": "console.app-backup.delete-in-progress",
+      "title": "Reject deleting a group backup while it is still in progress",
+      "title_zh": "备份进行中时阻止删除该备份记录",
+      "interface_type": "service_method",
+      "interface": "console.services.backup_service.GroupAppBackupService.delete_group_backup_by_backup_id",
+      "code_paths": [
+        "console/services/backup_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/backup_service_test.py",
+          "selector": "GroupAppBackupServiceDeleteInProgressTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-backup.state-service-guard",
       "title": "Reject backup while stateful services are still running",
       "title_zh": "有状态组件未关闭时阻止备份",
@@ -635,6 +653,24 @@
         {
           "path": "console/tests/groupapp_backup_migration_test.py",
           "selector": "GroupAppsBackupStatusViewWorkflowTests.test_get_returns_backup_status_list_without_internal_server_info"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app-backup.version-check",
+      "title": "Reject restoring a backup whose version does not match the platform",
+      "title_zh": "备份版本与平台版本不一致时阻止恢复",
+      "interface_type": "service_method",
+      "interface": "console.services.backup_data_service.PlatformDataBackupServices.version_than",
+      "code_paths": [
+        "console/services/backup_data_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/backup_data_service_version_than_test.py",
+          "selector": "VersionThanTests"
         }
       ],
       "test_type": "regression",
@@ -6677,6 +6713,42 @@
       "status": "active"
     },
     {
+      "id": "console.plugin.delete-by-sid",
+      "title": "Delete all plugin relations for a service by service id",
+      "title_zh": "按组件 ID 删除其全部插件关联",
+      "interface_type": "dao_method",
+      "interface": "console.repositories.plugin.service_plugin_repo.AppPluginRelationRepo.delete_by_sid",
+      "code_paths": [
+        "console/repositories/plugin/service_plugin_repo.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/service_plugin_repo_delete_by_sid_test.py",
+          "selector": "DeleteBySidTest.test_delete_by_sid_deletes_matching_relations"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.plugin.downstream-port-config",
+      "title": "Read downstream port dest service attributes from ORM model not dict",
+      "title_zh": "下游端口配置从 ORM 模型对象读取目标组件属性",
+      "interface_type": "service_method",
+      "interface": "console.services.plugin.app_plugin.AppPluginService.create_plugin_cfg_4marketsvc",
+      "code_paths": [
+        "console/services/plugin/app_plugin.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_plugin_downstream_port_test.py",
+          "selector": "CreatePluginCfg4MarketsvcDownstreamPortTest.test_downstream_port_reads_dest_service_attributes"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.pod.detail",
       "title": "Pod Detail",
       "title_zh": "Pod Detail",
@@ -8059,6 +8131,25 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceToolVisibilityTests.test_get_current_user_returns_identity_and_enterprise_admin_flag"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.user.get-users-by-ids",
+      "title": "Fetch users by a list of user ids via the user repository",
+      "title_zh": "通过用户仓储按用户 ID 列表批量查询用户",
+      "interface_type": "service_method",
+      "interface": "console.services.user_services.UserService.get_users_by_user_ids",
+      "code_paths": [
+        "console/services/user_services.py",
+        "console/repositories/user_repo.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/user_services_get_by_ids_test.py",
+          "selector": "GetUsersByUserIdsTest.test_delegates_to_repo_get_by_user_ids"
         }
       ],
       "test_type": "regression",


### PR DESCRIPTION
## 背景

mypy 类型标注（PR #1959）过程中抓出一批真实 bug，当时为「不改行为」保守地用 `# type: ignore` + `# NOTE:` 保留。本 PR 修复其中 **6 个高置信、改法唯一确定** 的 bug，每个都配了聚焦单元测试。

## 修复清单

| 模块 | 问题 | 修法 | 影响面 |
|------|------|------|--------|
| `user_services.get_users_by_user_ids` | 调用不存在的 `user_repo.get_users_by_user_ids` → AttributeError | → `user_repo.get_by_user_ids` | **live**：团队加用户后构造日志（role_prems）必崩 |
| `backup_service.delete_group_backup_by_backup_id` | `return ErrBackupInProgress`（返回异常实例而非 raise） | → `raise` | **live**：备份进行中删除静默返回成功，记录残留 |
| `service_plugin_repo.delete_by_sid` | 构造 filter 后漏 `.delete()`，是 no-op | 补 `.delete()` | **live**：组件恢复时静默不清理插件关系 |
| `app_plugin`（downstream_port 配置） | 对 TenantServiceInfo 模型对象误用 `.get()` | → 属性访问 | **live**：downstream_port 插件配置路径 AttributeError |
| `backup_data_service.version_than` | `'w'` 写模式打开后 `f.read()` → UnsupportedOperation | `'w'` → `'r'` | dead code，修正确性 |
| `share_repo.create_service` | 引用未定义的 `ServiceInfo` → NameError | 删除死代码（grep 证无调用方） | dead code |

> 另有一个 autoscaler `delete_autoscaler_rule` 的同类问题，因正确修法涉及新增 repo 方法 + 级联删除决策，需进一步确认 intent，未纳入本 PR。

## 测试

- 新增 4 个单测文件 + `backup_service_test.py` 加 1 个用例，全部 TDD（先 RED 复现 bug，再 GREEN）
- 全量 `console/tests` 回归：**0 failed**
- mypy 目录门禁：改动的 6 个模块 **0 错误**，无 unused-ignore

## Test plan

- [x] `python scripts/run_pytest.py console/tests` 全绿
- [x] mypy 门禁改动模块 0 错
- [ ] 在 staging/console-optimize 打包后做一次 E2E 回归