### PR TITLE
ci: skip coverage-gate heavy steps for non-Python PRs

### DIFF
--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -89,12 +89,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Coverage collection runs the whole suite with per-file subprocess
+      # instrumentation, which is intrinsically slow (~10min). Skip the heavy
+      # steps entirely when the PR changes no Python files (docs/CI/yaml-only
+      # PRs), so they don't burn ~10min for nothing.
+      - name: Detect Python changes
+        id: detect
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags origin "$GITHUB_BASE_REF"
+          if git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" | grep -qE '\.py$'; then
+            echo "py_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "py_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Python files changed in this PR; skipping coverage gate."
+          fi
+
       - name: Install native dependencies
+        if: steps.detect.outputs.py_changed == 'true'
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gcc git make default-libmysqlclient-dev sqlite3 curl
 
       - name: Install Python dependencies
+        if: steps.detect.outputs.py_changed == 'true'
         run: |
           mkdir -p "$PIP_SRC"
           python -m pip install --upgrade pip 'setuptools<70'
@@ -102,6 +120,7 @@ jobs:
           pip install diff-cover
 
       - name: Install openapi-client
+        if: steps.detect.outputs.py_changed == 'true'
         run: |
           curl -fsSL https://gitee.com/zhangsetsail/appstore-sdk-python/repository/archive/python3.tar.gz -o /tmp/openapi-client.tar.gz
           mkdir -p /tmp/openapi-client
@@ -110,6 +129,7 @@ jobs:
           rm -rf /tmp/openapi-client /tmp/openapi-client.tar.gz
 
       - name: Run tests with coverage
+        if: steps.detect.outputs.py_changed == 'true'
         run: |
           coverage erase || true
           python scripts/run_pytest.py . -- -q --cov=console --cov=www --cov=openapi --cov-append --cov-report= \
@@ -117,9 +137,8 @@ jobs:
           coverage xml -o coverage.xml
 
       - name: Diff coverage gate (new/changed code >= 80%)
+        if: steps.detect.outputs.py_changed == 'true'
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch --no-tags --depth=0 origin "$GITHUB_BASE_REF" || git fetch --no-tags origin "$GITHUB_BASE_REF"
           diff-cover coverage.xml --compare-branch="origin/${GITHUB_BASE_REF}" --fail-under=80
 
   rainbond-allinone:

--- a/docs/test-coverage-standard.md
+++ b/docs/test-coverage-standard.md
@@ -27,10 +27,13 @@
 
 `.github/workflows/pr-ci-build.yml` 的 `coverage-gate` job：
 1. `actions/checkout` 用 `fetch-depth: 0`（diff-cover 需要 base 历史）。
-2. 跑测试并收集覆盖率：`python scripts/run_pytest.py . -- -q --cov=console --cov=www --cov=openapi --cov-append --cov-report=`。
+2. **Detect Python changes**：diff PR base，若本次 PR **没有改动任何 `.py` 文件**（纯 doc/CI/yaml PR），后续所有重活步骤（装依赖 + 跑覆盖率 + diff-cover）全部 `if` 跳过，job 秒过。
+3. 跑测试并收集覆盖率：`python scripts/run_pytest.py . -- -q --cov=console --cov=www --cov=openapi --cov-append --cov-report=`。
    - 注意：`run_pytest.py` 每个测试文件起独立子进程（隔离手写 stub 测试），靠 `--cov-append` 把各文件覆盖率累加进单个 `.coverage`。
-3. `coverage xml -o coverage.xml`。
-4. `diff-cover coverage.xml --compare-branch=origin/${GITHUB_BASE_REF} --fail-under=80`。
+4. `coverage xml -o coverage.xml`。
+5. `diff-cover coverage.xml --compare-branch=origin/${GITHUB_BASE_REF} --fail-under=80`。
+
+> **关于耗时**：覆盖率收集对 ~190 个测试文件逐个子进程插桩，**固有耗时 ~10min**（C-tracer 逐行插桩是地板成本；实测避开 `--cov-append` 的 merge 也救不了，且 py3.11 无 py3.12 的 `sys.monitoring` 快速路径）。因此 coverage-gate 设计为 **advisory + 与 required check 并行**，不延长 PR 合并的关键路径；并对非 Python PR 直接跳过（见第 2 步）。未来升级到 py3.12+ 可借 `sys.monitoring` 显著提速。
 
 ## 4. 本地自查
 


### PR DESCRIPTION
## 背景

上线 coverage-gate（#1969）后实测它很慢（~10min）。本想"复用 unit-test 覆盖率产物"或"避开 --cov-append 的 merge"来提速，**基准测试证明这条路走不通**：

| 方案 | 40 文件耗时 |
|------|------------|
| `--cov-append`（现状） | 309s |
| 每 worker 独立 COVERAGE_FILE + `coverage combine` | 362s（更慢） |

**慢的根源是 coverage 的 C-tracer 逐行插桩本身**（~190 个隔离子进程逐个插桩），不是 .coverage 的 merge。避开 merge 救不了；把覆盖率塞进 unit-test 又会拖慢 required 路径。py3.11 也没有 py3.12 的 `sys.monitoring` 快速路径。

## 做法（诚实的优化）

既然单次收集耗时是固有的，就**别让它白跑**：
- 新增 **Detect Python changes** 步骤，diff PR base；若本次 PR **没改任何 `.py`**（纯 doc/CI/yaml），后续装依赖 + 跑覆盖率 + diff-cover 全部 `if` 跳过 → job 秒过。
- 对有 Python 改动的 PR，行为不变（仍 advisory + 与 required check 并行，不延长合并关键路径）。
- 文档补充耗时说明与 py3.12 `sys.monitoring` 未来提速路径。

## 自我演示

本 PR 只改 `.yml` + `.md`，无 `.py` → coverage-gate 应**直接跳过并秒过**，正好验证该优化。