### PR TITLE
chore: mypy strict typing for the console.views layer (P5)

### DIFF
--- a/console/services/operation_log.py
+++ b/console/services/operation_log.py
@@ -409,7 +409,7 @@ class OperationLogService(object):
             ctx.user,
             operation_type=OperationType.COMPONENT_MANAGE,
             comment=comment,
-            enterprise_id=ctx.user.enterprise_id,  # type: ignore[union-attr]  # NOTE: user may be None before auth; runtime guarantees non-None here
+            enterprise_id=ctx.user.enterprise_id,  # type: ignore[arg-type]  # NOTE: Users.enterprise_id nullable but create_log expects str (systemic, backlog)
             team_name=ctx.team_name,  # type: ignore[arg-type]  # NOTE: team_name may be None before initial(); runtime guarantees str here
             app_id=ctx.app.app_id,  # type: ignore[union-attr]  # NOTE: app is None until initial() runs; runtime guarantees non-None here
             service_alias=ctx.component.service_alias,  # type: ignore[union-attr]  # NOTE: same as above for component

--- a/console/views/account_fee.py
+++ b/console/views/account_fee.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.region_services import region_services
@@ -16,7 +18,7 @@ market_api = MarketOpenAPI()
 
 
 class EnterpriseAccountInfoView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         企业账户信息查询接口
         ---
@@ -39,19 +41,22 @@ class EnterpriseAccountInfoView(JWTAuthApiView):
 
             team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)
             try:
-                res, data = market_api.get_enterprise_account_info(tenant_id=team.tenant_id, enterprise_id=team.enterprise_id)
+                # NOTE: get_tenant_by_tenant_name typed Optional though exception=True raises (backlog).
+                res, data = market_api.get_enterprise_account_info(
+                    tenant_id=team.tenant_id, enterprise_id=team.enterprise_id)  # type: ignore[union-attr]
                 result = general_message(200, "success", "查询成功", bean=data)
             except Exception as e:
                 logger.exception(e)
                 result = general_message(400, "corporate account information failed", "企业账户信息获取失败")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2 Exception.message (backlog).
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class EnterpriseTeamFeeView(JWTAuthApiView):
-    def get(self, request, team_name):
+    def get(self, request: Request, team_name: str) -> Response:
         """
         企业下某团队资源费用账单查询接口
         ---
@@ -97,12 +102,12 @@ class EnterpriseTeamFeeView(JWTAuthApiView):
                 result = general_message(400, "enterprise expense account query failed.", "企业资源费用账单查询失败")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class EnterpriseRechargeRecordsView(JWTAuthApiView):
-    def get(self, request, team_name):
+    def get(self, request: Request, team_name: str) -> Response:
         """
         查询企业的充值记录
         ---
@@ -138,20 +143,21 @@ class EnterpriseRechargeRecordsView(JWTAuthApiView):
                 return Response(general_message(404, "team not found", "团队{0}不存在".format(team_name)), status=404)
 
             enterprise = enterprise_services.get_enterprise_by_enterprise_id(team.enterprise_id)
-            res, data = market_api.get_enterprise_recharge_records(team.tenant_id, enterprise.enterprise_id, start_time,
-                                                                   end_time, page, page_size)
+            res, data = market_api.get_enterprise_recharge_records(team.tenant_id,
+                                                                   enterprise.enterprise_id,  # type: ignore[union-attr]
+                                                                   start_time, end_time, page, page_size)
 
             result = general_message(
                 200, "get recharge record success", "查询成功", list=data["data"]["list"], total=data["data"]["total"])
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class EnterpriseAllRegionFeeView(JWTAuthApiView):
-    def get(self, request, team_name):
+    def get(self, request: Request, team_name: str) -> Response:
         """
         企业所有信息
         ---
@@ -169,15 +175,15 @@ class EnterpriseAllRegionFeeView(JWTAuthApiView):
             if not team:
                 return Response(general_message(404, "team not exist", "指定的团队不存在"), status=404)
 
-            regions = region_services.get_regions_by_enterprise_id(team.enterprise_id)
-            total_list = []
+            regions = region_services.get_regions_by_enterprise_id(team.enterprise_id)  # type: ignore[arg-type]
+            total_list: list = []
             for region in regions:
                 try:
                     res, dict_body = market_api.get_enterprise_region_fee(
                         region=region.region_name, enterprise_id=team.enterprise_id, team_id=team.tenant_id, date=date)
 
                     rt_list = dict_body["data"]["list"]
-                    enter_total = {}
+                    enter_total: dict = {}
                     for rt in rt_list:
                         bean = enter_total.get(rt['time'])
                         if bean:
@@ -207,12 +213,12 @@ class EnterpriseAllRegionFeeView(JWTAuthApiView):
             result = general_message(200, "success", "查询成功", list=result_list)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class EnterprisePurchaseDetails(JWTAuthApiView):
-    def get(self, request, team_name):
+    def get(self, request: Request, team_name: str) -> Response:
         """
         企业购买明细
         ---
@@ -258,5 +264,5 @@ class EnterprisePurchaseDetails(JWTAuthApiView):
             result = general_message(200, "success", "查询成功", list=result_list, total=total)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])

--- a/console/views/adaptor.py
+++ b/console/views/adaptor.py
@@ -15,13 +15,15 @@ from pathlib import Path
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 import re
+from typing import Any, Optional
 
 from console.repositories.helm import helm_repo, region_event
 from console.utils.offline import is_cloud_market_disabled
 from console.views.base import JWTAuthApiView
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.utils.cache import cache
-def _dockerhub_get_bearer_token(repository, username=None, password=None):
+def _dockerhub_get_bearer_token(repository: str, username: Optional[str] = None, password: Optional[str] = None) -> Any:
     """获取 Docker Hub 的匿名/Basic 授权 token。"""
     auth_url = "https://auth.docker.io/token"
     params = {
@@ -36,7 +38,7 @@ def _dockerhub_get_bearer_token(repository, username=None, password=None):
     return resp.json().get("token")
 
 
-def _oci_pull_chart_to_tempfile(oci_url, username=None, password=None):
+def _oci_pull_chart_to_tempfile(oci_url: str, username: Optional[str] = None, password: Optional[str] = None) -> str:
     """支持从 Docker Hub 拉取 Helm OCI chart，返回临时文件路径。"""
     # 解析 oci://host/repo[:tag]
     parsed = urlparse(oci_url)
@@ -66,7 +68,7 @@ def _oci_pull_chart_to_tempfile(oci_url, username=None, password=None):
             "User-Agent": "Rainbond-Console/1.0",
         }
         # 拉取 manifest 或 manifest list
-        def fetch_manifest(ref_or_digest):
+        def fetch_manifest(ref_or_digest: str) -> Any:
             murl = f"https://registry-1.docker.io/v2/{repository}/manifests/{ref_or_digest}"
             r = requests.get(murl, headers=headers, timeout=20)
             r.raise_for_status()
@@ -114,7 +116,7 @@ def _oci_pull_chart_to_tempfile(oci_url, username=None, password=None):
         # 兜底：如果未找到，尝试逐层探测
         try_layers = [] if chart_digest else layers
         # 下载 blob 层
-        def download_blob(digest):
+        def download_blob(digest: str) -> str:
             burl = f"https://registry-1.docker.io/v2/{repository}/blobs/{digest}"
             r = requests.get(burl, headers=headers, stream=True, timeout=60)
             r.raise_for_status()
@@ -150,10 +152,11 @@ def _oci_pull_chart_to_tempfile(oci_url, username=None, password=None):
 
 
 class Appstores(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         if is_cloud_market_disabled():
             result = {"code": 200, "msg": "success", "msg_show": "查询成功", "data": []}
-            return Response(result, status=result["code"])
+            # NOTE: status comes from a heterogeneous dict literal; mypy widens it to object (legacy).
+            return Response(result, status=result["code"])  # type: ignore[arg-type]
         appstores = helm_repo.get_all_repo()
         data = list()
         for appstore in appstores:
@@ -164,21 +167,21 @@ class Appstores(JWTAuthApiView):
                 "password": appstore.password,
             })
         result = {"code": 200, "msg": "success", "msg_show": "查询成功", "data": data}
-        return Response(result, status=result["code"])
+        return Response(result, status=result["code"])  # type: ignore[arg-type]
 
 
 class Appstore(JWTAuthApiView):
-    def get(self, request, enterprise_id, name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, name: str, *args: Any, **kwargs: Any) -> Response:
         app_store = helm_repo.get_helm_repo_by_name(name)
         if not app_store:
             result = {"code": 400, "msg": "success", "msg_show": "查询成功"}
-            return Response(result, status=result["code"])
+            return Response(result, status=result["code"])  # type: ignore[arg-type]
         result = {"code": 200, "msg": "success", "msg_show": "查询成功"}
-        return Response(result, status=result["code"])
+        return Response(result, status=result["code"])  # type: ignore[arg-type]
 
 
 class AppstoreCharts(JWTAuthApiView):
-    def get(self, request, enterprise_id, name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, name: str, *args: Any, **kwargs: Any) -> Response:
         logger = logging.getLogger('default')
         if is_cloud_market_disabled():
             try:
@@ -190,7 +193,7 @@ class AppstoreCharts(JWTAuthApiView):
             except Exception:
                 page_size = 50
             query_kw = (request.query_params.get('query', '') or '').strip()
-            result = {
+            result: dict = {
                 "code": 200,
                 "msg": "success",
                 "msg_show": "查询成功",
@@ -200,11 +203,12 @@ class AppstoreCharts(JWTAuthApiView):
                 "total": 0,
                 "query": query_kw
             }
-            return Response(result, status=result["code"])
+            return Response(result, status=result["code"])  # type: ignore[arg-type]
         app_store = helm_repo.get_helm_repo_by_name(name)
         if app_store:
             helm_repo_url = app_store.get("repo_url")
-            repo_index_url = f"{helm_repo_url.rstrip('/')}/index.yaml"
+            # NOTE: app_store.get may return None; legacy assumes present (backlog).
+            repo_index_url = f"{helm_repo_url.rstrip('/')}/index.yaml"  # type: ignore[union-attr]
             # 读取查询参数：分页与版本限制
             try:
                 page = int(request.query_params.get('page', 1))
@@ -279,9 +283,10 @@ class AppstoreCharts(JWTAuthApiView):
                 from yaml import CSafeLoader as _SafeLoader
             except Exception:
                 try:
-                    from yaml import CLoader as _SafeLoader  # 兼容别名
+                    # NOTE: yaml loader fallbacks share one alias; mypy flags the rebind (legacy).
+                    from yaml import CLoader as _SafeLoader  # type: ignore[assignment]  # 兼容别名
                 except Exception:
-                    from yaml import SafeLoader as _SafeLoader
+                    from yaml import SafeLoader as _SafeLoader  # type: ignore[assignment]
             try:
                 index_data = yaml.load(index_text, Loader=_SafeLoader) or {}
             except Exception:
@@ -347,7 +352,8 @@ class AppstoreCharts(JWTAuthApiView):
 
 
 class AppstoreChart(JWTAuthApiView):
-    def get(self, request, enterprise_id, name, chart_name, version, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, name: str, chart_name: str, version: str, *args: Any,
+            **kwargs: Any) -> Response:
         if is_cloud_market_disabled():
             data = {"readme": "", "questions": "", "values": {}}
             return Response({"code": 200, "msg": "success", "msg_show": "操作成功", "data": data})
@@ -435,9 +441,9 @@ class AppstoreChart(JWTAuthApiView):
                         from yaml import CSafeLoader as _SafeLoader
                     except Exception:
                         try:
-                            from yaml import CLoader as _SafeLoader
+                            from yaml import CLoader as _SafeLoader  # type: ignore[assignment]
                         except Exception:
-                            from yaml import SafeLoader as _SafeLoader
+                            from yaml import SafeLoader as _SafeLoader  # type: ignore[assignment]
                     try:
                         index_data = yaml.load(index_text, Loader=_SafeLoader) or {}
                     except Exception:
@@ -537,7 +543,7 @@ class AppstoreChart(JWTAuthApiView):
 
 
 class HelmRegionInstall(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取 Helm 安装区域事件信息
         """
@@ -549,7 +555,8 @@ class HelmRegionInstall(JWTAuthApiView):
                 event = events.first()
                 try:
                     # 反序列化事件消息
-                    event_data = json.loads(event.message)
+                    # NOTE: events.first() may return None; legacy assumes present (backlog).
+                    event_data = json.loads(event.message)  # type: ignore[union-attr]
                     response_data = {
                         "create_status": True,
                         "token": event_data.get("token"),
@@ -564,7 +571,7 @@ class HelmRegionInstall(JWTAuthApiView):
         except Exception as e:
             return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         初始化 Helm 安装区域事件
         """
@@ -590,7 +597,7 @@ class HelmRegionInstall(JWTAuthApiView):
         except Exception as e:
             return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    def delete(self, request, enterprise_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除 Helm 安装区域事件
         """

--- a/console/views/agent_access.py
+++ b/console/views/agent_access.py
@@ -1,11 +1,13 @@
 # -*- coding: utf8 -*-
+from typing import Any
 from console.services.agent_access_service import agent_access_service
 from console.views.base import JWTAuthApiView
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
 
 class AgentAccessView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         access = agent_access_service.get_agent_access(self.user)
         return Response(general_message(200, "success", "查询成功", bean=access), status=200)

--- a/console/views/agent_llm_config.py
+++ b/console/views/agent_llm_config.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from typing import Any, Optional
+
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -12,16 +15,16 @@ from www.utils.return_message import general_message
 
 class AgentLLMConfigView(JWTAuthApiView):
 
-    def _ensure_enterprise_admin(self):
+    def _ensure_enterprise_admin(self) -> Optional[Response]:
         if not self.is_enterprise_admin:
             return Response(general_message(403, "forbidden", "无权限操作 AI 助手配置"), status=403)
         return None
 
-    def get(self, request, eid, *args, **kwargs):
+    def get(self, request: Request, eid: str, *args: Any, **kwargs: Any) -> Response:
         data = agent_llm_config_service.get_masked_config()
         return Response(general_message(200, "success", "获取成功", bean=data), status=200)
 
-    def put(self, request, eid, *args, **kwargs):
+    def put(self, request: Request, eid: str, *args: Any, **kwargs: Any) -> Response:
         denied = self._ensure_enterprise_admin()
         if denied:
             return denied
@@ -34,7 +37,7 @@ class AgentLLMConfigView(JWTAuthApiView):
             return Response(general_message(exc.error_code, exc.msg, exc.msg_show, bean=exc.bean), status=exc.status_code)
         return Response(general_message(200, "success", "更新成功", bean=data), status=200)
 
-    def delete(self, request, eid, *args, **kwargs):
+    def delete(self, request: Request, eid: str, *args: Any, **kwargs: Any) -> Response:
         denied = self._ensure_enterprise_admin()
         if denied:
             return denied
@@ -46,6 +49,6 @@ class AgentLLMRuntimeConfigView(APIView):
     authentication_classes = (AgentRuntimeAuthentication, )
     permission_classes = (IsAuthenticated, )
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = agent_llm_config_service.get_runtime_config()
         return Response(general_message(200, "success", "获取成功", bean=data), status=200)

--- a/console/views/api_gateway.py
+++ b/console/views/api_gateway.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
 
@@ -9,6 +10,7 @@ from console.services.gateway_api import gateway_api
 from console.views.base import RegionTenantHeaderView
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import general_message
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 logger = logging.getLogger("default")
@@ -18,7 +20,7 @@ service_group_relation_repo = ServiceGroupRelationRepositry()
 
 class AppApiGatewayView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = request.query_params.get('appID', "")
         service_alias = request.query_params.get('service_alias', "")
         port = request.query_params.get('port', "")
@@ -51,16 +53,17 @@ class AppApiGatewayView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = request.query_params.get('appID', "")
         query = request.query_params.get('query', "")
         path = request.get_full_path().replace("/console", "")
         resp = region_api.api_gateway_get_proxy(self.region, self.tenant.tenant_id, path, app_id, query)
-        result = general_message(200, "success", "查询成功", bean=resp['bean'], list=resp['list'])
+        # NOTE: regionapi proxy may return None; legacy code indexes directly (backlog).
+        result = general_message(200, "success", "查询成功", bean=resp['bean'], list=resp['list'])  # type: ignore[index]
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         path = request.get_full_path().replace("/console", "")
         # app_id = request.query_params.get('appID', "")
         resp = region_api.api_gateway_delete_proxy(self.response_region, self.tenant_name, path)
@@ -70,14 +73,15 @@ class AppApiGatewayView(RegionTenantHeaderView):
 
 class AppApiGatewayConvertView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         all = domain_repo.get_all_domain()
         list = []
         for e in all:
             svc = port_repo.get_service_port_by_port(e.tenant_id, e.service_id, e.container_port)
             app_id = service_group_relation_repo.get_group_id_by_service_tenant(svc)
+            # NOTE: app_id from repo is Optional; regionapi expects str (legacy mismatch, backlog).
             region_api.api_gateway_bind_http_domain_convert(e.service_name, self.region, self.tenant_name,
-                                                            [e.domain_name], svc, app_id)
+                                                            [e.domain_name], svc, app_id)  # type: ignore[arg-type]
             list.append(e.domain_name)
 
         result = general_message(200, "success", "创建成功", list=list)

--- a/console/views/app/apps.py
+++ b/console/views/app/apps.py
@@ -4,7 +4,9 @@
 """
 import logging
 import json
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
 
@@ -17,7 +19,7 @@ logger = logging.getLogger("default")
 
 
 class AppLView(RegionTenantHeaderView):
-    def get(self, request, enterprise_id, team_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, team_name: str, *args: Any, **kwargs: Any) -> Response:
         name = request.GET.get("name", None)
         page = request.GET.get("page", 1)
         page_size = request.GET.get("page_size", 10)
@@ -27,8 +29,8 @@ class AppLView(RegionTenantHeaderView):
             return Response(result, status=status.HTTP_200_OK)
         team_id = team.tenant_id
         data = []
-        app_list = service_repo.get_app_list(team_id, name, page, page_size)
-        app_count = service_repo.get_app_count(team_id, name)
+        app_list = service_repo.get_app_list(team_id, name, page, page_size)  # type: ignore[arg-type]
+        app_count = service_repo.get_app_count(team_id, name)  # type: ignore[arg-type]
         for app in app_list:
             data.append({
                 "ID": app.ID,

--- a/console/views/app_autoscaler.py
+++ b/console/views/app_autoscaler.py
@@ -1,7 +1,9 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any, Optional
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import AbortRequest
@@ -16,7 +18,7 @@ from www.utils.return_message import general_message
 logger = logging.getLogger("default")
 
 
-def validate_parameter(data):
+def validate_parameter(data: Any) -> None:
     xpa_type = parse_item(data, key="xpa_type", required=True)
     if xpa_type not in ["hpa"]:
         raise AbortRequest(msg="unsupported xpa_type: " + xpa_type)
@@ -54,13 +56,13 @@ def validate_parameter(data):
 
 class ListAppAutoscalerView(AppBaseView):
     @never_cache
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         rules = autoscaler_service.list_autoscaler_rules(self.service.service_id)
         result = general_message(200, "success", "查询成功", list=rules)
         return Response(data=result, status=200)
 
     @never_cache
-    def post(self, req, *args, **kwargs):
+    def post(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         validate_parameter(req.data)
 
         data = req.data
@@ -90,23 +92,26 @@ class ListAppAutoscalerView(AppBaseView):
 
 class AppAutoscalerView(AppBaseView):
     @never_cache
-    def get(self, req, rule_id, *args, **kwargs):
+    def get(self, req: Request, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         res = autoscaler_service.get_by_rule_id(rule_id)
 
         result = general_message(200, "success", "创建成功", bean=res)
         return Response(data=result, status=200)
 
     @never_cache
-    def put(self, req, rule_id, *args, **kwargs):
+    def put(self, req: Request, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         validate_parameter(req.data)
         old = AutoscalerRules.objects.get(rule_id=rule_id)
         old_metrics = AutoscalerRuleMetrics.objects.filter(rule_id=rule_id).values()
-        old_information = autoscaler_service.json_autoscaler_rules(
-            max_replicas=old.max_replicas, min_replicas=old.min_replicas, metrics=old_metrics)
-        res = autoscaler_service.update_autoscaler_rule(self.region_name, self.tenant.tenant_name, self.service.service_alias,
-                                                        rule_id, req.data, self.user.nick_name)
+        # NOTE: .values() yields a QuerySet but callee expects list[dict] (arg-type backlog).
+        old_information: Optional[str] = autoscaler_service.json_autoscaler_rules(
+            max_replicas=old.max_replicas, min_replicas=old.min_replicas, metrics=old_metrics)  # type: ignore[arg-type]
+        # NOTE: nick_name is nullable but callee expects str (arg-type backlog).
+        res = autoscaler_service.update_autoscaler_rule(
+            self.region_name, self.tenant.tenant_name, self.service.service_alias,
+            rule_id, req.data, self.user.nick_name)  # type: ignore[arg-type]
 
-        new_information = autoscaler_service.json_autoscaler_rules(
+        new_information: Optional[str] = autoscaler_service.json_autoscaler_rules(
             max_replicas=req.data["max_replicas"], min_replicas=req.data["min_replicas"], metrics=req.data["metrics"])
         if req.data["enable"] and not old.enable:
             old_information = None
@@ -134,11 +139,13 @@ class AppAutoscalerView(AppBaseView):
 
 class AppScalingRecords(AppBaseView):
     @never_cache
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         page = req.GET.get("page", 1)
         page_size = req.GET.get("page_size", 10)
 
-        data = scaling_records_service.list_scaling_records(self.region_name, self.tenant.tenant_name,
-                                                            self.service.service_alias, page, page_size)
+        # NOTE: page/page_size from GET are str but callee expects int (arg-type backlog).
+        data = scaling_records_service.list_scaling_records(
+            self.region_name, self.tenant.tenant_name,
+            self.service.service_alias, page, page_size)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(data=result, status=200)

--- a/console/views/app_config/app_dependency.py
+++ b/console/views/app_config/app_dependency.py
@@ -4,6 +4,7 @@
 """
 import json
 import logging
+from typing import Any
 
 from console.repositories.app import service_repo
 from console.services.app_config import dependency_service, port_service
@@ -11,17 +12,19 @@ from console.services.group_service import group_service
 from console.services.operation_log import operation_log_service, Operation
 from console.views.app_config.base import AppBaseView
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 from console.exception.main import AbortRequest
 from console.repositories.group import group_service_relation_repo
+from www.models.main import Tenants
 
 logger = logging.getLogger("default")
 
 
 class AppDependencyReverseView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件可以被依赖但未依赖的组件
         ---
@@ -113,7 +116,7 @@ class AppDependencyReverseView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         反向依赖，让其他的组件来依赖自己
         ---
@@ -145,7 +148,8 @@ class AppDependencyReverseView(AppBaseView):
         # 这一步真的去添加依赖
         try:
             data = dependency_service.patch_add_service_reverse_dependency(
-                self.tenant, self.service, be_dep_service_ids=be_dep_service_ids, user_name=self.user.nick_name)
+                self.tenant, self.service, be_dep_service_ids=be_dep_service_ids,
+                user_name=self.user.nick_name)  # type: ignore[arg-type] # NOTE: nick_name str|None (backlog)
             result = general_message(200, "success", "依赖添加成功", list=data)
             return Response(result, status=result["code"])
         except Exception as e:
@@ -156,7 +160,7 @@ class AppDependencyReverseView(AppBaseView):
 
 class AppDependencyViewList(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         page_num = int(request.GET.get("page", 1))
         if page_num < 1:
             page_num = 1
@@ -217,7 +221,7 @@ class AppDependencyViewList(AppBaseView):
 
 class AppDependencyView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件依赖的组件
         ---
@@ -301,7 +305,7 @@ class AppDependencyView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加依赖组件
         ---
@@ -333,8 +337,9 @@ class AppDependencyView(AppBaseView):
             raise AbortRequest(msg="third-party components cannot add dependencies", msg_show="第三方组件不能添加依赖组件")
         if dep_service_id == self.service.service_id:
             raise AbortRequest(msg="components cannot rely on themselves", msg_show="组件不能依赖自己")
-        code, msg, data = dependency_service.add_service_dependency(self.tenant, self.service, dep_service_id, open_inner,
-                                                                    container_port, self.user.nick_name)
+        code, msg, data = dependency_service.add_service_dependency(
+            self.tenant, self.service, dep_service_id, open_inner,
+            container_port, self.user.nick_name)  # type: ignore[arg-type]
         if code == 201:
             result = general_message(code, "add dependency success", msg, list=data, bean={"is_inner": False})
             return Response(result, status=code)
@@ -343,7 +348,10 @@ class AppDependencyView(AppBaseView):
             return Response(result, status=code)
         dependency = dependency_service.get_service_dependencies_part([dep_service_id])
         service_group = group_service.get_service_group_info(dep_service_id)
-        new_information = json.dumps({"所属应用": service_group.group_name, "组件名": dependency[0].service_cname}, ensure_ascii=False)
+        # NOTE: get_service_group_info may return None (backlog)
+        new_information = json.dumps(
+            {"所属应用": service_group.group_name, "组件名": dependency[0].service_cname},  # type: ignore[union-attr]
+            ensure_ascii=False)
 
         result = general_message(code, msg, "依赖添加成功", bean=data.to_dict())
         dep_component_name = handle_dep_component_info(self.tenant, dep_service_id)
@@ -365,7 +373,7 @@ class AppDependencyView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def patch(self, request, *args, **kwargs):
+    def patch(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加依赖组件
         ---
@@ -394,7 +402,8 @@ class AppDependencyView(AppBaseView):
             raise AbortRequest(msg="third-party components cannot add dependencies", msg_show="第三方组件不能添加依赖组件")
         dep_service_list = dep_service_ids.split(",")
         code, msg = dependency_service.patch_add_dependency(
-            self.tenant, self.service, dep_service_list, user_name=self.user.nick_name)
+            self.tenant, self.service, dep_service_list,
+            user_name=self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             result = general_message(code, "add dependency error", msg)
             return Response(result, status=code)
@@ -426,7 +435,7 @@ class AppDependencyView(AppBaseView):
 
 class AppNotDependencyView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件可以依赖但未依赖的组件
         ---
@@ -524,7 +533,7 @@ class AppNotDependencyView(AppBaseView):
 
 class AppDependencyManageView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件的某个依赖
         ---
@@ -551,9 +560,12 @@ class AppDependencyManageView(AppBaseView):
             return Response(general_message(400, "attr_name not specify", "未指定需要删除的依赖组件"))
         dependency = dependency_service.get_service_dependencies_part([dep_service_id])
         service_group = group_service.get_service_group_info(dep_service_id)
-        old_information = json.dumps({"所属应用": service_group.group_name, "组件名": dependency[0].service_cname}, ensure_ascii=False)
-        code, msg, dependency = dependency_service.delete_service_dependency(self.tenant, self.service, dep_service_id,
-                                                                             self.user.nick_name)
+        # NOTE: get_service_group_info may return None (backlog)
+        old_information = json.dumps(
+            {"所属应用": service_group.group_name, "组件名": dependency[0].service_cname},  # type: ignore[union-attr]
+            ensure_ascii=False)
+        code, msg, dependency = dependency_service.delete_service_dependency(
+            self.tenant, self.service, dep_service_id, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "delete dependency error", msg))
 
@@ -578,12 +590,13 @@ class AppDependencyManageView(AppBaseView):
         return Response(result, status=result["code"])
 
 
-def handle_dep_component_info(tenant, dep_service_id):
+def handle_dep_component_info(tenant: Tenants, dep_service_id: str) -> Any:
     dep_component = service_repo.get_service_by_service_id(dep_service_id)
+    # NOTE: get_service_by_service_id may return None (backlog)
     dep_component_name = operation_log_service.process_component_name(
-        name=dep_component.service_cname,
-        region=dep_component.service_region,
+        name=dep_component.service_cname,  # type: ignore[union-attr]
+        region=dep_component.service_region,  # type: ignore[union-attr]
         team_name=tenant.tenant_name,
-        service_alias=dep_component.service_alias,
+        service_alias=dep_component.service_alias,  # type: ignore[union-attr]
     )
     return dep_component_name

--- a/console/views/app_config/app_domain.py
+++ b/console/views/app_config/app_domain.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import re
+from typing import Any, Tuple
 
 from console.constants import DomainType
 from console.repositories.app import service_repo
@@ -26,6 +27,7 @@ from console.views.base import RegionTenantHeaderView
 from django.db import connection
 from console.utils.cache_decorators import never_cache
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import ServiceDomain
@@ -40,7 +42,7 @@ region_api = RegionInvokeApi()
 dns1123_subdomain_max_length = 253
 
 
-def validate_domain(domain):
+def validate_domain(domain: str) -> Tuple[bool, str]:
     if len(domain) > dns1123_subdomain_max_length:
         return False, "域名长度不能超过{}".format(dns1123_subdomain_max_length)
 
@@ -60,7 +62,7 @@ def validate_domain(domain):
 
 class TenantCertificateView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取团队下的证书
         ---
@@ -86,7 +88,7 @@ class TenantCertificateView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为团队添加证书
         ---
@@ -114,14 +116,15 @@ class TenantCertificateView(RegionTenantHeaderView):
 
         """
         alias = request.data.get("alias", None)
-        if len(alias) > 64:
+        if len(alias) > 64:  # type: ignore[arg-type]
             return Response(general_message(400, "alias len is not allow more than 64", "证书名称最大长度64位"), status=400)
         private_key = request.data.get("private_key", None)
         certificate = request.data.get("certificate", None)
         certificate_type = request.data.get("certificate_type", None)
         certificate_id = make_uuid()
-        new_c = domain_service.add_certificate(self.region, self.tenant, alias, certificate_id, certificate, private_key,
-                                               certificate_type)
+        new_c = domain_service.add_certificate(
+            self.region, self.tenant, alias, certificate_id, certificate, private_key,  # type: ignore[arg-type]
+            certificate_type)  # type: ignore[arg-type]
         bean = {"alias": alias, "id": new_c.ID}
         result = general_message(200, "success", "操作成功", bean=bean)
         new_information = json.dumps({
@@ -133,14 +136,14 @@ class TenantCertificateView(RegionTenantHeaderView):
             ensure_ascii=False)
         comment = operation_log_service.generate_team_comment(
             operation=Operation.FOR,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 添加了 {} 证书".format(alias))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             new_information=new_information)
         return Response(result, status=result["code"])
@@ -148,7 +151,7 @@ class TenantCertificateView(RegionTenantHeaderView):
 
 class TenantCertificateManageView(RegionTenantHeaderView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除证书
         ---
@@ -166,32 +169,32 @@ class TenantCertificateManageView(RegionTenantHeaderView):
 
         """
         certificate_id = kwargs.get("certificate_id", None)
-        _, _, cert = domain_service.get_certificate_by_pk(certificate_id)
+        _, _, cert = domain_service.get_certificate_by_pk(certificate_id)  # type: ignore[arg-type]
         old_information = json.dumps({
-            "证书名称": cert["alias"],
-            "证书类型": cert["certificate_type"],
-            "公钥证书": cert["certificate"],
-            "私钥": cert["private_key"]
+            "证书名称": cert["alias"],  # type: ignore[index]
+            "证书类型": cert["certificate_type"],  # type: ignore[index]
+            "公钥证书": cert["certificate"],  # type: ignore[index]
+            "私钥": cert["private_key"]  # type: ignore[index]
         },
             ensure_ascii=False)
-        domain_service.delete_certificate_by_pk(self.region.region_name, self.tenant, certificate_id)
+        domain_service.delete_certificate_by_pk(self.region.region_name, self.tenant, certificate_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "证书删除成功")
         comment = operation_log_service.generate_team_comment(
             operation=Operation.DELETE,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
-            suffix=" 下的 {} 证书".format(cert.get("alias", "")))
+            suffix=" 下的 {} 证书".format(cert.get("alias", "")))  # type: ignore[union-attr]
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             old_information=old_information)
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改证书
         ---
@@ -225,9 +228,11 @@ class TenantCertificateManageView(RegionTenantHeaderView):
         """
         certificate_id = kwargs.get("certificate_id", None)
         if not certificate_id:
-            return Response(400, "no param certificate_id", "缺少未指明具体证书")
+            # NOTE: latent bug — Response()'s 2nd positional arg is `status` (int) but a str is
+            # passed here; behavior preserved as-is (backlog)
+            return Response(400, "no param certificate_id", "缺少未指明具体证书")  # type: ignore[arg-type]
         new_alias = request.data.get("alias", None)
-        if len(new_alias) > 64:
+        if len(new_alias) > 64:  # type: ignore[arg-type]
             return Response(general_message(400, "alias len is not allow more than 64", "证书名称最大长度64位"), status=400)
 
         private_key = request.data.get("private_key", None)
@@ -235,17 +240,18 @@ class TenantCertificateManageView(RegionTenantHeaderView):
         certificate_type = request.data.get("certificate_type", None)
         _, _, cert = domain_service.get_certificate_by_pk(certificate_id)
         old_information = json.dumps({
-            "证书名称": cert["alias"],
-            "证书类型": cert["certificate_type"],
-            "公钥证书": cert["certificate"],
-            "私钥": cert["private_key"]
+            "证书名称": cert["alias"],  # type: ignore[index]
+            "证书类型": cert["certificate_type"],  # type: ignore[index]
+            "公钥证书": cert["certificate"],  # type: ignore[index]
+            "私钥": cert["private_key"]  # type: ignore[index]
         },
                                      ensure_ascii=False)
         domain_repo.get_certificate_by_pk(int(certificate_id))
 
-        cert = domain_service.update_certificate(self.region, self.tenant, certificate_id, new_alias, certificate,
-                                                 private_key,
-                                                 certificate_type)
+        cert = domain_service.update_certificate(
+            self.region, self.tenant, certificate_id, new_alias, certificate,  # type: ignore[arg-type]
+            private_key,  # type: ignore[arg-type]
+            certificate_type)  # type: ignore[arg-type]
         new_information = json.dumps({
             "证书名称": cert.alias,
             "证书类型": certificate_type,
@@ -256,21 +262,21 @@ class TenantCertificateManageView(RegionTenantHeaderView):
         result = general_message(200, "success", "证书修改成功")
         comment = operation_log_service.generate_team_comment(
             operation=Operation.UPDATE,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 下的 {} 证书".format(cert.alias))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             old_information=old_information,
             new_information=new_information)
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询某个证书详情
         ---
@@ -288,7 +294,7 @@ class TenantCertificateManageView(RegionTenantHeaderView):
 
         """
         certificate_id = kwargs.get("certificate_id", None)
-        code, msg, certificate = domain_service.get_certificate_by_pk(certificate_id)
+        code, msg, certificate = domain_service.get_certificate_by_pk(certificate_id)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "delete error", msg), status=code)
 
@@ -298,7 +304,7 @@ class TenantCertificateManageView(RegionTenantHeaderView):
 
 class ServiceDomainView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件下某个端口绑定的域名
         ---
@@ -321,13 +327,13 @@ class ServiceDomainView(AppBaseView):
 
         """
         container_port = request.GET.get("container_port", None)
-        domains = domain_service.get_port_bind_domains(self.service, int(container_port))
+        domains = domain_service.get_port_bind_domains(self.service, int(container_port))  # type: ignore[arg-type]
         domain_list = [domain.to_dict() for domain in domains]
         result = general_message(200, "success", "查询成功", list=domain_list)
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件端口绑定域名
         ---
@@ -366,7 +372,7 @@ class ServiceDomainView(AppBaseView):
         """
         container_port = request.data.get("container_port", None)
         domain_name = request.data.get("domain_name", None)
-        flag, msg = validate_domain(domain_name)
+        flag, msg = validate_domain(domain_name)  # type: ignore[arg-type]
         if not flag:
             result = general_message(400, "invalid domain", msg)
             return Response(result, status=400)
@@ -375,21 +381,25 @@ class ServiceDomainView(AppBaseView):
         rule_extensions = request.data.get("rule_extensions", None)
 
         # 判断策略是否存在
-        service_domain = domain_repo.get_domain_by_name_and_port_and_protocol(self.service.service_id, container_port,
-                                                                              domain_name, protocol)
+        service_domain = domain_repo.get_domain_by_name_and_port_and_protocol(
+            self.service.service_id, container_port,  # type: ignore[arg-type]
+            domain_name, protocol)  # type: ignore[arg-type]
         if service_domain:
             result = general_message(400, "failed", "策略已存在")
             return Response(result, status=400)
 
-        domain_service.bind_domain(self.tenant, self.user, self.service, domain_name, container_port, protocol, certificate_id,
-                                   DomainType.WWW, rule_extensions)
+        domain_service.bind_domain(
+            self.tenant, self.user, self.service, domain_name, container_port, protocol,  # type: ignore[arg-type]
+            certificate_id, DomainType.WWW, rule_extensions)  # type: ignore[arg-type]
         # htt与https共存的协议需存储两条数据(创建完https数据再创建一条http数据)
         if protocol == "httpandhttps":
             certificate_id = 0
-            domain_service.bind_domain(self.tenant, self.user, self.service, domain_name, container_port, protocol,
-                                       certificate_id, DomainType.WWW, rule_extensions)
+            domain_service.bind_domain(
+                self.tenant, self.user, self.service, domain_name, container_port, protocol,  # type: ignore[arg-type]
+                certificate_id, DomainType.WWW, rule_extensions)  # type: ignore[arg-type]
         result = general_message(200, "success", "域名绑定成功")
-        svc = port_repo.get_service_port_by_port(self.tenant.tenant_id, self.service.service_id, container_port)
+        svc = port_repo.get_service_port_by_port(
+            self.tenant.tenant_id, self.service.service_id, container_port)  # type: ignore[arg-type]
 
         region_api.api_gateway_bind_http_domain(self.service.service_alias, self.region, self.tenant.tenant_name,
                                                 [domain_name], svc, self.app.app_id)
@@ -414,7 +424,7 @@ class ServiceDomainView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件端口解绑域名
         ---
@@ -444,7 +454,7 @@ class ServiceDomainView(AppBaseView):
 
         container_port = request.data.get("container_port", None)
         domain_name = request.data.get("domain_name", None)
-        flag, msg = validate_domain(domain_name)
+        flag, msg = validate_domain(domain_name)  # type: ignore[arg-type]
         if not flag:
             result = general_message(400, "invalid domain", msg)
             return Response(result, status=400)
@@ -462,7 +472,7 @@ class ServiceDomainView(AppBaseView):
             if protocol == "https" else "HTTP和HTTPS"
         service_domain = {"端口": container_port, "协议": agreement, "域名": domain_name}
         if protocol != "http":
-            certificate = domain_repo.get_certificate_by_id(old_service_domain.certificate_id)
+            certificate = domain_repo.get_certificate_by_id(old_service_domain.certificate_id)  # type: ignore[attr-defined]
             if certificate:
                 service_domain["证书别名"] = certificate.alias
         domain_service.unbind_domain(self.tenant, self.service, container_port, domain_name, is_tcp, self.app.app_id)
@@ -489,17 +499,17 @@ class ServiceDomainView(AppBaseView):
 
 class CalibrationCertificate(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         certificate_id = request.data.get("certificate_id", None)
         domain_name = request.data.get("domain_name", None)
-        is_pass = domain_service.check_certificate(certificate_id, domain_name)
+        is_pass = domain_service.check_certificate(certificate_id, domain_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean={"is_pass": is_pass})
         return Response(result, status=result["code"])
 
 
 class HttpStrategyView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取单个http策略
 
@@ -518,13 +528,13 @@ class HttpStrategyView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     g_id = int(gsr.group_id)
             if domain.certificate_id:
                 certificate_info = domain_repo.get_certificate_by_pk(int(domain.certificate_id))
 
-                bean.update({"certificate_name": certificate_info.alias})
+                bean.update({"certificate_name": certificate_info.alias})  # type: ignore[union-attr]
             bean.update({"service_alias": service_alias})
             bean.update({"group_name": group_name})
             bean.update({"g_id": g_id})
@@ -542,7 +552,7 @@ class HttpStrategyView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加http策略
 
@@ -555,14 +565,14 @@ class HttpStrategyView(RegionTenantHeaderView):
 
         domain_heander = request.data.get("domain_heander", None)
         # 检查设置的请求头对不对
-        header_items = domain_heander.split('=')
+        header_items = domain_heander.split('=')  # type: ignore[union-attr]
         if len(header_items) > 1 and not self.check_nginx_header(header_items[0], header_items[1]):
             result = general_message(400, "success", "请求头配置有误")
             return Response(result, status=status.HTTP_400_BAD_REQUEST)
 
         container_port = request.data.get("container_port", None)
         domain_name = request.data.get("domain_name", None)
-        flag, msg = validate_domain(domain_name)
+        flag, msg = validate_domain(domain_name)  # type: ignore[arg-type]
         if not flag:
             result = general_message(400, "invalid domain", msg)
             return Response(result, status=400)
@@ -603,7 +613,8 @@ class HttpStrategyView(RegionTenantHeaderView):
         if auto_ssl:
             auto_ssl = True
         if auto_ssl:
-            auto_ssl_configs = EnterpriseConfigService(self.tenant.enterprise_id, self.user.user_id).get_auto_ssl_info()
+            auto_ssl_configs = EnterpriseConfigService(
+                self.tenant.enterprise_id, self.user.user_id).get_auto_ssl_info()  # type: ignore[arg-type]
             if not auto_ssl_configs:
                 result = general_message(400, "failed", "未找到自动分发证书相关配置")
                 return Response(result, status=400)
@@ -680,7 +691,7 @@ class HttpStrategyView(RegionTenantHeaderView):
         return Response(result, status=status.HTTP_201_CREATED)
 
     # 预先检查nginx 的header 值是否正确
-    def check_nginx_syntax(self, config_data):
+    def check_nginx_syntax(self, config_data: dict) -> bool:
         try:
             if "set_headers" not in config_data:
                 return False
@@ -696,14 +707,14 @@ class HttpStrategyView(RegionTenantHeaderView):
             return False
         return True
 
-    def check_nginx_header(self, key, value):
+    def check_nginx_header(self, key: str, value: str) -> Any:
         # Nginx 标准的正则表达式模式
         nginx_key_pattern = re.compile(r'^[a-zA-Z0-9_\-]+$')
         nginx_value_pattern = re.compile(r'^[a-zA-Z0-9_\-.*$()#]+(\s*[a-zA-Z0-9_\-.*$()#]+)*$')
         return re.match(nginx_key_pattern, key) and re.match(nginx_value_pattern, value)
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         编辑http策略
         """
@@ -715,14 +726,14 @@ class HttpStrategyView(RegionTenantHeaderView):
 
         domain_heander = request.data.get("domain_heander", None)
         # 检查设置的请求头对不对
-        header_items = domain_heander.split('=')
+        header_items = domain_heander.split('=')  # type: ignore[union-attr]
         if len(header_items) > 1 and not self.check_nginx_header(header_items[0], header_items[1]):
             result = general_message(400, "success", "请求头配置有误")
             return Response(result, status=status.HTTP_400_BAD_REQUEST)
 
         container_port = request.data.get("container_port", None)
         domain_name = request.data.get("domain_name", None)
-        flag, msg = validate_domain(domain_name)
+        flag, msg = validate_domain(domain_name)  # type: ignore[arg-type]
         if not flag:
             result = general_message(400, "invalid domain", msg)
             return Response(result, status=400)
@@ -796,7 +807,7 @@ class HttpStrategyView(RegionTenantHeaderView):
         return Response(result, status=200)
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
        删除策略
 
@@ -811,7 +822,7 @@ class HttpStrategyView(RegionTenantHeaderView):
 
 
 class GatewayRouteBatch(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = request.GET.get("app_id", "")
         namespace = self.tenant.namespace
         data = gateway_api.list_http_routes(self.region_name, self.tenant_name, namespace, app_id)
@@ -820,7 +831,7 @@ class GatewayRouteBatch(RegionTenantHeaderView):
 
 
 class TenantService(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         ports = port_repo.get_tenant_services(self.tenant.tenant_id)
         component_list = service_repo.get_tenant_region_services(self.region_name, self.tenant.tenant_id)
         component_dict = {component.service_id: component.service_cname for component in component_list}
@@ -831,7 +842,7 @@ class TenantService(RegionTenantHeaderView):
                 port_dict = dict()
                 port_dict["service_name"] = port.k8s_service_name
                 port_dict["namespace"] = self.tenant.namespace
-                port_dict["component_name"] = component_dict.get(port.service_id)
+                port_dict["component_name"] = component_dict.get(port.service_id)  # type: ignore[assignment]
                 port_list.append(port_dict)
         ret_data = {"namespace": self.tenant.namespace, "ports": port_list}
         result = general_message(200, "success", "查询成功", bean=ret_data)
@@ -839,14 +850,14 @@ class TenantService(RegionTenantHeaderView):
 
 
 class GatewayRoute(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         namespace = self.tenant.namespace
         name = request.GET.get("name", "")
         data = gateway_api.get_http_route(self.region_name, self.tenant_name, namespace, name)
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = request.data.get("app_id")
         gateway_name = request.data.get("gateway_name")
         gateway_namespace = request.data.get("gateway_namespace")
@@ -854,12 +865,13 @@ class GatewayRoute(RegionTenantHeaderView):
         rules = request.data.get("rules", [])
         section_name = request.data.get("section_name", "")
         namespace = self.tenant.namespace
-        data = gateway_api.add_http_route(self.region_name, self.tenant_name, app_id, namespace, gateway_name,
-                                          gateway_namespace, hosts, rules, section_name)
+        data = gateway_api.add_http_route(
+            self.region_name, self.tenant_name, app_id, namespace, gateway_name,  # type: ignore[arg-type]
+            gateway_namespace, hosts, rules, section_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = request.data.get("app_id")
         name = request.data.get("name")
         gateway_namespace = request.data.get("gateway_namespace")
@@ -868,35 +880,37 @@ class GatewayRoute(RegionTenantHeaderView):
         hosts = request.data.get("hosts", [])
         section_name = request.data.get("section_name", "")
         namespace = self.tenant.namespace
-        region_app_id = region_app_repo.get_region_app_id(self.region_name, app_id)
+        region_app_id = region_app_repo.get_region_app_id(self.region_name, app_id)  # type: ignore[arg-type]
         if not region_app_id:
             return Response(general_message(400, "can not find app by region_app_id", "提供的region_app_id查找不到应用"), status=400)
-        ret = gateway_api.update_http_route(self.region_name, self.tenant_name, name, app_id, namespace, gateway_name,
-                                            gateway_namespace, hosts, rules, section_name)
+        ret = gateway_api.update_http_route(
+            self.region_name, self.tenant_name, name, app_id, namespace, gateway_name,  # type: ignore[arg-type]
+            gateway_namespace, hosts, rules, section_name)  # type: ignore[arg-type]
         if ret:
             data = {
                 "content": ret.get("content"),
                 "state": 2,
                 "error_overview": "更新成功",
             }
-            k8s_resources_repo.update(app_id, name, "HTTPRoute", **data)
+            k8s_resources_repo.update(app_id, name, "HTTPRoute", **data)  # type: ignore[arg-type]
         result = general_message(200, "success", "更新成功", bean=ret)
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         region_app_id = request.GET.get("region_app_id")
         name = request.GET.get("name", "")
         namespace = self.tenant.namespace
-        app_id = region_app_repo.get_app_id(self.region_name, region_app_id)
-        data = gateway_api.delete_http_route(self.region_name, self.tenant_name, namespace, name, region_app_id)
-        k8s_resources_repo.delete_by_name(app_id, "HTTPRoute", name)
+        app_id = region_app_repo.get_app_id(self.region_name, region_app_id)  # type: ignore[arg-type]
+        data = gateway_api.delete_http_route(
+            self.region_name, self.tenant_name, namespace, name, region_app_id)  # type: ignore[arg-type]
+        k8s_resources_repo.delete_by_name(app_id, "HTTPRoute", name)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])
 
 
 class DomainView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询某个域名是否存在
         ---
@@ -924,7 +938,7 @@ class DomainView(RegionTenantHeaderView):
 
 class SecondLevelDomainView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取二级域名后缀
         ---
@@ -946,7 +960,7 @@ class SecondLevelDomainView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件端口自定义二级域名
         ---
@@ -985,15 +999,22 @@ class SecondLevelDomainView(AppBaseView):
         container_port = int(container_port)
         sld_domains = domain_service.get_sld_domains(self.service, container_port)
         if not sld_domains:
-            domain_service.bind_domain(self.tenant, self.user, self.service, domain_name, container_port, "http", None,
-                                       DomainType.SLD_DOMAIN)
+            # NOTE: latent bug — bind_domain is missing the required `rule_extensions` arg and
+            # passes None for a str param; behavior preserved as-is (backlog)
+            domain_service.bind_domain(  # type: ignore[call-arg]
+                self.tenant, self.user, self.service, domain_name, container_port, "http",
+                None,  # type: ignore[arg-type]
+                DomainType.SLD_DOMAIN)
         else:
-            code, msg = domain_service.unbind_domain(
+            # NOTE: latent bug — unbind_domain returns None but is unpacked into (code, msg) (backlog)
+            code, msg = domain_service.unbind_domain(  # type: ignore[func-returns-value]
                 self.tenant, self.service, container_port, sld_domains[0].domain_name, is_tcp=False, app_id=self.app.app_id)
             if code != 200:
                 return Response(general_message(code, "unbind domain error", msg), status=code)
-            domain_service.bind_domain(self.tenant, self.user, self.service, domain_name, container_port, "http", None,
-                                       DomainType.SLD_DOMAIN)
+            domain_service.bind_domain(  # type: ignore[call-arg]
+                self.tenant, self.user, self.service, domain_name, container_port, "http",
+                None,  # type: ignore[arg-type]
+                DomainType.SLD_DOMAIN)
 
         result = general_message(200, "success", "二级域名修改成功")
         return Response(result, status=result["code"])
@@ -1001,7 +1022,7 @@ class SecondLevelDomainView(AppBaseView):
 
 # 获取团队下的策略
 class DomainQueryView(RegionTenantHeaderView):
-    def get(self, request, tenantName, *args, **kwargs):
+    def get(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
 
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
@@ -1019,7 +1040,8 @@ class DomainQueryView(RegionTenantHeaderView):
                 where sd.tenant_id='{0}' and sd.region_id='{1}' \
                     and (sd.domain_name like '%{2}%' \
                         or sd.service_alias like '%{2}%' \
-                        or sg.group_name like '%{2}%');".format(tenant.tenant_id, region.region_id, search_conditions))
+                        or sg.group_name like '%{2}%');".format(
+                tenant.tenant_id, region.region_id, search_conditions))  # type: ignore[union-attr]
             domain_count = cursor.fetchall()
 
             total = domain_count[0][0]
@@ -1044,14 +1066,15 @@ class DomainQueryView(RegionTenantHeaderView):
                         and (sd.domain_name like '%{2}%' \
                             or sd.service_alias like '%{2}%' \
                             or sg.group_name like '%{2}%') \
-                    order by type desc LIMIT {3},{4};".format(tenant.tenant_id, region.region_id, search_conditions, start,
-                                                              end))
+                    order by type desc LIMIT {3},{4};".format(
+                        tenant.tenant_id, region.region_id, search_conditions, start,  # type: ignore[union-attr]
+                        end))
                 tenant_tuples = cursor.fetchall()
         else:
             # 获取总数
             cursor = connection.cursor()
             cursor.execute("select count(1) from service_domain where tenant_id='{0}' and region_id='{1}';".format(
-                tenant.tenant_id, region.region_id))
+                tenant.tenant_id, region.region_id))  # type: ignore[union-attr]
             domain_count = cursor.fetchall()
 
             total = domain_count[0][0]
@@ -1069,8 +1092,9 @@ class DomainQueryView(RegionTenantHeaderView):
                     service_name, container_port, http_rule_id, service_id, domain_path, domain_cookie,
                     domain_heander, the_weight, is_outer_service, path_rewrite,
                     rewrites from service_domain where tenant_id='{0}'
-                    and region_id='{1}' order by type desc LIMIT {2},{3};""".format(tenant.tenant_id, region.region_id, start,
-                                                                                    end))
+                    and region_id='{1}' order by type desc LIMIT {2},{3};""".format(
+                        tenant.tenant_id, region.region_id, start,  # type: ignore[union-attr]
+                        end))
                 tenant_tuples = cursor.fetchall()
         # 拼接展示数据
         domain_list = list()
@@ -1083,7 +1107,7 @@ class DomainQueryView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     group_id = int(gsr.group_id)
             domain_dict = dict()
@@ -1111,7 +1135,7 @@ class DomainQueryView(RegionTenantHeaderView):
             if isinstance(rewrites, str):
                 rewrites = eval(rewrites)
             domain_dict["rewrites"] = rewrites
-            domain_dict["group_id"] = group_id
+            domain_dict["group_id"] = group_id  # type: ignore[assignment]
             domain_list.append(domain_dict)
         bean = dict()
         bean["total"] = total
@@ -1121,7 +1145,7 @@ class DomainQueryView(RegionTenantHeaderView):
 
 class ServiceTcpDomainQueryView(RegionTenantHeaderView):
     # 查询团队下tcp/udp策略
-    def get(self, request, tenantName, *args, **kwargs):
+    def get(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         search_conditions = request.GET.get("search_conditions", None)
@@ -1138,7 +1162,8 @@ class ServiceTcpDomainQueryView(RegionTenantHeaderView):
                     where std.tenant_id='{0}' and std.region_id='{1}' \
                         and (std.end_point like '%{2}%' \
                             or std.service_alias like '%{2}%' \
-                            or sg.group_name like '%{2}%');".format(tenant.tenant_id, region.region_id, search_conditions))
+                            or sg.group_name like '%{2}%');".format(
+                    tenant.tenant_id, region.region_id, search_conditions))  # type: ignore[union-attr]
                 domain_count = cursor.fetchall()
 
                 total = domain_count[0][0]
@@ -1158,14 +1183,15 @@ class ServiceTcpDomainQueryView(RegionTenantHeaderView):
                         and (std.end_point like '%{2}%' \
                             or std.service_alias like '%{2}%' \
                             or sg.group_name like '%{2}%') \
-                    order by type desc LIMIT {3},{4};".format(tenant.tenant_id, region.region_id, search_conditions, start,
-                                                              end))
+                    order by type desc LIMIT {3},{4};".format(
+                        tenant.tenant_id, region.region_id, search_conditions, start,  # type: ignore[union-attr]
+                        end))
                 tenant_tuples = cursor.fetchall()
             else:
                 # 获取总数
                 cursor = connection.cursor()
                 cursor.execute("select count(1) from service_tcp_domain where tenant_id='{0}' and region_id='{1}';".format(
-                    tenant.tenant_id, region.region_id))
+                    tenant.tenant_id, region.region_id))  # type: ignore[union-attr]
                 domain_count = cursor.fetchall()
 
                 total = domain_count[0][0]
@@ -1185,7 +1211,7 @@ class ServiceTcpDomainQueryView(RegionTenantHeaderView):
                         from service_tcp_domain
                         where tenant_id='{0}' and region_id='{1}' order by type desc
                         LIMIT {2},{3};
-                    """.format(tenant.tenant_id, region.region_id, start, end))
+                    """.format(tenant.tenant_id, region.region_id, start, end))  # type: ignore[union-attr]
                 tenant_tuples = cursor.fetchall()
         except Exception as e:
             logger.exception(e)
@@ -1202,7 +1228,7 @@ class ServiceTcpDomainQueryView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     group_id = int(gsr.group_id)
             domain_dict = dict()
@@ -1228,14 +1254,15 @@ class ServiceTcpDomainQueryView(RegionTenantHeaderView):
 
 # 查询应用下策略
 class AppServiceDomainQueryView(RegionTenantHeaderView):
-    def get(self, request, enterprise_id, team_name, app_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, team_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         search_conditions = request.GET.get("search_conditions", None)
         tenant = team_services.get_enterprise_tenant_by_tenant_name(enterprise_id, team_name)
         region = region_repo.get_region_by_region_name(self.response_region)
-        tenant_tuples, total = domain_service.get_app_service_domain_list(region, tenant, app_id, search_conditions, page,
-                                                                          page_size)
+        tenant_tuples, total = domain_service.get_app_service_domain_list(
+            region, tenant, app_id, search_conditions, page,  # type: ignore[arg-type]
+            page_size)
         # 拼接展示数据
         domain_list = list()
         for tenant_tuple in tenant_tuples:
@@ -1247,7 +1274,7 @@ class AppServiceDomainQueryView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     group_id = int(gsr.group_id)
             domain_dict = dict()
@@ -1275,7 +1302,7 @@ class AppServiceDomainQueryView(RegionTenantHeaderView):
             if isinstance(rewrites, str):
                 rewrites = eval(rewrites)
             domain_dict["rewrites"] = rewrites
-            domain_dict["group_id"] = group_id
+            domain_dict["group_id"] = group_id  # type: ignore[assignment]
             domain_list.append(domain_dict)
         bean = dict()
         bean["total"] = total
@@ -1285,15 +1312,16 @@ class AppServiceDomainQueryView(RegionTenantHeaderView):
 
 class AppServiceTcpDomainQueryView(RegionTenantHeaderView):
     # 查询应用下tcp/udp策略
-    def get(self, request, enterprise_id, team_name, app_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, team_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         search_conditions = request.GET.get("search_conditions", None)
         tenant = team_services.get_enterprise_tenant_by_tenant_name(enterprise_id, team_name)
         region = region_repo.get_region_by_region_name(self.response_region)
 
-        tenant_tuples, total = domain_service.get_app_service_tcp_domain_list(region, tenant, app_id, search_conditions, page,
-                                                                              page_size)
+        tenant_tuples, total = domain_service.get_app_service_tcp_domain_list(
+            region, tenant, app_id, search_conditions, page,  # type: ignore[arg-type]
+            page_size)
 
         # 拼接展示数据
         domain_list = list()
@@ -1305,7 +1333,7 @@ class AppServiceTcpDomainQueryView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     group_id = int(gsr.group_id)
             domain_dict = dict()
@@ -1332,7 +1360,7 @@ class AppServiceTcpDomainQueryView(RegionTenantHeaderView):
 # tcp/ucp策略操作
 class ServiceTcpDomainView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # 获取单个tcp/udp策略信息
         tcp_rule_id = request.GET.get("tcp_rule_id", None)
         # 判断参数
@@ -1349,7 +1377,7 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
             if service:
                 gsr = group_service_relation_repo.get_group_by_service_id(service.service_id)
                 if gsr:
-                    group = group_repo.get_group_by_id(int(gsr.group_id))
+                    group = group_repo.get_group_by_id(int(gsr.group_id))  # type: ignore[arg-type]
                     group_name = group.group_name if group else ''
                     g_id = int(gsr.group_id)
             bean.update({"service_alias": service_alias})
@@ -1363,7 +1391,7 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
 
     @never_cache
     # 添加
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         container_port = request.data.get("container_port", None)
         service_id = request.data.get("service_id", None)
         end_point = request.data.get("end_point", None)
@@ -1381,7 +1409,7 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
 
         # Check if the given endpoint exists.
         region = region_repo.get_region_by_region_name(service.service_region)
-        service_tcpdomain = tcp_domain.get_tcpdomain_by_end_point(region.region_id, end_point)
+        service_tcpdomain = tcp_domain.get_tcpdomain_by_end_point(region.region_id, end_point)  # type: ignore[union-attr]
         if service_tcpdomain:
             result = general_message(400, "failed", "策略已存在")
             return Response(result)
@@ -1406,14 +1434,15 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
             return Response(general_message(200, "not outer port", "没有开启对外端口", bean={"is_outer_service": False}), status=200)
 
         # 添加tcp策略
-        data = domain_service.bind_tcpdomain(self.tenant, self.user, service, end_point, container_port, default_port,
-                                             rule_extensions, default_ip)
+        data = domain_service.bind_tcpdomain(
+            self.tenant, self.user, service, end_point, container_port, default_port,  # type: ignore[assignment,arg-type]
+            rule_extensions, default_ip)
         result = general_message(200, "success", "tcp策略添加成功", bean=data)
         return Response(result, status=result["code"])
 
     @never_cache
     # 修改
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         container_port = request.data.get("container_port", None)
         service_id = request.data.get("service_id", None)
         end_point = request.data.get("end_point", None)
@@ -1426,12 +1455,12 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
         if not tcp_rule_id:
             return Response(general_message(400, "parameters are missing", "参数缺失"), status=400)
 
-        service = service_repo.get_service_by_service_id(service_id)
+        service = service_repo.get_service_by_service_id(service_id)  # type: ignore[arg-type]
         if not service:
             return Response(general_message(400, "not service", "组件不存在"), status=400)
 
         # 查询端口协议
-        tenant_service_port = port_service.get_service_port_by_port(service, container_port)
+        tenant_service_port = port_service.get_service_port_by_port(service, container_port)  # type: ignore[arg-type]
         if tenant_service_port:
             protocol = tenant_service_port.protocol
         else:
@@ -1439,14 +1468,16 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
 
         # Check if the given endpoint exists.
         region = region_repo.get_region_by_region_name(service.service_region)
-        service_tcpdomain = tcp_domain.get_tcpdomain_by_end_point(region.region_id, end_point)
+        service_tcpdomain = tcp_domain.get_tcpdomain_by_end_point(
+            region.region_id, end_point)  # type: ignore[union-attr,arg-type]
         if service_tcpdomain and service_tcpdomain[0].tcp_rule_id != tcp_rule_id:
             result = general_message(400, "failed", "策略已存在")
             return Response(result)
 
         # 修改策略
-        code, msg = domain_service.update_tcpdomain(self.tenant, self.user, service, end_point, container_port, tcp_rule_id,
-                                                    protocol, type, rule_extensions, default_ip)
+        code, msg = domain_service.update_tcpdomain(
+            self.tenant, self.user, service, end_point, container_port, tcp_rule_id,  # type: ignore[arg-type]
+            protocol, type, rule_extensions, default_ip)  # type: ignore[arg-type]
 
         if code != 200:
             return Response(general_message(code, "bind domain error", msg), status=code)
@@ -1457,7 +1488,7 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
 
     @never_cache
     # 删除
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         tcp_rule_id = request.data.get("tcp_rule_id", None)
 
         if not tcp_rule_id:
@@ -1469,24 +1500,24 @@ class ServiceTcpDomainView(RegionTenantHeaderView):
 
 # 给数据中心发请求获取可用端口
 class GetPortView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         ipres, ipdata = region_api.get_ips(self.response_region, self.tenant.tenant_name)
         if int(ipres.status) != 200:
             result = general_message(400, "call region error", "请求数据中心异常")
             return Response(result, status=400)
-        result = general_message(200, "success", "可用端口查询成功", list=ipdata.get("list"))
+        result = general_message(200, "success", "可用端口查询成功", list=ipdata.get("list"))  # type: ignore[union-attr]
         return Response(result, status=200)
 
 
 # 查看高级路由信息
 class GetSeniorUrlView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         http_rule_id = request.GET.get("http_rule_id", None)
         # 判断参数
         if not http_rule_id:
             return Response(general_message(400, "parameters are missing", "参数缺失"), status=400)
         service_domain = domain_repo.get_service_domain_by_http_rule_id(http_rule_id)
-        result = general_message(200, "success", "查询成功", bean=service_domain.to_dict())
+        result = general_message(200, "success", "查询成功", bean=service_domain.to_dict())  # type: ignore[union-attr]
         return Response(result, status=200)
 
 
@@ -1494,7 +1525,7 @@ class GetSeniorUrlView(RegionTenantHeaderView):
 class GatewayCustomConfigurationView(RegionTenantHeaderView):
     # 获取策略的网关自定义参数
     @never_cache
-    def get(self, request, rule_id, *args, **kwargs):
+    def get(self, request: Request, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         if not rule_id:
             return Response(general_message(400, "parameters are missing", "参数缺失"), status=400)
         cf = configuration_repo.get_configuration_by_rule_id(rule_id)
@@ -1507,7 +1538,7 @@ class GatewayCustomConfigurationView(RegionTenantHeaderView):
 
     # 修改网关的自定义参数
     @never_cache
-    def put(self, request, rule_id, *args, **kwargs):
+    def put(self, request: Request, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         value = parse_item(request, 'value', required=True, error='value is a required parameter')
         domain_service.update_http_rule_config(self.tenant, self.response_region, rule_id, value)
         result = general_message(200, "success", "更新成功")
@@ -1515,39 +1546,41 @@ class GatewayCustomConfigurationView(RegionTenantHeaderView):
 
 
 class VirtualMachineImageView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = vms.list_vm_image(self.tenant.tenant_id, self.response_region, self.tenant.tenant_name)
         result = general_message(200, "success", "查询成功", list=data)
         return Response(result, status=result["code"])
 
 
 class VirtualMachineCapabilityView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = vms.get_vm_capabilities(self.response_region, self.tenant.tenant_name)
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])
 
 
 class VirtualMachineAssetListView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = vms.list_vm_image(self.tenant.tenant_id, self.response_region, self.tenant.tenant_name)
         result = general_message(200, "success", "查询成功", list=data)
         return Response(result, status=result["code"])
 
 
 class VirtualMachineAssetManageView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         asset_id = kwargs.get("asset_id")
-        asset = vms.get_vm_asset(self.tenant.tenant_id, asset_id, self.response_region, self.tenant.tenant_name)
+        asset = vms.get_vm_asset(
+            self.tenant.tenant_id, asset_id, self.response_region, self.tenant.tenant_name)  # type: ignore[arg-type]
         if not asset:
             return Response(general_message(404, "vm asset not found", "虚拟机镜像资产不存在"), status=404)
         result = general_message(200, "success", "查询成功", bean=asset)
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         asset_id = kwargs.get("asset_id")
         try:
-            deleted, _ = vms.delete_vm_image(self.tenant.tenant_id, asset_id, self.response_region, self.tenant.tenant_name)
+            deleted, _ = vms.delete_vm_image(
+                self.tenant.tenant_id, asset_id, self.response_region, self.tenant.tenant_name)  # type: ignore[arg-type]
         except ValueError:
             result = general_message(409, "vm asset is referenced", "虚拟机镜像资产仍被引用，无法删除")
             return Response(result, status=409)

--- a/console/views/app_config/app_env.py
+++ b/console/views/app_config/app_env.py
@@ -4,6 +4,7 @@
 """
 import json
 import logging
+from typing import Any, Tuple
 
 from console.repositories.app import service_repo
 from console.repositories.app_config import env_var_repo
@@ -29,6 +30,7 @@ from console.views.app_config.base import AppBaseView
 from django.db import connection
 from django.forms.models import model_to_dict
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 from console.exception.main import AbortRequest
@@ -40,14 +42,14 @@ env_var_service = AppEnvVarService()
 
 class AppEnvView(AppBaseView):
     @staticmethod
-    def _get_page_limit(total, page, page_size):
+    def _get_page_limit(total: int, page: int, page_size: int) -> Tuple[int, int]:
         page = max(page, 1)
         page_size = max(page_size, 1)
         start = (page - 1) * page_size
         return start, min(page_size, max(total - start, 0))
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的环境变量参数
         ---
@@ -187,7 +189,7 @@ class AppEnvView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加环境变量
         ---
@@ -239,12 +241,15 @@ class AppEnvView(AppBaseView):
             return Response(general_message(400, "params error", "参数异常"), status=400)
         if scope not in ("inner", "outer"):
             return Response(general_message(400, "params error", "scope范围只能是inner或outer"), status=400)
-        code, msg, data = env_var_service.add_service_env_var(self.tenant, self.service, 0, name, attr_name, attr_value,
-                                                              is_change, scope, self.user.nick_name)
+        # NOTE: nick_name is str|None (backlog)
+        code, msg, data = env_var_service.add_service_env_var(
+            self.tenant, self.service, 0, name, attr_name, attr_value,
+            is_change, scope, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             result = general_message(code, "add env error", msg)
             return Response(result, status=code)
-        result = general_message(code, msg, "环境变量添加成功", bean=data.to_dict())
+        # NOTE: add_service_env_var may return None data (backlog)
+        result = general_message(code, msg, "环境变量添加成功", bean=data.to_dict())  # type: ignore[union-attr]
         new_information = env_var_service.json_service_env_var(attr_name=attr_name, attr_value=attr_value, name=name)
         comment = operation_log_service.generate_component_comment(
             operation=Operation.ADD,
@@ -266,7 +271,7 @@ class AppEnvView(AppBaseView):
 
 class AppEnvManageView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件的某个环境变量
         ---
@@ -294,7 +299,8 @@ class AppEnvManageView(AppBaseView):
         env = env_var_repo.get_env_by_ids_and_env_id(self.tenant.tenant_id, self.service.service_id, env_id)
         old_information = env_var_service.json_service_env_var(
             attr_name=env.attr_name, attr_value=env.attr_value, name=env.name)
-        env_var_service.delete_env_by_env_id(self.tenant, self.service, env_id, self.user.nick_name)
+        env_var_service.delete_env_by_env_id(
+            self.tenant, self.service, env_id, self.user.nick_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功")
         comment = operation_log_service.generate_component_comment(
             operation=Operation.DELETE,
@@ -314,7 +320,7 @@ class AppEnvManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的某个环境变量详情
         ---
@@ -341,11 +347,12 @@ class AppEnvManageView(AppBaseView):
             return Response(general_message(400, "attr_name not specify", "环境变量名未指定"))
         env = env_var_service.get_env_by_attr_name(self.tenant, self.service, attr_name)
 
-        result = general_message(200, "success", "查询成功", bean=model_to_dict(env))
+        # NOTE: get_env_by_attr_name may return None (backlog)
+        result = general_message(200, "success", "查询成功", bean=model_to_dict(env))  # type: ignore[arg-type]
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件环境变量
         ---
@@ -389,17 +396,19 @@ class AppEnvManageView(AppBaseView):
         new_information = env_var_service.json_service_env_var(attr_name=attr_name or env.attr_name, attr_value=attr_value,
                                                                name=name)
         code, msg, env = env_var_service.update_env_by_env_id(
-            self.tenant, self.service, env_id, name, attr_value, self.user.nick_name, attr_name=attr_name)
+            self.tenant, self.service, env_id, name, attr_value,
+            self.user.nick_name, attr_name=attr_name)  # type: ignore[arg-type]
         if code != 200:
             raise AbortRequest(msg="update value error", msg_show=msg, status_code=code)
-        result = general_message(200, "success", "更新成功", bean=model_to_dict(env))
+        # NOTE: update_env_by_env_id may return None env (backlog)
+        result = general_message(200, "success", "更新成功", bean=model_to_dict(env))  # type: ignore[arg-type]
         comment = operation_log_service.generate_component_comment(
             operation=Operation.UPDATE,
             module_name=self.service.service_cname,
             region=self.service.service_region,
             team_name=self.tenant.tenant_name,
             service_alias=self.service.service_alias,
-            suffix=" 下的环境变量 {}".format(env.attr_name))
+            suffix=" 下的环境变量 {}".format(env.attr_name))  # type: ignore[union-attr]
         operation_log_service.create_component_log(
             user=self.user,
             comment=comment,
@@ -412,12 +421,15 @@ class AppEnvManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def patch(self, request, env_id, *args, **kwargs):
+    def patch(self, request: Request, env_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         """变更环境变量范围"""
         scope = parse_item(request, 'scope', required=True, error="scope is is a required parameter")
-        env = env_var_service.patch_env_scope(self.tenant, self.service, env_id, scope, self.user.nick_name)
+        # NOTE: nick_name is str|None (backlog)
+        env = env_var_service.patch_env_scope(
+            self.tenant, self.service, env_id, scope, self.user.nick_name)  # type: ignore[arg-type]
+        # NOTE: env may be None here (deref precedes the `if env:` guard below) (backlog)
         old_information = env_var_service.json_service_env_var(
-            attr_name=env.attr_name, attr_value=env.attr_value, name=env.name)
+            attr_name=env.attr_name, attr_value=env.attr_value, name=env.name)  # type: ignore[union-attr]
         if env:
             comment = operation_log_service.generate_component_comment(
                 operation=Operation.TRANSFER,
@@ -441,7 +453,7 @@ class AppEnvManageView(AppBaseView):
 
 class AppBuildEnvView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取构建组件的环境变量参数
         ---
@@ -465,7 +477,8 @@ class AppBuildEnvView(AppBaseView):
         # 获取组件构建时环境变量
         build_env_dict = dict()
         build_envs = env_var_service.get_service_build_envs(self.service)
-        if build_envs and not supports_cnb_build_strategy(self.service.language):
+        # NOTE: service.language is str|None (backlog)
+        if build_envs and not supports_cnb_build_strategy(self.service.language):  # type: ignore[arg-type]
             for build_env in build_envs:
                 if build_env.attr_name in CNB_BUILD_ENV_NAMES:
                     build_env.delete()
@@ -489,7 +502,7 @@ class AppBuildEnvView(AppBaseView):
         return Response(result, status=result["code"])
 
     # 全量更新，build_env_dict必须为包含环境变量
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改构建运行时环境变量
         :param request:
@@ -553,7 +566,7 @@ class AppBuildEnvView(AppBaseView):
         for build_env in new_build_envs:
             new_build_env_dict[build_env.attr_name] = build_env.attr_value
 
-        source_build_state_service.save_user_snapshot(self.service, self.service.language)
+        source_build_state_service.save_user_snapshot(self.service, self.service.language)  # type: ignore[arg-type]
         new_information = json.dumps(new_build_env_dict, ensure_ascii=False)
         result = general_message(200, "success", "环境变量添加成功")
         comment = operation_log_service.generate_component_comment(

--- a/console/views/app_config/app_extend.py
+++ b/console/views/app_config/app_extend.py
@@ -4,11 +4,13 @@
 """
 
 import logging
+from typing import Any
 
 from console.services.app_config import extend_service
 from www.apiclient.regionapi import RegionInvokeApi
 from console.views.app_config.base import AppBaseView
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
@@ -18,7 +20,7 @@ region_api = RegionInvokeApi()
 
 class AppExtendView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件扩展方式
         ---

--- a/console/views/app_config/app_label.py
+++ b/console/views/app_config/app_label.py
@@ -3,8 +3,10 @@
   Created on 18/1/15.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.label_repo import (label_repo, node_label_repo, service_label_repo)
@@ -18,7 +20,7 @@ logger = logging.getLogger("default")
 
 class AppLabelView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件已使用和未使用的标签
         ---
@@ -40,7 +42,7 @@ class AppLabelView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加组件标签
         ---
@@ -64,7 +66,9 @@ class AppLabelView(AppBaseView):
         label_ids = request.data.get("label_ids", None)
         if not label_ids:
             return Response(general_message(400, "param error", "标签ID未指定"), status=400)
-        code, msg, event = label_service.add_service_labels(self.tenant, self.service, label_ids, self.user.nick_name)
+        # NOTE: nick_name is str|None (backlog)
+        code, msg, event = label_service.add_service_labels(
+            self.tenant, self.service, label_ids, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "add labels error", msg), status=code)
         result = general_message(200, "success", "标签添加成功")
@@ -85,7 +89,7 @@ class AppLabelView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件标签
         ---
@@ -112,7 +116,8 @@ class AppLabelView(AppBaseView):
         service_label = service_label_repo.get_service_label(self.service.service_id, label_id)
         if not service_label:
             return Response(general_message(400, "tag does not exist", "标签不存在"), status=400)
-        code, msg, event = label_service.delete_service_label(self.tenant, self.service, label_id, self.user.nick_name)
+        code, msg, event = label_service.delete_service_label(
+            self.tenant, self.service, label_id, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "add labels error", msg), status=code)
         result = general_message(200, "success", "标签删除成功")
@@ -136,7 +141,7 @@ class AppLabelView(AppBaseView):
 # 添加特性获取可用标签
 class AppLabelAvailableView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加特性获取可用标签
         :param request:
@@ -155,7 +160,7 @@ class AppLabelAvailableView(AppBaseView):
                 labels_name_list.append(label_obj.label_name)
         # 查询数据中心可使用的标签
         labels = label_service.list_available_labels(self.tenant, self.region_name)
-        for label in labels:
+        for label in labels:  # type: ignore[union-attr] # NOTE: list_available_labels may return None (backlog)
             labels_name_list.append(label.label_name)
 
         # 去除该组件已绑定的标签
@@ -170,8 +175,9 @@ class AppLabelAvailableView(AppBaseView):
         for labels_name in labels_name_list:
             label_dict = dict()
             label_oj = label_repo.get_labels_by_label_name(labels_name)
-            label_dict["label_id"] = label_oj.label_id
-            label_dict["label_alias"] = label_oj.label_alias
+            # NOTE: get_labels_by_label_name may return None (backlog)
+            label_dict["label_id"] = label_oj.label_id  # type: ignore[union-attr]
+            label_dict["label_alias"] = label_oj.label_alias  # type: ignore[union-attr]
             labels_list.append(label_dict)
 
         result = general_message(200, "success", "查询成功", list=labels_list)

--- a/console/views/app_config/app_log.py
+++ b/console/views/app_config/app_log.py
@@ -1,5 +1,8 @@
 # -*- coding: utf8 -*-
+from typing import Any
+
 from django.http.response import StreamingHttpResponse
+from rest_framework.request import Request
 
 from console.views.app_config.base import AppBaseView
 from console.services.app_config.component_logs import component_log_service
@@ -7,7 +10,7 @@ from console.exception.main import AbortRequest
 
 
 class ComponentLogView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> StreamingHttpResponse:
         pod_name = request.GET.get("pod_name")
         if not pod_name:
             raise AbortRequest("the field 'pod_name' is required")

--- a/console/views/app_config/app_mnt.py
+++ b/console/views/app_config/app_mnt.py
@@ -4,8 +4,10 @@
 """
 import json
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.app_config import volume_repo, mnt_repo
@@ -21,7 +23,7 @@ logger = logging.getLogger("default")
 
 class AppMntView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件挂载的组件
         ---
@@ -74,8 +76,10 @@ class AppMntView(AppBaseView):
         elif query_type == "unmnt":
             services = app_service.get_app_list(self.tenant.tenant_id, self.service.service_region, dep_app_name)
             services_ids = [s.service_id for s in services]
-            mnt_list, total = mnt_service.get_service_unmount_volume_list(self.tenant, self.service, services_ids, page,
-                                                                          page_size, is_config, dep_app_group, config_name)
+            # NOTE: page/page_size from GET are str|int (backlog)
+            mnt_list, total = mnt_service.get_service_unmount_volume_list(
+                self.tenant, self.service, services_ids, page,  # type: ignore[arg-type]
+                page_size, is_config, dep_app_group, config_name)  # type: ignore[arg-type]
         else:
             return Response(general_message(400, "param error", "参数错误"), status=400)
         result = general_message(200, "success", "查询成功", list=mnt_list, total=total)
@@ -83,7 +87,7 @@ class AppMntView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加挂载依赖
         ---
@@ -107,7 +111,8 @@ class AppMntView(AppBaseView):
         """
         dep_vol_data = request.data["body"]
         dep_vol_data = json.loads(dep_vol_data)
-        mnt_service.batch_mnt_serivce_volume(self.tenant, self.service, dep_vol_data, self.user.nick_name)
+        mnt_service.batch_mnt_serivce_volume(
+            self.tenant, self.service, dep_vol_data, self.user.nick_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "操作成功")
         volume_a, mnt_type = handle_mnt_info(dep_vol_data[0]["id"])
         suffix = " 挂载了{0} {1}".format(mnt_type, volume_a.volume_name)
@@ -136,7 +141,7 @@ class AppMntView(AppBaseView):
 
 class AppMntManageView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件取消挂载依赖
         ---
@@ -159,13 +164,16 @@ class AppMntManageView(AppBaseView):
 
         """
         dep_vol_id = kwargs.get("dep_vol_id", None)
-        mnt = volume_repo.get_service_volume_by_id(id=dep_vol_id)
+        mnt = volume_repo.get_service_volume_by_id(id=dep_vol_id)  # type: ignore[arg-type] # NOTE: dep_vol_id Any|None (backlog)
+        # NOTE: get_service_volume_by_id may return None (backlog)
         path = mnt_repo.get_mnt_relation_by_id(
-            service_id=self.service.service_id, dep_service_id=mnt.service_id, mnt_name=mnt.volume_name).mnt_dir
+            service_id=self.service.service_id, dep_service_id=mnt.service_id,  # type: ignore[union-attr]
+            mnt_name=mnt.volume_name).mnt_dir  # type: ignore[union-attr]
 
         old_mnt_list = mnt_service.get_service_mnt_details_byid([{"path": path, "id": dep_vol_id}])
 
-        code, msg = mnt_service.delete_service_mnt_relation(self.tenant, self.service, dep_vol_id, self.user.nick_name)
+        code, msg = mnt_service.delete_service_mnt_relation(
+            self.tenant, self.service, dep_vol_id, self.user.nick_name)  # type: ignore[arg-type]
 
         if code != 200:
             return Response(general_message(code, "add error", msg), status=code)
@@ -194,7 +202,7 @@ class AppMntManageView(AppBaseView):
         return Response(result, status=result["code"])
 
 
-def handle_mnt_info(dependency_volume_id):
+def handle_mnt_info(dependency_volume_id: Any) -> Any:
     volume = volume_repo.get_service_volume_by_pk(dependency_volume_id)
     if not volume:
         return

--- a/console/views/app_config/app_plugin.py
+++ b/console/views/app_config/app_plugin.py
@@ -4,10 +4,12 @@
 """
 import json
 import logging
+from typing import Any, List
 
 from console.services.app_config.plugin_service import app_plugin_service
 from console.services.plugin import plugin_version_service
 from console.views.app_config.base import AppBaseView
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.plugin import HasNoDownStreamService
@@ -19,7 +21,7 @@ logger = logging.getLogger("default")
 
 
 class APPPluginsView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件可用的插件列表
         ---
@@ -52,12 +54,13 @@ class APPPluginsView(AppBaseView):
             result = general_message(200, "success", "查询成功", bean=bean)
         except Exception as e:
             logger.exception(e)
-            result = general_message(500, e.message, "查询失败")
+            # NOTE: legacy py2-style Exception.message attr access (backlog)
+            result = general_message(500, e.message, "查询失败")  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class APPPluginInstallView(AppBaseView):
-    def useDefaultAttr(self, plugin_id, build_version, tag):
+    def useDefaultAttr(self, plugin_id: str, build_version: str, tag: str) -> List[Any]:
         metaTypeList = plugin_svc.get_service_meta_type(plugin_id, build_version)
         logger.debug("plugin.relation", "metatype List is {}".format(len(metaTypeList)))
         attrsList = []
@@ -84,7 +87,7 @@ class APPPluginInstallView(AppBaseView):
         logger.debug("plugin.relation", "attrsList is {}".format(attrsList))
         return attrsList
 
-    def post(self, request, plugin_id, *args, **kwargs):
+    def post(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件安装插件
         ---
@@ -118,14 +121,15 @@ class APPPluginInstallView(AppBaseView):
                 return Response(general_message(400, "params error", "参数错误"), status=400)
             if not build_version:
                 plugin_version = plugin_version_service.get_newest_usable_plugin_version(self.tenant.tenant_id, plugin_id)
-                build_version = plugin_version.build_version
+                # NOTE: get_newest_usable_plugin_version may return None (backlog)
+                build_version = plugin_version.build_version  # type: ignore[union-attr]
 
             # 1. 建立关联关系
             # 2. 生成默认的配置发送给前端
             # 3. 生成默认配置存储至console数据库
             # 4. 生成默认配置发送给region
             # >> 进行关联
-            body_relation = {}
+            body_relation: dict = {}
             body_relation["plugin_id"] = plugin_id
             body_relation["switch"] = True
             body_relation["version_id"] = build_version
@@ -150,7 +154,7 @@ class APPPluginInstallView(AppBaseView):
             config_envs = {}
             config_envs["normal_envs"] = normal
             config_envs["complex_envs"] = complex
-            body = {}
+            body: dict = {}
             body["tenant_id"] = self.tenant.tenant_id
             body["service_id"] = self.service.service_id
             body["config_envs"] = config_envs
@@ -170,7 +174,9 @@ class APPPluginInstallView(AppBaseView):
             except Exception as e:
                 logger.exception(e)
             result = general_message(400, "havs no downstream services", '缺少关联组件，不能使用该类型插件')
-            logger.exception(e)
+            # NOTE: latent bug — inner `except ... as e` deletes e, so this references a deleted
+            # variable (NameError at runtime if reached); behavior preserved as-is (backlog)
+            logger.exception(e)  # type: ignore[misc]
             return Response(result, status=400)
         except Exception as e:
             try:
@@ -181,10 +187,10 @@ class APPPluginInstallView(AppBaseView):
                 logger.exception(e)
                 pass
             result = general_message(500, "service relate plugin error", '关联插件失败')
-            logger.exception(e)
+            logger.exception(e)  # type: ignore[misc] # NOTE: deleted-variable latent bug, see above (backlog)
             return Response(result, status=500)
 
-    def delete(self, request, plugin_id, *args, **kwargs):
+    def delete(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件卸载插件
         ---
@@ -217,12 +223,12 @@ class APPPluginInstallView(AppBaseView):
                 return Response(result, status=200)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=200)
 
 
 class APPPluginOpenView(AppBaseView):
-    def put(self, request, plugin_id, *args, **kwargs):
+    def put(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         启停用组件插件
         ---
@@ -273,12 +279,12 @@ class APPPluginOpenView(AppBaseView):
                 return Response(result, result["code"])
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=result["code"])
 
 
 class APPPluginConfigView(AppBaseView):
-    def useDefaultAttr(self, plugin_id, build_version, tag):
+    def useDefaultAttr(self, plugin_id: str, build_version: str, tag: str) -> List[Any]:
         metaTypeList = plugin_svc.get_service_meta_type(plugin_id, build_version)
         logger.debug("plugin.relation", "metatype List is {}".format(len(metaTypeList)))
         attrsList = []
@@ -306,7 +312,7 @@ class APPPluginConfigView(AppBaseView):
         logger.debug("plugin.relation", "attrsList is {}".format(attrsList))
         return attrsList
 
-    def get(self, request, plugin_id, *args, **kwargs):
+    def get(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件插件查看配置
         ---
@@ -336,7 +342,7 @@ class APPPluginConfigView(AppBaseView):
         if not plugin_id or not build_version:
             logger.error("plugin.relation", '参数错误，plugin_id and version_id')
             return Response(general_message(400, "params error", "参数错误"), status=400)
-        result = {}
+        result: dict = {}
         try:
             result["config_group"] = self.useDefaultAttr(plugin_id, build_version, "get")
             build_relations = plugin_svc.get_tenant_service_plugin_relation_by_plugin(self.service.service_id, plugin_id)
@@ -356,10 +362,10 @@ class APPPluginConfigView(AppBaseView):
             return Response(general_message(409, "service has no dependence", "组件没有依赖其他组件，配置无效"), status=409)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, result["code"])
 
-    def put(self, request, plugin_id, *args, **kwargs):
+    def put(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件插件更新
         ---
@@ -399,7 +405,7 @@ class APPPluginConfigView(AppBaseView):
             config_envs = {}
             config_envs["normal_envs"] = normal
             config_envs["complex_envs"] = complex
-            body = {}
+            body: dict = {}
             body["tenant_id"] = self.tenant.tenant_id
             body["service_id"] = self.service.service_id
             body["config_envs"] = config_envs
@@ -409,5 +415,5 @@ class APPPluginConfigView(AppBaseView):
             return Response(result, result["code"])
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, result["code"])

--- a/console/views/app_config/app_port.py
+++ b/console/views/app_config/app_port.py
@@ -3,6 +3,7 @@
   Created on 18/1/15.
 """
 import logging
+from typing import Any
 
 from console.exception.main import AbortRequest
 from console.repositories.app_config import port_repo
@@ -12,6 +13,7 @@ from console.utils.reqparse import parse_item
 from console.views.app_config.base import AppBaseView
 from django.forms.models import model_to_dict
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import general_message
@@ -22,7 +24,7 @@ region_api = RegionInvokeApi()
 
 class AppPortView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的端口信息
         ---
@@ -71,14 +73,15 @@ class AppPortView(AppBaseView):
                 path = ("/api-gateway/v1/" + self.tenant_name + "/routes/http/domains?service_alias=" +
                         self.service.service_alias + "&port=" + str(port.container_port))
                 body = region_api.api_gateway_get_proxy(self.region, self.tenant.tenant_id, path, None)
-                if body.get("list", []):
+                # NOTE: regionapi may return None (backlog)
+                if body.get("list", []):  # type: ignore[union-attr]
                     port_info["bind_domains"] = [{
                         "protocol": "http",
                         "domain_type": "www",
                         "ID": -1,
                         "domain_name": host,
                         "container_port": port.container_port
-                    } for host in body.get("list", [])]
+                    } for host in body.get("list", [])]  # type: ignore[union-attr]
                     port_info["is_outer_service"] = len(port_info["bind_domains"]) > 0
                     port_info["is_outer_service"] = True
                     port.is_outer_service = True
@@ -90,11 +93,11 @@ class AppPortView(AppBaseView):
                 path = ("/api-gateway/v1/" + self.tenant_name + "/routes/tcp/domains?service_alias=" +
                         self.service.service_alias + "&port=" + str(port.container_port))
                 body = region_api.api_gateway_get_proxy(self.region, self.tenant.tenant_id, path, None)
-                if body.get("list", []):
+                if body.get("list", []):  # type: ignore[union-attr]
                     outer = False
                     tcp_domain_list = []
                     # list 是 nodeport 列表（整数）
-                    for nodeport in body.get("list", []):
+                    for nodeport in body.get("list", []):  # type: ignore[union-attr]
                         # 拼接成 0.0.0.0:nodeport 格式
                         tcp_domain_dict = {
                             "protocol": port.protocol,
@@ -121,7 +124,7 @@ class AppPortView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加端口
         ---
@@ -174,14 +177,16 @@ class AppPortView(AppBaseView):
             return Response(general_message(400, "params error", "缺少协议参数"), status=400)
         if not port_alias:
             port_alias = self.service.service_alias.upper().replace("-", "_") + str(port)
-        code, msg, port_info = port_service.add_service_port(self.tenant, self.service, port, protocol, port_alias,
-                                                             is_inner_service, is_outer_service, None, self.user.nick_name)
+        code, msg, port_info = port_service.add_service_port(
+            self.tenant, self.service, port, protocol, port_alias,
+            is_inner_service, is_outer_service, None, self.user.nick_name)  # type: ignore[arg-type]
         tenant_service_port = port_service.get_service_port_by_port(self.service, port)
         new_information = port_service.json_service_port(tenant_service_port)
         if code != 200:
             return Response(general_message(code, "add port error", msg), status=code)
 
-        result = general_message(200, "success", "端口添加成功", bean=model_to_dict(port_info))
+        # NOTE: add_service_port may return None port_info (backlog)
+        result = general_message(200, "success", "端口添加成功", bean=model_to_dict(port_info))  # type: ignore[arg-type]
         comment = operation_log_service.generate_component_comment(
             operation=Operation.ADD,
             module_name=self.service.service_cname,
@@ -203,7 +208,7 @@ class AppPortView(AppBaseView):
 
 class AppPortManageView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查看组件的某个端口的详情
         ---
@@ -238,7 +243,7 @@ class AppPortManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件的某个端口
         ---
@@ -265,7 +270,8 @@ class AppPortManageView(AppBaseView):
             raise AbortRequest("container_port not specify", "端口变量名未指定")
         tenant_service_port = port_service.get_service_port_by_port(self.service, container_port)
         old_information = port_service.json_service_port(tenant_service_port)
-        data = port_service.delete_port_by_container_port(self.tenant, self.service, int(container_port), self.user.nick_name)
+        data = port_service.delete_port_by_container_port(
+            self.tenant, self.service, int(container_port), self.user.nick_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功", bean=model_to_dict(data))
         comment = operation_log_service.generate_component_comment(
             operation=Operation.DELETE,
@@ -285,7 +291,7 @@ class AppPortManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件的某个端口（打开|关闭|修改协议|修改环境变量）
         ---
@@ -329,23 +335,26 @@ class AppPortManageView(AppBaseView):
         k8s_service_name = parse_item(request, "k8s_service_name", default="")
         if not container_port:
             raise AbortRequest("container_port not specify", "端口变量名未指定")
-        if self.service.service_source == "third_party" and ("outer" in action):
+        # NOTE: action from request.data may be None (backlog)
+        if self.service.service_source == "third_party" and ("outer" in action):  # type: ignore[operator]
             msg, msg_show, code = port_service.check_domain_thirdpart(self.tenant, self.service)
             if code != 200:
                 logger.exception(msg, msg_show)
                 return Response(general_message(code, msg, msg_show), status=code)
         tenant_service_port = port_service.get_service_port_by_port(self.service, container_port)
         old_information = port_service.json_service_port(tenant_service_port)
-        code, msg, data = port_service.manage_port(self.tenant, self.service, self.response_region, int(container_port), action,
-                                                   protocol, port_alias, k8s_service_name, self.user.nick_name, self.app)
+        code, msg, data = port_service.manage_port(
+            self.tenant, self.service, self.response_region, int(container_port), action,  # type: ignore[arg-type]
+            protocol, port_alias, k8s_service_name, self.user.nick_name, self.app)  # type: ignore[arg-type]
         new_information = port_service.json_service_port(tenant_service_port)
         if code != 200:
             return Response(general_message(code, "change port fail", msg), status=code)
-        result = general_message(200, "success", "操作成功", bean=model_to_dict(data))
+        # NOTE: manage_port may return None data (backlog)
+        result = general_message(200, "success", "操作成功", bean=model_to_dict(data))  # type: ignore[arg-type]
         op = Operation.CHANGE
-        if action in "open_outer|open_inner":
+        if action in "open_outer|open_inner":  # type: ignore[operator]
             op = Operation.OPEN
-        if action in "close_outer|close_inner":
+        if action in "close_outer|close_inner":  # type: ignore[operator]
             op = Operation.CLOSE
         comment = operation_log_service.generate_component_comment(
             operation=op,
@@ -353,7 +362,8 @@ class AppPortManageView(AppBaseView):
             region=self.service.service_region,
             team_name=self.tenant.tenant_name,
             service_alias=self.service.service_alias,
-            suffix=" 端口 {} 的{}".format(container_port, operation_log_service.port_action_to_zh(action)))
+            suffix=" 端口 {} 的{}".format(
+                container_port, operation_log_service.port_action_to_zh(action)))  # type: ignore[arg-type]
         operation_log_service.create_component_log(
             user=self.user,
             comment=comment,
@@ -368,7 +378,7 @@ class AppPortManageView(AppBaseView):
 
 class AppTcpOuterManageView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取当前可修改的tcp端口信息
         ---
@@ -400,7 +410,7 @@ class AppTcpOuterManageView(AppBaseView):
 
 class TopologicalPortView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件拓扑图打开(关闭)对外端口
         :param request:
@@ -413,15 +423,18 @@ class TopologicalPortView(AppBaseView):
         container_port = request.data.get("container_port", None)
         # 开启对外端口
         if open_outer:
-            tenant_service_port = port_service.get_service_port_by_port(self.service, int(container_port))
+            # NOTE: container_port from request.data may be None (backlog)
+            tenant_service_port = port_service.get_service_port_by_port(
+                self.service, int(container_port))  # type: ignore[arg-type]
             if self.service.service_source == "third_party":
                 msg, msg_show, code = port_service.check_domain_thirdpart(self.tenant, self.service)
                 if code != 200:
                     logger.exception(msg, msg_show)
                     return Response(general_message(code, msg, msg_show), status=code)
-            code, msg, data = port_service.manage_port(self.tenant, self.service, self.response_region, int(container_port),
-                                                       "open_outer", tenant_service_port.protocol,
-                                                       tenant_service_port.port_alias)
+            code, msg, data = port_service.manage_port(
+                self.tenant, self.service, self.response_region, int(container_port),  # type: ignore[arg-type]
+                "open_outer", tenant_service_port.protocol,
+                tenant_service_port.port_alias)
             if code != 200:
                 return Response(general_message(412, "open outer fail", "打开对外端口失败"), status=412)
             return Response(general_message(200, "open outer success", "开启成功"), status=200)
@@ -431,7 +444,8 @@ class TopologicalPortView(AppBaseView):
             for tenant_service_port in tenant_service_ports:
                 code, msg, data = port_service.manage_port(
                     self.tenant, self.service, self.response_region, tenant_service_port.container_port, "close_outer",
-                    tenant_service_port.protocol, tenant_service_port.port_alias, user_name=self.user.nick_name, app=self.app)
+                    tenant_service_port.protocol, tenant_service_port.port_alias,
+                    user_name=self.user.nick_name, app=self.app)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(412, "open outer fail", "关闭对外端口失败"), status=412)
             return Response(general_message(200, "close outer success", "关闭对外端口成功"), status=200)
@@ -450,8 +464,10 @@ class TopologicalPortView(AppBaseView):
             if len(port_list) == 1:
                 # 一个端口直接开启
                 tenant_service_port = port_service.get_service_port_by_port(self.service, int(port_list[0]))
-                code, msg, data = port_service.manage_port(self.tenant, self.service, self.response_region, int(
-                    port_list[0]), "open_outer", tenant_service_port.protocol, tenant_service_port.port_alias, user_name=self.user.nick_name, app=self.app)
+                code, msg, data = port_service.manage_port(
+                    self.tenant, self.service, self.response_region, int(port_list[0]), "open_outer",
+                    tenant_service_port.protocol, tenant_service_port.port_alias,
+                    user_name=self.user.nick_name, app=self.app)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(412, "open outer fail", "打开对外端口失败"), status=412)
                 return Response(general_message(200, "open outer success", "开启成功"), status=200)

--- a/console/views/app_config/app_probe.py
+++ b/console/views/app_config/app_probe.py
@@ -3,8 +3,10 @@
   Created on 18/1/15.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.serializer import ProbeSerilizer
@@ -18,7 +20,7 @@ logger = logging.getLogger("default")
 
 class AppProbeView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件指定模式的探针
         ---
@@ -43,14 +45,15 @@ class AppProbeView(AppBaseView):
             code, msg, probe = probe_service.get_service_probe(self.service)
             if code != 200:
                 return Response(general_message(code, "get probe error", msg))
-            result = general_message(200, "success", "查询成功", bean=probe.to_dict())
+            # NOTE: probe is None only on code!=200 path which already returned above (backlog)
+            result = general_message(200, "success", "查询成功", bean=probe.to_dict())  # type: ignore[union-attr]
         else:
             mode = request.GET.get("mode", None)
             if not mode:
                 code, msg, probe = probe_service.get_service_probe(self.service)
                 if code != 200:
                     return Response(general_message(code, "get probe error", msg))
-                result = general_message(200, "success", "查询成功", bean=probe.to_dict())
+                result = general_message(200, "success", "查询成功", bean=probe.to_dict())  # type: ignore[union-attr]
             else:
                 code, msg, probe = probe_service.get_service_probe_by_mode(self.service, mode)
                 if code != 200:
@@ -62,7 +65,7 @@ class AppProbeView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加组件探针
         ---
@@ -98,7 +101,7 @@ class AppProbeView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件探针,包括启用停用 mode参数必填
         ---
@@ -107,7 +110,8 @@ class AppProbeView(AppBaseView):
         data = request.data
         _, _, old_probe = probe_service.get_service_probe(self.service)
         probe = probe_service.update_service_probea(
-            tenant=self.tenant, service=self.service, data=data, user_name=self.user.nick_name)
+            tenant=self.tenant, service=self.service, data=data,
+            user_name=self.user.nick_name)  # type: ignore[arg-type] # NOTE: nick_name is str|None (backlog)
         result = general_message(200, "success", "修改成功", bean=(probe.to_dict() if probe else probe))
         old_information = ''
         if old_probe:

--- a/console/views/app_config/app_volume.py
+++ b/console/views/app_config/app_volume.py
@@ -4,8 +4,10 @@
 """
 import re
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.app_config import volume_repo
@@ -22,7 +24,7 @@ region_api = RegionInvokeApi()
 logger = logging.getLogger("default")
 
 
-def ensure_volume_mode(mode):
+def ensure_volume_mode(mode: Any) -> Any:
     if type(mode) != int:
         raise AbortRequest("mode be a number between 0 and 777 (octal)", msg_show="权限必须是在0和777之间的八进制数")
     regex = re.compile(r"^[0-7]{1,3}$")
@@ -33,7 +35,7 @@ def ensure_volume_mode(mode):
 
 class AppVolumeOptionsView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件可用的存储列表
         ---
@@ -46,7 +48,7 @@ class AppVolumeOptionsView(AppBaseView):
 
 class AppVolumeView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的持久化路径
         ---
@@ -69,13 +71,14 @@ class AppVolumeView(AppBaseView):
         if is_config:
             for tenant_service_volume in volumes:
                 volume = volume_repo.get_service_volume_by_pk(tenant_service_volume["ID"])
-                cf_file = volume_repo.get_service_config_file(volume)
+                # NOTE: get_service_volume_by_pk may return None (backlog)
+                cf_file = volume_repo.get_service_config_file(volume)  # type: ignore[arg-type]
                 if cf_file:
                     tenant_service_volume["file_content"] = cf_file.file_content
                 volumes_list.append(tenant_service_volume)
         else:
             dependents = mnt_service.get_volume_dependent(self.tenant, self.service)
-            name2deps = {}
+            name2deps: dict = {}
             if dependents:
                 for dep in dependents:
                     if name2deps.get(dep["volume_name"], None) is None:
@@ -90,7 +93,7 @@ class AppVolumeView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         为组件添加持久化目录
         ---
@@ -124,7 +127,7 @@ class AppVolumeView(AppBaseView):
         """
         volume_name = request.data.get("volume_name", None)
         r = re.compile('(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$')
-        if not r.match(volume_name):
+        if not r.match(volume_name):  # type: ignore[arg-type] # NOTE: volume_name from request.data is Any|None (backlog)
             raise AbortRequest(msg="volume name illegal", msg_show="持久化名称只支持数字字母下划线")
         volume_type = request.data.get("volume_type", None)
         volume_path = request.data.get("volume_path", None)
@@ -150,24 +153,25 @@ class AppVolumeView(AppBaseView):
         settings['allow_expansion'] = allow_expansion
         if self.service.extend_method == "vm" and volume_type != "config-file":
             settings, _ = volume_service.build_vm_live_migration_volume_settings(
-                self.tenant, self.service, volume_type, settings)
-            volume_path = volume_service.resolve_vm_volume_path(self.service, volume_path)
+                self.tenant, self.service, volume_type, settings)  # type: ignore[arg-type]
+            volume_path = volume_service.resolve_vm_volume_path(self.service, volume_path)  # type: ignore[arg-type]
+        # NOTE: request.data.get values are Any|None / nick_name str|None (backlog)
         new_information = volume_service.json_service_volume(
-            volume_type=volume_type,
-            volume_name=volume_name,
-            volume_path=volume_path,
+            volume_type=volume_type,  # type: ignore[arg-type]
+            volume_name=volume_name,  # type: ignore[arg-type]
+            volume_path=volume_path,  # type: ignore[arg-type]
             volume_cap=volume_capacity,
             mode=mode,
             file_content=file_content)
         data = volume_service.add_service_volume(
             self.tenant,
             self.service,
-            volume_path,
-            volume_type,
-            volume_name,
+            volume_path,  # type: ignore[arg-type]
+            volume_type,  # type: ignore[arg-type]
+            volume_name,  # type: ignore[arg-type]
             file_content,
             settings,
-            self.user.nick_name,
+            self.user.nick_name,  # type: ignore[arg-type]
             mode=mode)
         result = general_message(200, "success", "持久化路径添加成功", bean=data.to_dict())
         src_suffix = " 下的配置文件 {}".format(volume_name) if volume_type == "config-file" else " 下的存储 {}".format(volume_name)
@@ -192,7 +196,7 @@ class AppVolumeView(AppBaseView):
 
 class AppVolumeFileUploadView(AppBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         通过上传文件的方式更新配置文件内容
         ---
@@ -320,7 +324,7 @@ class AppVolumeFileUploadView(AppBaseView):
 
 class AppVolumeManageView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件的某个持久化路径
         ---
@@ -348,17 +352,19 @@ class AppVolumeManageView(AppBaseView):
             return Response(general_message(400, "attr_name not specify", "未指定需要删除的持久化路径"), status=400)
         volume = volume_repo.get_service_volume_by_pk(volume_id)
         file_content = ""
-        if volume.volume_type == "config-file":
-            file_content = volume_repo.get_service_config_file(volume).file_content
+        # NOTE: get_service_volume_by_pk / get_service_config_file may return None (backlog)
+        if volume.volume_type == "config-file":  # type: ignore[union-attr]
+            file_content = volume_repo.get_service_config_file(volume).file_content  # type: ignore[arg-type,union-attr]
         old_information = volume_service.json_service_volume(
-            volume_name=volume.volume_name,
-            volume_path=volume.volume_path,
-            mode=volume.mode,
+            volume_name=volume.volume_name,  # type: ignore[union-attr]
+            volume_path=volume.volume_path,  # type: ignore[union-attr]
+            mode=volume.mode,  # type: ignore[union-attr]
             file_content=file_content,
-            volume_cap=volume.volume_capacity,
-            volume_type=volume.volume_type)
-        code, msg, volume = volume_service.delete_service_volume_by_id(self.tenant, self.service, int(volume_id),
-                                                                       self.user.nick_name, force)
+            volume_cap=volume.volume_capacity,  # type: ignore[union-attr]
+            volume_type=volume.volume_type)  # type: ignore[union-attr]
+        # NOTE: nick_name is str|None (backlog)
+        code, msg, volume = volume_service.delete_service_volume_by_id(
+            self.tenant, self.service, int(volume_id), self.user.nick_name, force)  # type: ignore[arg-type]
         if code != 200:
             result = general_message(code=code, msg="delete volume error", msg_show=msg, list=volume)
             return Response(result, status=result["code"])
@@ -384,7 +390,7 @@ class AppVolumeManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改存储设置
         :param request:
@@ -405,10 +411,11 @@ class AppVolumeManageView(AppBaseView):
         if volume_capacity in ("", None):
             volume_capacity = None
         else:
-            volume_capacity = int(volume_capacity)
+            volume_capacity = int(volume_capacity)  # type: ignore[arg-type] # NOTE: volume_capacity is Any|None (backlog)
         target_volume_capacity = volume.volume_capacity if volume_capacity is None else volume_capacity
         if self.service.extend_method == "vm" and volume.volume_type != "config-file":
-            new_volume_path = volume_service.resolve_vm_volume_path(self.service, new_volume_path, current_volume=volume)
+            new_volume_path = volume_service.resolve_vm_volume_path(
+                self.service, new_volume_path, current_volume=volume)  # type: ignore[arg-type]
         mode = request.data.get("mode")
         if mode is not None:
             mode = ensure_volume_mode(mode)
@@ -426,7 +433,7 @@ class AppVolumeManageView(AppBaseView):
 
         new_information = volume_service.json_service_volume(
             volume_name=volume.volume_name,
-            volume_path=new_volume_path,
+            volume_path=new_volume_path,  # type: ignore[arg-type] # NOTE: new_volume_path is Any|None (backlog)
             mode=mode,
             file_content=new_file_content,
             volume_type=volume.volume_type,
@@ -457,16 +464,17 @@ class AppVolumeManageView(AppBaseView):
                 return Response(general_message(405, "update failed", "修改失败"), status=405)
 
         # 更新数据库
-        volume.volume_path = new_volume_path
+        volume.volume_path = new_volume_path  # type: ignore[assignment] # NOTE: new_volume_path is Any|None (backlog)
         if volume_capacity is not None:
             volume.volume_capacity = volume_capacity
         if mode is not None:
             volume.mode = mode
         volume.save()
+        # NOTE: service_config may be None here for non config-file paths (backlog)
         if volume.volume_type == 'config-file':
-            service_config.volume_name = volume.volume_name
-            service_config.file_content = new_file_content
-            service_config.save()
+            service_config.volume_name = volume.volume_name  # type: ignore[union-attr]
+            service_config.file_content = new_file_content  # type: ignore[union-attr]
+            service_config.save()  # type: ignore[union-attr]
 
         result = general_message(200, "success", "修改成功")
         src_suffix = " 下的配置文件 {}".format(

--- a/console/views/app_config/base.py
+++ b/console/views/app_config/base.py
@@ -3,7 +3,9 @@
   Created on 18/1/15.
 """
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import BusinessException, AbortRequest, ServiceHandleException
@@ -18,13 +20,19 @@ logger = logging.getLogger('default')
 
 
 class AppBaseView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
+    # service is populated and guarded in initial(); app/component are loosely typed
+    # (app via get_app_by_id, component is set by subclasses) — see P5 convention.
+    service: TenantServiceInfo
+    app: Any
+    component: Any
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(AppBaseView, self).__init__(*args, **kwargs)
-        self.service = None
+        self.service = None  # type: ignore[assignment]
         self.app = None
         self.component = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(AppBaseView, self).initial(request, *args, **kwargs)
         service_alias = kwargs.get("serviceAlias", None)
         if not service_alias:
@@ -59,29 +67,31 @@ class AppBaseView(RegionTenantHeaderView):
         app = group_service.get_service_group_info(self.service.service_id)
         if not app:
             raise ServiceHandleException("app not found", "应用不存在", 404, 404)
-        self.app = group_service.get_app_by_id(self.tenant, self.region_name, app.ID)
+        self.app = group_service.get_app_by_id(self.tenant, self.region_name, app.ID)  # type: ignore[arg-type]
         if not self.app:
             raise ServiceHandleException("app not found", "应用不存在", 404, 404)
 
 
 class AppBaseCloudEnterpriseCenterView(AppBaseView, CloudEnterpriseCenterView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(AppBaseCloudEnterpriseCenterView, self).__init__(*args, **kwargs)
         self.oauth_instance = None
         self.oauth = None
         self.oauth_user = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         AppBaseView.initial(self, request, *args, **kwargs)
         CloudEnterpriseCenterView.initial(self, request, *args, **kwargs)
 
 
 class ComponentGraphBaseView(AppBaseView):
-    def __init__(self, *args, **kwargs):
+    graph: Any
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(ComponentGraphBaseView, self).__init__(*args, **kwargs)
         self.graph = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(ComponentGraphBaseView, self).initial(request, *args, **kwargs)
         try:
             graph_id = kwargs.get("graph_id", None)

--- a/console/views/app_config/graph.py
+++ b/console/views/app_config/graph.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import json
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
@@ -12,12 +14,13 @@ from console.utils.reqparse import parse_item
 
 
 class ComponentGraphListView(AppBaseView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = CreateComponentGraphReq(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.data
-        graph = component_graph_service.create_component_graph(self.service.service_id, data['title'], data['promql'],
-                                                               self.service.arch)
+        graph = component_graph_service.create_component_graph(
+            self.service.service_id, data['title'], data['promql'],
+            self.service.arch)  # type: ignore[arg-type] # NOTE: service.arch is str|None (backlog)
         result = general_message(200, "success", "创建成功", bean=graph)
         new_information = json.dumps({"图表标题": request.data["title"], "查询条件": request.data["promql"]},
                                      ensure_ascii=False)
@@ -39,12 +42,12 @@ class ComponentGraphListView(AppBaseView):
         )
         return Response(result, status=result["code"])
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         graphs = component_graph_service.list_component_graphs(self.service.service_id)
         result = general_message(200, "success", "查询成功", list=graphs)
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         graph_ids = parse_item(request, "graph_ids", required=True)
         graphs = component_graph_service.select_component_graphs(self.service.service_id, graph_ids)
         old_information = component_graph_service.json_component_graphs(graphs)
@@ -69,17 +72,18 @@ class ComponentGraphListView(AppBaseView):
 
 
 class ComponentGraphView(ComponentGraphBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         result = general_message(200, "success", "查询成功", bean=self.graph.to_dict())
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = UpdateComponentGraphReq(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.data
         old_information = json.dumps({"图表标题": self.graph.title, "查询条件": self.graph.promql}, ensure_ascii=False)
-        graphs = component_graph_service.update_component_graph(self.graph, data["title"], data["promql"], data["sequence"],
-                                                                self.service.arch)
+        graphs = component_graph_service.update_component_graph(
+            self.graph, data["title"], data["promql"], data["sequence"],
+            self.service.arch)  # type: ignore[arg-type]
         new_information = json.dumps({"图表标题": self.graph.title, "查询条件": self.graph.promql}, ensure_ascii=False)
         result = general_message(200, "success", "修改成功", list=graphs)
         comment = operation_log_service.generate_component_comment(
@@ -100,7 +104,7 @@ class ComponentGraphView(ComponentGraphBaseView):
             new_information=new_information)
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         old_information = json.dumps({"图表标题": self.graph.title, "查询条件": self.graph.promql}, ensure_ascii=False)
         graphs = component_graph_service.delete_component_graph(self.graph)
         result = general_message(200, "success", "删除成功", list=graphs)
@@ -123,10 +127,12 @@ class ComponentGraphView(ComponentGraphBaseView):
 
 
 class ComponentInternalGraphsView(AppBaseView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         graph_name = parse_item(request, "graph_name", required=True)
-        graphs = component_graph_service.create_internal_graphs(self.service.service_id, graph_name, self.service.arch)
-        new_information = component_graph_service.json_component_graphs(graphs)
+        graphs = component_graph_service.create_internal_graphs(
+            self.service.service_id, graph_name, self.service.arch)  # type: ignore[arg-type]
+        # NOTE: json_component_graphs is typed for QuerySet but receives a list here (backlog)
+        new_information = component_graph_service.json_component_graphs(graphs)  # type: ignore[arg-type]
         result = general_message(200, "success", "导入成功")
         comment = operation_log_service.generate_component_comment(
             operation=Operation.FOR,
@@ -145,14 +151,14 @@ class ComponentInternalGraphsView(AppBaseView):
             new_information=new_information)
         return Response(result, status=result["code"])
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         graphs = component_graph_service.list_internal_graphs()
         result = general_message(200, "success", "查询成功", list=graphs)
         return Response(result, status=result["code"])
 
 
 class ComponentExchangeGraphsView(AppBaseView):
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = ExchangeComponentGraphsReq(data=request.data)
         serializer.is_valid(raise_exception=True)
         graph_ids = serializer.data["graph_ids"]

--- a/console/views/app_config/service_monitor.py
+++ b/console/views/app_config/service_monitor.py
@@ -1,4 +1,7 @@
 # -*- coding: utf8 -*-
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.app_config import component_service_monitor
@@ -9,7 +12,7 @@ from www.utils.return_message import general_data, general_message
 
 
 class ComponentServiceMonitorView(AppBaseView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         port = request.data.get("port", None)
         name = request.data.get("name", None)
         service_show_name = request.data.get("service_show_name", None)
@@ -40,13 +43,13 @@ class ComponentServiceMonitorView(AppBaseView):
             new_information=new_information)
         return Response(status=200, data=general_data(bean=sm.to_dict()))
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         sms = component_service_monitor.get_component_service_monitors(self.tenant.tenant_id, self.service.service_id)
         return Response(status=200, data=general_data(list=[p.to_dict() for p in sms]))
 
 
 class ComponentServiceMonitorEditView(AppBaseView):
-    def put(self, request, name, *args, **kwargs):
+    def put(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         port = request.data.get("port", None)
         service_show_name = request.data.get("service_show_name", None)
         path = request.data.get("path", "/metrics")
@@ -61,7 +64,8 @@ class ComponentServiceMonitorEditView(AppBaseView):
         new_information = component_service_monitor.json_component_service_monitor(
             name=name, s_name=service_show_name, interval=interval, path=path, port=port)
         old_information = component_service_monitor.json_component_service_monitor(
-            name=old.name, s_name=old.service_show_name, interval=old.interval, path=old.path, port=old.port)
+            name=old.name, s_name=old.service_show_name, interval=old.interval, path=old.path,  # type: ignore[union-attr]
+            port=old.port)  # type: ignore[union-attr] # NOTE: get_component_service_monitor may return None (backlog)
         comment = operation_log_service.generate_component_comment(
             operation=Operation.UPDATE,
             module_name=self.service.service_cname,
@@ -78,9 +82,9 @@ class ComponentServiceMonitorEditView(AppBaseView):
             service_alias=self.service.service_alias,
             new_information=new_information,
             old_information=old_information)
-        return Response(status=200, data=general_data(bean=sm.to_dict()))
+        return Response(status=200, data=general_data(bean=sm.to_dict()))  # type: ignore[union-attr]
 
-    def delete(self, request, name, *args, **kwargs):
+    def delete(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         sm = component_service_monitor.delete_component_service_monitor(self.tenant, self.service, self.user, name)
         comment = operation_log_service.generate_component_comment(
             operation=Operation.DELETE,
@@ -101,13 +105,13 @@ class ComponentServiceMonitorEditView(AppBaseView):
             old_information=old_information)
         return Response(status=200, data=general_data(bean=sm.to_dict()))
 
-    def get(self, request, name, *args, **kwargs):
+    def get(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         sm = component_service_monitor.get_component_service_monitor(self.tenant.tenant_id, self.service.service_id, name)
-        return Response(status=200, data=general_data(bean=sm.to_dict()))
+        return Response(status=200, data=general_data(bean=sm.to_dict()))  # type: ignore[union-attr]
 
 
 class ComponentMetricsView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         metrics = monitor_service.get_monitor_metrics(
             self.region_name, self.tenant, "component", component_id=self.service.service_id)
         return Response(general_message(200, "OK", "获取成功", list=metrics), status=200)

--- a/console/views/app_config_group.py
+++ b/console/views/app_config_group.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.app_config_group import app_config_group_service
@@ -12,7 +15,7 @@ from console.exception.main import AbortRequest
 
 
 class ListAppConfigGroupView(ApplicationView):
-    def post(self, request, team_name, app_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = AppConfigGroupCreateSerilizer(data=request.data)
         serializer.is_valid()
         params = serializer.data
@@ -34,7 +37,7 @@ class ListAppConfigGroupView(ApplicationView):
         operation_log_service.create_app_log(self, comment, format_app=False, new_information=new_information)
         return Response(status=200, data=general_data(bean=acg))
 
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             page = int(request.GET.get("page", 1))
         except ValueError:
@@ -49,7 +52,7 @@ class ListAppConfigGroupView(ApplicationView):
 
 
 class AppConfigGroupView(ApplicationView):
-    def put(self, request, team_name, app_id, name, *args, **kwargs):
+    def put(self, request: Request, team_name: str, app_id: str, name: str, *args: Any, **kwargs: Any) -> Response:
         serializer = AppConfigGroupUpdateSerilizer(data=request.data)
         serializer.is_valid()
         params = serializer.data
@@ -80,18 +83,20 @@ class AppConfigGroupView(ApplicationView):
             self, comment, format_app=False, new_information=new_information, old_information=old_information)
         return Response(status=200, data=general_data(bean=acg))
 
-    def get(self, request, app_id, name, *args, **kwargs):
+    def get(self, request: Request, app_id: str, name: str, *args: Any, **kwargs: Any) -> Response:
         acg = app_config_group_service.get_config_group(self.region_name, app_id, name)
         return Response(status=200, data=general_data(bean=acg))
 
-    def delete(self, request, team_name, app_id, name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, app_id: str, name: str, *args: Any, **kwargs: Any) -> Response:
         acg = app_config_group_service.delete_config_group(self.region_name, team_name, app_id, name)
-        service_names = [service["service_cname"] for service in acg["services"]]
-        config_items = [{"变量名": item["item_key"], "变量值": item["item_value"]} for item in acg["config_items"]]
+        # NOTE: delete_config_group returns None; indexing acg raises TypeError at runtime (real bug, backlog).
+        service_names = [service["service_cname"] for service in acg["services"]]  # type: ignore[index]
+        config_items = [{"变量名": item["item_key"], "变量值": item["item_value"]}
+                        for item in acg["config_items"]]  # type: ignore[index]
         old_information = app_config_group_service.json_config_groups(
-            config_group_name=acg["config_group_name"],
+            config_group_name=acg["config_group_name"],  # type: ignore[index]
             config_items=config_items,
-            enable=acg["enable"],
+            enable=acg["enable"],  # type: ignore[index]
             services_names=service_names)
         app_config_group_service.delete_config_group(self.region_name, team_name, app_id, name)
         app_name = operation_log_service.process_app_name(self.app.app_name, self.region_name, self.tenant_name,
@@ -101,7 +106,7 @@ class AppConfigGroupView(ApplicationView):
         return Response(status=200, data=general_data(bean=acg))
 
 
-def check_services(app_id, req_service_ids):
+def check_services(app_id: str, req_service_ids: Any) -> None:
     services = group_service.get_group_services(app_id)
     service_ids = [service.service_id for service in services]
 

--- a/console/views/app_create/app_build.py
+++ b/console/views/app_create/app_build.py
@@ -3,6 +3,7 @@
   Created on 18/2/1.
 """
 import logging
+from typing import Any
 
 from console.cloud.services import check_account_quota
 from console.exception.bcode import ErrComponentBuildFailed
@@ -19,6 +20,7 @@ from console.views.app_config.base import AppBaseView
 from console.views.base import (CloudEnterpriseCenterView, RegionTenantHeaderCloudEnterpriseCenterView)
 from django.db import transaction
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.baseclient import HttpClient
 from www.utils.return_message import error_message, general_message
@@ -29,7 +31,7 @@ logger = logging.getLogger("default")
 class AppBuild(AppBaseView, CloudEnterpriseCenterView):
     @never_cache
     @transaction.atomic
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件构建
         ---
@@ -55,20 +57,23 @@ class AppBuild(AppBaseView, CloudEnterpriseCenterView):
             if self.service.service_source == "third_party":
                 is_deploy = False
                 # create third component from region
-                new_service = app_service.create_third_party_service(self.tenant, self.service, self.user.nick_name)
+                new_service = app_service.create_third_party_service(
+                    self.tenant, self.service, self.user.nick_name)  # type: ignore[arg-type]
             else:
                 # 数据中心创建组件
-                new_service = app_service.create_region_service(self.tenant, self.service, self.user.nick_name)
+                new_service = app_service.create_region_service(
+                    self.tenant, self.service, self.user.nick_name)  # type: ignore[arg-type]
 
             self.service = new_service
 
             if is_deploy:
                 tracker = enterprise_first_deploy_service.begin_tracking(
-                    enterprise_id=self.tenant.enterprise_id,
+                    enterprise_id=self.tenant.enterprise_id,  # type: ignore[arg-type]
                     tenant_name=self.tenant.tenant_name,
                     region_name=self.service.service_region,
-                    deploy_type=enterprise_first_deploy_service.get_deploy_type(self.service.service_source),
-                    operator=self.user.nick_name,
+                    deploy_type=enterprise_first_deploy_service.get_deploy_type(
+                        self.service.service_source),  # type: ignore[arg-type]
+                    operator=self.user.nick_name,  # type: ignore[arg-type]
                     source_language=self.service.language or "",
                     service_id=self.service.service_id,
                     service_alias=self.service.service_alias)
@@ -141,7 +146,7 @@ class AppBuild(AppBaseView, CloudEnterpriseCenterView):
         self.service.save()
         return Response(result, status=status)
 
-    def is_need_to_add_default_probe(self):
+    def is_need_to_add_default_probe(self) -> bool:
         if self.service.service_source != "source_code":
             return True
         else:
@@ -154,7 +159,7 @@ class AppBuild(AppBaseView, CloudEnterpriseCenterView):
 
 class ComposeBuildView(RegionTenantHeaderCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         docker-compose组件检测
         ---
@@ -175,7 +180,7 @@ class ComposeBuildView(RegionTenantHeaderCloudEnterpriseCenterView):
               type: string
               paramType: form
         """
-        probe_map = dict()
+        probe_map: dict = dict()
         services = None
 
         try:
@@ -187,10 +192,12 @@ class ComposeBuildView(RegionTenantHeaderCloudEnterpriseCenterView):
             # 数据中心创建组件
             new_app_list = []
             for service in services:
-                new_service = app_service.create_region_service(self.tenant, service, self.user.nick_name)
+                new_service = app_service.create_region_service(
+                    self.tenant, service, self.user.nick_name)  # type: ignore[arg-type]
                 new_app_list.append(new_service)
-            group_compose.create_status = "complete"
-            group_compose.save()
+            # NOTE: get_group_compose_by_compose_id may return None; backlog
+            group_compose.create_status = "complete"  # type: ignore[union-attr]
+            group_compose.save()  # type: ignore[union-attr]
             for s in new_app_list:
                 try:
                     app_manage_service.deploy(self.tenant, s, self.user, oauth_instance=self.oauth_instance)
@@ -204,12 +211,12 @@ class ComposeBuildView(RegionTenantHeaderCloudEnterpriseCenterView):
             result = general_message(200, "success", "构建成功")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             if services:
                 for service in services:
                     if probe_map:
                         probe_id = probe_map.get(service.service_id)
-                        probe_service.delete_service_probe(self.tenant, service, probe_id)
+                        probe_service.delete_service_probe(self.tenant, service, probe_id)  # type: ignore[arg-type]
                     event_service.delete_service_events(service)
                     port_service.delete_region_port(self.tenant, service)
                     volume_service.delete_region_volumes(self.tenant, service)
@@ -224,7 +231,7 @@ class ComposeBuildView(RegionTenantHeaderCloudEnterpriseCenterView):
 
 class CodeBuildLangVersionView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         源码构建组件获取构建环境版本。
         ---

--- a/console/views/app_create/app_check.py
+++ b/console/views/app_create/app_check.py
@@ -5,6 +5,7 @@
 import json
 import logging
 from re import split as re_spilt
+from typing import Any
 
 from console.serializer import TenantServiceUpdateSerilizer
 from console.services.app_config import env_var_service
@@ -15,6 +16,7 @@ from console.services.source_build_state_service import source_build_state_servi
 from console.utils.oauth.oauth_types import support_oauth_type
 from console.views.app_config.base import AppBaseView
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
@@ -23,11 +25,11 @@ logger = logging.getLogger("default")
 
 class LangUpdate(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         lang = request.GET.get('lang', None)
         dockerfile_path = request.data.get('dockerfile_path', '')
         if lang:
-            source_build_state_service.save_user_snapshot(self.service, self.service.language)
+            source_build_state_service.save_user_snapshot(self.service, self.service.language)  # type: ignore[arg-type]
             restored = source_build_state_service.restore_language(self.service, lang)
             self.service.language = lang
             self.service.build_strategy = restored.get("build_strategy") or resolve_lang_update_build_strategy(
@@ -57,7 +59,7 @@ class LangUpdate(AppBaseView):
 
 class AppCheck(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件检测信息
         ---
@@ -111,7 +113,7 @@ class AppCheck(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件信息检测
         ---
@@ -131,7 +133,8 @@ class AppCheck(AppBaseView):
         user = request.user
         is_again = request.data.get("is_again", False)
         event_id = request.data.get("event_id", "")
-        code, msg, service_info = app_check_service.check_service(self.tenant, self.service, is_again, event_id, user)
+        code, msg, service_info = app_check_service.check_service(
+            self.tenant, self.service, is_again, event_id, user)  # type: ignore[arg-type]
         if code != 200:
             result = general_message(code, "check service error", msg)
         else:
@@ -141,14 +144,14 @@ class AppCheck(AppBaseView):
 
 class GetCheckUUID(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         result = general_message(200, "success", "获取成功", bean={"check_uuid": self.service.check_uuid})
         return Response(result, status=200)
 
 
 class AppCheckUpdate(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件检测信息修改
         ---

--- a/console/views/app_create/docker_compose.py
+++ b/console/views/app_create/docker_compose.py
@@ -3,6 +3,7 @@
   Created by leon on 18/1/12.
 """
 import logging
+from typing import Any
 
 from console.exception.main import (AccountOverdueException, BusinessException, ResourceNotEnoughException,
                                     ServiceHandleException)
@@ -14,18 +15,23 @@ from console.services.group_service import group_service
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
+from console.models.main import ComposeGroup
+from www.models.main import ServiceGroup
 from www.utils.return_message import general_message
 
 logger = logging.getLogger("default")
 
 
 class ComposeGroupBaseView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
-        super(ComposeGroupBaseView, self).__init__(*args, **kwargs)
-        self.group = None
+    group: ServiceGroup
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(ComposeGroupBaseView, self).__init__(*args, **kwargs)
+        self.group = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(ComposeGroupBaseView, self).initial(request, *args, **kwargs)
         group_id = kwargs.get("group_id", None)
         if not group_id:
@@ -37,16 +43,18 @@ class ComposeGroupBaseView(RegionTenantHeaderView):
             raise BusinessException(Response(general_message(404, "group not found", "组ID{0}不存在".format(group_id)), status=404))
         self.initial_header_info(request)
 
-    def initial_header_info(self, request):
+    def initial_header_info(self, request: Request) -> None:
         pass
 
 
 class ComposeBaseView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
-        super(ComposeBaseView, self).__init__(*args, **kwargs)
-        self.group_compose = None
+    group_compose: ComposeGroup
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(ComposeBaseView, self).__init__(*args, **kwargs)
+        self.group_compose = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(ComposeBaseView, self).initial(request, *args, **kwargs)
         compose_id = kwargs.get("compose_id", None)
         if not compose_id:
@@ -59,13 +67,13 @@ class ComposeBaseView(RegionTenantHeaderView):
                 Response(general_message(404, "compose not found", "compose组{0}不存在".format(compose_id)), status=404))
         self.initial_header_info(request)
 
-    def initial_header_info(self, request):
+    def initial_header_info(self, request: Request) -> None:
         pass
 
 
 class DockerComposeCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         docker-compose创建组件
         ---
@@ -114,17 +122,18 @@ class DockerComposeCreateView(RegionTenantHeaderView):
         if not event_id:
             return Response(general_message(400, "params error", "未指明上传事件ID"), status=400)
         # 创建组
-        group = group_repo.get_group_by_pk(self.tenant.tenant_id, self.response_region, group_id)
-        group_info = group.to_dict()
-        group_info["group_id"] = group.ID
-        group_info['app_id'] = group.ID
-        group_info['app_name'] = group.group_name
-        group_info['k8s_app'] = group.k8s_app
+        group = group_repo.get_group_by_pk(self.tenant.tenant_id, self.response_region, group_id)  # type: ignore[arg-type]
+        # NOTE: get_group_by_pk may return None; backlog
+        group_info = group.to_dict()  # type: ignore[union-attr]
+        group_info["group_id"] = group.ID  # type: ignore[union-attr]
+        group_info['app_id'] = group.ID  # type: ignore[union-attr]
+        group_info['app_name'] = group.group_name  # type: ignore[union-attr]
+        group_info['k8s_app'] = group.k8s_app  # type: ignore[union-attr]
         code, msg, group_compose = compose_service.create_group_compose(
             self.tenant, self.response_region, group_info["group_id"], event_id, compose_file_path, hub_user, hub_pass)
         if code != 200:
             return Response(general_message(code, "create group compose error", msg), status=code)
-        bean = dict()
+        bean: dict = dict()
         bean["group_id"] = group_compose.group_id
         bean["compose_id"] = group_compose.compose_id
         bean["app_name"] = group_info["app_name"]
@@ -134,7 +143,7 @@ class DockerComposeCreateView(RegionTenantHeaderView):
 
 class GetComposeCheckUUID(ComposeGroupBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         compose_id = request.GET.get("compose_id", None)
         if not compose_id:
             return Response(general_message(400, "params error", "参数错误，请求参数应该包含compose ID"), status=400)
@@ -148,7 +157,7 @@ class GetComposeCheckUUID(ComposeGroupBaseView):
 
 class ComposeCheckView(ComposeGroupBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         docker-compose组件检测
         ---
@@ -180,7 +189,7 @@ class ComposeCheckView(ComposeGroupBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取compose文件检测信息
         ---
@@ -217,10 +226,12 @@ class ComposeCheckView(ComposeGroupBaseView):
             if not compose_id:
                 return Response(general_message(400, "params error", "参数错误，请求参数应该包含compose ID"), status=400)
             group_compose = compose_service.get_group_compose_by_compose_id(compose_id)
-            code, msg, data = app_check_service.get_service_check_info(self.tenant, self.response_region, check_uuid)
-            logger.debug("start save compose info ! {0}".format(group_compose.create_status))
-            save_code, save_msg, service_list = compose_service.save_compose_services(self.tenant, self.user,
-                                                                                      self.response_region, group_compose, data, arch)
+            code, msg, data = app_check_service.get_service_check_info(
+                self.tenant, self.response_region, check_uuid)  # type: ignore[arg-type]
+            # NOTE: get_group_compose_by_compose_id may return None; backlog
+            logger.debug("start save compose info ! {0}".format(group_compose.create_status))  # type: ignore[union-attr]
+            save_code, save_msg, service_list = compose_service.save_compose_services(
+                self.tenant, self.user, self.response_region, group_compose, data, arch)  # type: ignore[arg-type]
             if save_code != 200:
                 data["check_status"] = "failure"
                 save_error = {
@@ -233,20 +244,22 @@ class ComposeCheckView(ComposeGroupBaseView):
                 else:
                     data["error_infos"] = [save_error]
             else:
-                transaction.savepoint_commit(sid)
+                # NOTE: sid is always None (savepoint never created); savepoint_commit(None); latent bug, backlog
+                transaction.savepoint_commit(sid)  # type: ignore[arg-type]
             compose_check_brief = compose_service.wrap_compose_check_info(data)
             result = general_message(200, "success", "请求成功", bean=compose_check_brief, list=[s.to_dict() for s in service_list])
         except ResourceNotEnoughException as re:
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            # NOTE: py2-style Exception.message
+            return Response(general_message(10410, "resource is not enough", re.message), status=412)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class ComposeCheckUpdate(ComposeGroupBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         compose文件内容修改
         ---
@@ -279,12 +292,12 @@ class ComposeCheckUpdate(ComposeGroupBaseView):
         if not yaml_content and not group_name:
             return Response(general_message(400, "params error", "请填入需要修改的参数"), status=400)
         if group_name:
-            group_service.update_group(self.tenant, self.response_region, group_id, group_name)
+            group_service.update_group(self.tenant, self.response_region, group_id, group_name)  # type: ignore[arg-type]
         if yaml_content:
             code, msg, json_data = compose_service.yaml_to_json(yaml_content)
             if code != 200:
                 return Response(general_message(code, "parse yaml error", msg), status=code)
-            code, msg, new_compose = compose_service.update_compose(group_id, json_data)
+            code, msg, new_compose = compose_service.update_compose(group_id, json_data)  # type: ignore[arg-type]
             if code != 200:
                 return Response(general_message(code, "save yaml content error", msg), status=code)
         result = general_message(200, "success", "修改成功")
@@ -295,7 +308,7 @@ class ComposeDeleteView(ComposeGroupBaseView):
     """放弃创建compose"""
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         放弃创建compose组组件
         ---
@@ -320,7 +333,7 @@ class ComposeDeleteView(ComposeGroupBaseView):
         group_id = kwargs.get("group_id", None)
         app_name = request.data.get("app_name", "")
         try:
-            group_id = int(group_id)
+            group_id = int(group_id)  # type: ignore[arg-type]
         except ValueError:
             raise ServiceHandleException(msg="group id is invalid", msg_show="参数不合法")
         if group_id:
@@ -337,7 +350,7 @@ class ComposeDeleteView(ComposeGroupBaseView):
 
 class ComposeServicesView(ComposeBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取compose组下的组件
         ---
@@ -361,7 +374,7 @@ class ComposeServicesView(ComposeBaseView):
 
 class ComposeContentView(ComposeBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取compose文件内容
         ---

--- a/console/views/app_create/docker_run.py
+++ b/console/views/app_create/docker_run.py
@@ -3,8 +3,10 @@
   Created by leon on 18/1/5.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.bcode import ErrK8sComponentNameExists
@@ -21,7 +23,7 @@ logger = logging.getLogger("default")
 
 class DockerRunCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         image和docker-run创建组件
         ---
@@ -78,14 +80,14 @@ class DockerRunCreateView(RegionTenantHeaderView):
                     self.tenant,
                     self.region_name,
                     "镜像构建示例",
-                    None,
+                    None,  # type: ignore[arg-type] # NOTE: create_app legacy signature expects str but callers pass None
                     self.user.get_username(),
-                    None,
-                    None,
-                    None,
-                    None,
-                    self.user.enterprise_id,
-                    None,
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    self.user.enterprise_id,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
                     k8s_app=k8s_app_name)
                 group_id = data["group_id"]
         if k8s_component_name and app_service.is_k8s_component_name_duplicate(group_id, k8s_component_name):
@@ -100,23 +102,26 @@ class DockerRunCreateView(RegionTenantHeaderView):
                 return Response(general_message(400, "docker_cmd cannot be null", "参数错误"), status=400)
 
             code, msg_show, new_service = app_service.create_docker_run_app(self.response_region, self.tenant, self.user,
-                                                                            service_cname, docker_cmd, image_type,
+                                                                            service_cname,  # type: ignore[arg-type]
+                                                                            docker_cmd, image_type,
                                                                             k8s_component_name, "", arch)
             if code != 200:
                 return Response(general_message(code, "service create fail", msg_show), status=code)
 
             # 添加username,password信息
             if docker_password or docker_user_name:
-                app_service.create_service_source_info(self.tenant, new_service, docker_user_name, docker_password)
+                # NOTE: new_service may be None; create_service_source_info also expects non-None str args; backlog
+                app_service.create_service_source_info(self.tenant, new_service, docker_user_name, docker_password)  # type: ignore[arg-type]
 
             code, msg_show = group_service.add_service_to_group(self.tenant, self.response_region, group_id,
-                                                                new_service.service_id)
+                                                                new_service.service_id)  # type: ignore[union-attr]
             if code != 200:
                 logger.debug("service.create", msg_show)
-            result = general_message(200, "success", "创建成功", bean=new_service.to_dict())
+            result = general_message(200, "success", "创建成功", bean=new_service.to_dict())  # type: ignore[union-attr]
         except ResourceNotEnoughException as re:
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            # NOTE: py2-style Exception.message
+            return Response(general_message(10410, "resource is not enough", re.message), status=412)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])

--- a/console/views/app_create/image_repositories.py
+++ b/console/views/app_create/image_repositories.py
@@ -1,10 +1,12 @@
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
 
 from console.views.base import RegionTenantHeaderView
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import general_message
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 logger = logging.getLogger("default")
@@ -13,16 +15,17 @@ region_api = RegionInvokeApi()
 
 class TenantImageRepositories(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         res, body = region_api.get_tenant_image_repositories(self.region_name, self.tenant_name, self.tenant.namespace)
-        result = general_message(200, "success", "请求成功", list=body.get("list", []))
+        # NOTE: regionapi may return None; backlog
+        result = general_message(200, "success", "请求成功", list=body.get("list", []))  # type: ignore[union-attr]
         return Response(result, status=result["code"])
 
 
 class TenantImageTags(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         repository = request.GET.get("repository", None)
-        res, body = region_api.get_tenant_image_tags(self.region_name, self.tenant_name, repository)
-        result = general_message(200, "success", "请求成功", list=body.get("list", []))
+        res, body = region_api.get_tenant_image_tags(self.region_name, self.tenant_name, repository)  # type: ignore[arg-type]
+        result = general_message(200, "success", "请求成功", list=body.get("list", []))  # type: ignore[union-attr]
         return Response(result, status=result["code"])

--- a/console/views/app_create/kubeblocks_create.py
+++ b/console/views/app_create/kubeblocks_create.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.bcode import ErrK8sComponentNameExists
@@ -15,7 +17,7 @@ logger = logging.getLogger("default")
 
 class KubeBlocksComponentCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # pylint: disable=unused-argument
         """
         一次性完成创建 KubeBlocks Component 的创建
         
@@ -81,7 +83,7 @@ class KubeBlocksComponentCreateView(RegionTenantHeaderView):
                 user=self.user,
                 operation_type=OperationType.COMPONENT_MANAGE,
                 comment=f"创建KubeBlocks组件: {service_cname} (类型: {request.data.get('database_type', 'unknown')})",
-                enterprise_id=self.user.enterprise_id,
+                enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name,
                 service_alias=result_data.get("service_alias", ""),
                 service_cname=service_cname,

--- a/console/views/app_create/multi_app.py
+++ b/console/views/app_create/multi_app.py
@@ -1,7 +1,9 @@
 # -*- coding: utf8 -*-
 import logging
 import os
+from typing import Any, Optional
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 from console.utils.cache_decorators import never_cache
@@ -13,7 +15,7 @@ logger = logging.getLogger("default")
 
 class MultiAppCheckView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         multiple application check
         ---
@@ -35,7 +37,7 @@ class MultiAppCheckView(RegionTenantHeaderView):
 
 class MultiAppCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         multiple-service application creation
         ---
@@ -66,7 +68,7 @@ class MultiAppCreateView(RegionTenantHeaderView):
             region_name=self.response_region,
             tenant=self.tenant,
             user=self.user,
-            service_alias=service_alias,
+            service_alias=service_alias,  # type: ignore[arg-type]
             service_infos=service_infos,
             host=host)
 
@@ -82,7 +84,7 @@ class MultiAppCreateView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
 
-def validate_request(item, name):
+def validate_request(item: Any, name: str) -> Optional[Response]:
     if not item:
         return Response(general_message(400, "params error", "the field '" + name + "' is required"), status=400)
     return None

--- a/console/views/app_create/source_code.py
+++ b/console/views/app_create/source_code.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+from typing import Any
 
 from console.exception.bcode import ErrK8sComponentNameExists
 from console.exception.main import (AccountOverdueException, ResourceNotEnoughException)
@@ -21,6 +22,7 @@ from console.utils.oauth.oauth_types import get_oauth_instance
 from console.views.app_config.base import AppBaseView
 from console.views.base import RegionTenantHeaderView, JWTAuthApiView, ApplicationView
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from www.apiclient.regionapi import RegionInvokeApi
@@ -34,7 +36,7 @@ region_api = RegionInvokeApi()
 
 class SourceCodeCreateView(ApplicationView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         源码创建组件
         ---
@@ -104,7 +106,7 @@ class SourceCodeCreateView(ApplicationView):
         check_uuid = request.data.get("check_uuid")
         event_id = request.data.get("event_id")
         server_type = request.data.get("server_type", "git")
-        user_id = request.user.user_id
+        user_id = request.user.user_id  # type: ignore[union-attr]
         oauth_service_id = request.data.get("service_id")
         git_full_name = request.data.get("full_name")
         is_demo = request.data.get("is_demo", False)
@@ -122,13 +124,15 @@ class SourceCodeCreateView(ApplicationView):
             open_webhook = request.data.get("open_webhook", False)
             try:
                 oauth_service = oauth_repo.get_oauth_services_by_service_id(service_id=oauth_service_id)
-                oauth_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=oauth_service_id, user_id=user_id)
+                oauth_user = oauth_user_repo.get_user_oauth_by_user_id(
+                    service_id=oauth_service_id, user_id=user_id)  # type: ignore[arg-type]
             except Exception as e:
                 logger.debug(e)
                 rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务, 请检查该服务是否存在且属于开启状态"}
                 return Response(rst, status=200)
             try:
-                git_service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+                # NOTE: get_oauth_services_by_service_id may return None; backlog
+                git_service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
             except Exception as e:
                 logger.debug(e)
                 rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务"}
@@ -137,7 +141,7 @@ class SourceCodeCreateView(ApplicationView):
                 rst = {"data": {"bean": None}, "status": 400, "msg_show": "该OAuth服务不是代码仓库类型"}
                 return Response(rst, status=200)
 
-            service_code_from = "oauth_" + oauth_service.oauth_type
+            service_code_from = "oauth_" + oauth_service.oauth_type  # type: ignore[operator,union-attr]
         try:
             if not service_code_clone_url:
                 return Response(general_message(400, "code url is null", "仓库地址未指明"), status=400)
@@ -153,9 +157,9 @@ class SourceCodeCreateView(ApplicationView):
                 self.tenant,
                 self.user,
                 service_code_from,
-                service_cname,
+                service_cname,  # type: ignore[arg-type]
                 service_code_clone_url,
-                service_code_id,
+                service_code_id,  # type: ignore[arg-type]
                 service_code_version,
                 server_type,
                 check_uuid,
@@ -167,28 +171,31 @@ class SourceCodeCreateView(ApplicationView):
             if code != 200:
                 return Response(general_message(code, "service create fail", msg_show), status=code)
             # 添加username,password信息
+            # NOTE: create_source_code_app may return None new_service; create_service_source_info also expects non-None; backlog
             if git_password or git_user_name:
-                app_service.create_service_source_info(self.tenant, new_service, git_user_name, git_password)
+                app_service.create_service_source_info(self.tenant, new_service, git_user_name, git_password)  # type: ignore[arg-type]
 
             # 自动添加hook
-            if open_webhook and is_oauth and not new_service.open_webhooks:
-                service_webhook = service_webhooks_repo.create_service_webhooks(new_service.service_id, "code_webhooks")
+            if open_webhook and is_oauth and not new_service.open_webhooks:  # type: ignore[union-attr]
+                service_webhook = service_webhooks_repo.create_service_webhooks(
+                    new_service.service_id, "code_webhooks")  # type: ignore[union-attr]
                 service_webhook.state = True
                 service_webhook.deploy_keyword = "deploy"
                 service_webhook.save()
                 try:
-                    git_service.create_hook(host, git_full_name, endpoint='console/webhooks/' + new_service.service_id)
-                    new_service.open_webhooks = True
+                    git_service.create_hook(  # type: ignore[union-attr]
+                        host, git_full_name, endpoint='console/webhooks/' + new_service.service_id)  # type: ignore[union-attr]
+                    new_service.open_webhooks = True  # type: ignore[union-attr]
                 except Exception as e:
                     logger.exception(e)
-                    new_service.open_webhooks = False
-                new_service.save()
+                    new_service.open_webhooks = False  # type: ignore[union-attr]
+                new_service.save()  # type: ignore[union-attr]
             code, msg_show = group_service.add_service_to_group(self.tenant, self.response_region, self.app_id,
-                                                                new_service.service_id)
+                                                                new_service.service_id)  # type: ignore[union-attr]
 
             if code != 200:
                 logger.debug("service.create", msg_show)
-            bean = new_service.to_dict()
+            bean = new_service.to_dict()  # type: ignore[union-attr]
             result = general_message(200, "success", "创建成功", bean=bean)
             new_information = json.dumps({
                 "应用名称": self.app.group_name,
@@ -198,8 +205,9 @@ class SourceCodeCreateView(ApplicationView):
                 "代码版本": service_code_version
             },
                 ensure_ascii=False)
-            component = operation_log_service.process_component_name(new_service.service_cname, self.region_name,
-                                                                     self.tenant_name, new_service.service_alias)
+            component = operation_log_service.process_component_name(
+                new_service.service_cname, self.region_name,  # type: ignore[union-attr]
+                self.tenant_name, new_service.service_alias)  # type: ignore[union-attr]
             comment = "在应用{app}中创建了组件 ".format(
                 app=operation_log_service.process_app_name(self.app.group_name, self.region_name, self.tenant_name,
                                                            self.app.app_id)) + component
@@ -209,13 +217,14 @@ class SourceCodeCreateView(ApplicationView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            # NOTE: py2-style Exception.message
+            return Response(general_message(10410, "resource is not enough", re.message), status=412)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class AppCompileEnvView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件运行环境信息
         ---
@@ -236,7 +245,7 @@ class AppCompileEnvView(AppBaseView):
         bean = dict()
         selected_dependency = []
         if compile_env:
-            check_dependency = json.loads(compile_env.check_dependency)
+            check_dependency = json.loads(compile_env.check_dependency)  # type: ignore[arg-type]
             user_dependency = {}
             if compile_env.user_dependency:
                 user_dependency, _ = read_compile_env_state(compile_env.user_dependency)
@@ -249,7 +258,7 @@ class AppCompileEnvView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件运行环境信息
         ---
@@ -284,7 +293,7 @@ class AppCompileEnvView(AppBaseView):
         service_runtimes = request.data.get("service_runtimes", "")
         service_server = request.data.get("service_server", "")
         service_dependency = request.data.get("service_dependency", "")
-        checkJson = {}
+        checkJson: dict = {}
         checkJson["language"] = self.service.language
         checkJson["runtimes"] = service_runtimes
         checkJson["procfile"] = service_server
@@ -304,10 +313,11 @@ class AppCompileEnvView(AppBaseView):
             "language": self.service.language
         }
         compile_env = compile_env_service.update_service_compile_env(self.service, **update_params)
-        source_build_state_service.save_user_snapshot(self.service, self.service.language, compile_env_payload=checkJson)
+        source_build_state_service.save_user_snapshot(
+            self.service, self.service.language, compile_env_payload=checkJson)  # type: ignore[arg-type]
         bean = dict()
         if compile_env:
-            check_dependency = json.loads(compile_env.check_dependency)
+            check_dependency = json.loads(compile_env.check_dependency)  # type: ignore[arg-type]
             user_dependency = {}
             if compile_env.user_dependency:
                 user_dependency, _ = read_compile_env_state(compile_env.user_dependency)
@@ -321,7 +331,7 @@ class AppCompileEnvView(AppBaseView):
 
 class PackageCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, tenantName, *args, **kwargs):
+    def post(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         本地文件创建组件
         ---
@@ -356,17 +366,19 @@ class PackageCreateView(RegionTenantHeaderView):
         if k8s_component_name and app_service.is_k8s_component_name_duplicate(group_id, k8s_component_name):
             raise ErrK8sComponentNameExists
         try:
-            pkg_record = package_upload_service.get_upload_record(self.team_name, region, event_id)
-            pkg_create_time = pkg_record.create_time
+            # NOTE: get_upload_record may return None; backlog
+            pkg_record = package_upload_service.get_upload_record(self.team_name, region, event_id)  # type: ignore[arg-type]
+            pkg_create_time = pkg_record.create_time  # type: ignore[union-attr]
             # 创建信息
-            ts = app_service.create_package_upload_info(region, self.tenant, self.user, service_cname, k8s_component_name,
-                                                        event_id, pkg_create_time, arch)
+            ts = app_service.create_package_upload_info(
+                region, self.tenant, self.user, service_cname, k8s_component_name,  # type: ignore[arg-type]
+                event_id, pkg_create_time, arch)  # type: ignore[arg-type]
             # 更新状态
             update_record = {
                 "status": "finished",
                 "component_id": ts.service_id,
             }
-            package_upload_service.update_upload_record(tenantName, event_id, **update_record)
+            package_upload_service.update_upload_record(tenantName, event_id, **update_record)  # type: ignore[arg-type]
             code, msg_show = group_service.add_service_to_group(self.tenant, self.response_region, group_id, ts.service_id)
             if code != 200:
                 logger.debug("service.create", msg_show)
@@ -379,7 +391,7 @@ class PackageCreateView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, tenantName, *args, **kwargs):
+    def put(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         构建源修改
         """
@@ -387,14 +399,14 @@ class PackageCreateView(RegionTenantHeaderView):
         service_id = request.data.get("service_id", "")
         region = request.data.get("region", "")
         try:
-            pkg_record = package_upload_service.get_upload_record(self.team_name, region, event_id)
-            pkg_create_time = pkg_record.create_time
-            app_service.change_package_upload_info(service_id, event_id, pkg_create_time)
+            pkg_record = package_upload_service.get_upload_record(self.team_name, region, event_id)  # type: ignore[arg-type]
+            pkg_create_time = pkg_record.create_time  # type: ignore[union-attr]
+            app_service.change_package_upload_info(service_id, event_id, pkg_create_time)  # type: ignore[arg-type]
             update_record = {
                 "status": "finished",
                 "component_id": service_id,
             }
-            package_upload_service.update_upload_record(tenantName, event_id, **update_record)
+            package_upload_service.update_upload_record(tenantName, event_id, **update_record)  # type: ignore[arg-type]
             result = general_message(200, "success", "上传成功")
             return Response(result, status=result["code"])
         except Exception as e:
@@ -405,7 +417,7 @@ class PackageCreateView(RegionTenantHeaderView):
 
 class PackageUploadRecordView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, tenantName, *args, **kwargs):
+    def get(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询上传结果
         ---
@@ -424,8 +436,8 @@ class PackageUploadRecordView(RegionTenantHeaderView):
         region = request.GET.get("region", None)
         event_id = request.GET.get("event_id", None)
         try:
-            res, body = region_api.get_upload_file_dir(region, tenantName, event_id)
-            packages = body["bean"].get("packages", [])
+            res, body = region_api.get_upload_file_dir(region, tenantName, event_id)  # type: ignore[arg-type]
+            packages = body["bean"].get("packages", [])  # type: ignore[index]
             packages = packages if packages else []
             bean = dict()
             packages_name = []
@@ -433,7 +445,7 @@ class PackageUploadRecordView(RegionTenantHeaderView):
                 packages_name.append(package)
             bean["package_name"] = packages_name
             data = {"source_dir": packages_name}
-            package_upload_service.update_upload_record(tenantName, event_id, **data)
+            package_upload_service.update_upload_record(tenantName, event_id, **data)  # type: ignore[arg-type]
             result = general_message(200, "success", "上传成功", bean=bean)
             return Response(result, status=result["code"])
         except Exception as e:
@@ -442,7 +454,7 @@ class PackageUploadRecordView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, tenantName, *args, **kwargs):
+    def post(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         保存上传记录
         ---
@@ -487,7 +499,7 @@ class PackageUploadRecordView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, tenantName, *args, **kwargs):
+    def put(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         修改上传记录
         ---
@@ -506,7 +518,7 @@ class PackageUploadRecordView(RegionTenantHeaderView):
         event_id = request.data.get("event_id")
         update_record = {"status": "finished"}
         try:
-            package_upload_service.update_upload_record(tenantName, event_id, **update_record)
+            package_upload_service.update_upload_record(tenantName, event_id, **update_record)  # type: ignore[arg-type]
             result = general_message(200, "success", "操作成功", bean={"res": "ok"})
             return Response(result, status=result["code"])
         except Exception as e:
@@ -517,7 +529,7 @@ class PackageUploadRecordView(RegionTenantHeaderView):
 
 class UploadRecordLastView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, tenantName, *args, **kwargs):
+    def get(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询上次上传记录
         ---
@@ -536,12 +548,13 @@ class UploadRecordLastView(RegionTenantHeaderView):
         region = request.GET.get("region", None)
         component_id = request.GET.get("component_id", None)
         try:
-            records = package_upload_service.get_last_upload_record(tenantName, region, component_id)
+            # NOTE: get_last_upload_record may return None; backlog
+            records = package_upload_service.get_last_upload_record(tenantName, region, component_id)  # type: ignore[arg-type]
             bean = dict()
-            if records.source_dir != "":
-                dir_list = eval(records.source_dir)
+            if records.source_dir != "":  # type: ignore[union-attr]
+                dir_list = eval(records.source_dir)  # type: ignore[union-attr,arg-type]
                 bean["source_dir"] = dir_list
-                bean["event_id"] = records.event_id
+                bean["event_id"] = records.event_id  # type: ignore[union-attr]
             result = general_message(200, "success", "操作成功", bean=bean)
             return Response(result, status=result["code"])
         except Exception as e:
@@ -552,7 +565,7 @@ class UploadRecordLastView(RegionTenantHeaderView):
 
 class TarImageLoadView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, tenantName, *args, **kwargs):
+    def post(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         开始解析tar包镜像(异步任务)
         ---
@@ -588,7 +601,7 @@ class TarImageLoadView(RegionTenantHeaderView):
                 logger.info("-------------{}".format(res))
                 return Response(general_message(500, "failed to get upload files", "获取上传文件失败"), status=500)
 
-            packages = body.get("bean", {}).get("packages", [])
+            packages = body.get("bean", {}).get("packages", [])  # type: ignore[union-attr]
             if not packages or len(packages) == 0:
                 return Response(general_message(400, "no tar file found", "未找到上传的tar文件"), status=400)
 
@@ -610,13 +623,13 @@ class TarImageLoadView(RegionTenantHeaderView):
             res, body = region_api.load_tar_image(region, tenantName, load_data)
 
             if res.status != 200:
-                error_msg = body.get("msg", "启动解析任务失败")
+                error_msg = body.get("msg", "启动解析任务失败")  # type: ignore[union-attr]
                 return Response(general_message(500, "load task failed", error_msg), status=500)
 
             # 4. 返回任务ID,用于后续查询
             result_bean = {
                 "event_id": event_id,
-                "load_id": body.get("bean", {}).get("load_id"),  # 用于查询解析结果的ID
+                "load_id": body.get("bean", {}).get("load_id"),  # type: ignore[union-attr]  # 用于查询解析结果的ID
                 "status": "loading"  # loading, success, failure
             }
 
@@ -631,7 +644,7 @@ class TarImageLoadView(RegionTenantHeaderView):
 
 class TarImageLoadResultView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, tenantName, load_id, *args, **kwargs):
+    def get(self, request: Request, tenantName: str, load_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询tar包解析结果(包含镜像信息)
         ---
@@ -662,10 +675,10 @@ class TarImageLoadResultView(RegionTenantHeaderView):
             res, body = region_api.get_tar_load_result(region, tenantName, load_id)
 
             if res.status != 200:
-                error_msg = body.get("msg", "查询解析结果失败")
+                error_msg = body.get("msg", "查询解析结果失败")  # type: ignore[union-attr]
                 return Response(general_message(500, "query failed", error_msg), status=500)
 
-            result = body.get("bean", {})
+            result = body.get("bean", {})  # type: ignore[union-attr]
 
             # 返回解析状态和镜像列表(如果解析完成)
             result_bean = {
@@ -689,7 +702,7 @@ class TarImageLoadResultView(RegionTenantHeaderView):
 
 class TarImageImportView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, tenantName, *args, **kwargs):
+    def post(self, request: Request, tenantName: str, *args: Any, **kwargs: Any) -> Response:
         """
         确认导入镜像到镜像仓库(同步执行)
         ---
@@ -740,7 +753,8 @@ class TarImageImportView(RegionTenantHeaderView):
                 "namespace": namespace
             }
 
-            res, body = region_api.import_tar_images(region, tenantName, import_data)
+            # NOTE: import_tar_images not defined on RegionInvokeApi; latent missing-method bug; backlog
+            res, body = region_api.import_tar_images(region, tenantName, import_data)  # type: ignore[attr-defined]
 
             if res.status != 200:
                 error_msg = body.get("msg", "导入镜像失败")

--- a/console/views/app_create/source_outer.py
+++ b/console/views/app_create/source_outer.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pickle
+from typing import Any, List, Tuple
 
 from console.exception.bcode import ErrK8sComponentNameExists
 from console.exception.main import ServiceHandleException
@@ -21,6 +22,7 @@ from console.views.app_config.base import AppBaseView
 from console.views.base import AlowAnyApiView, RegionTenantHeaderView, ApplicationView
 from django.db.transaction import atomic
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import Tenants, TenantServiceInfo
@@ -32,7 +34,7 @@ region_api = RegionInvokeApi()
 
 class ThirdPartyServiceCreateView(ApplicationView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         创建第三方组件
 
@@ -68,7 +70,7 @@ class ThirdPartyServiceCreateView(ApplicationView):
             self.user,
             service_cname,
             static,
-            endpoints_type,
+            endpoints_type,  # type: ignore[arg-type]
             source_config,
             k8s_component_name=k8s_component_name)
         # 添加组件所在组
@@ -103,7 +105,7 @@ class ThirdPartyServiceCreateView(ApplicationView):
         return Response(result, status=result["code"])
 
 
-def check_endpoints(endpoints):
+def check_endpoints(endpoints: List) -> Tuple[List, bool]:
     if not endpoints:
         return ["parameter error"], False
     total_errs = []
@@ -135,7 +137,7 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
     获取实例endpoint列表
     """
 
-    def get(self, request, service_id, *args, **kwargs):
+    def get(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         secret_key = request.GET.get("secret_key")
         # 加密
         deploy_key = deploy_repo.get_secret_key_by_service_id(service_id=service_id)
@@ -155,7 +157,8 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
             return Response(general_message(412, "region error", "数据中心查询失败"), status=412)
 
         endpoint_list = []
-        for item in body["list"]:
+        # NOTE: regionapi may return None body; backlog
+        for item in body["list"]:  # type: ignore[index]
             endpoint = item
             endpoint["ip"] = item["address"]
             endpoint_list.append(endpoint)
@@ -165,7 +168,8 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
         return Response(result, status=result["code"])
 
     # 修改实例endpoint
-    def put(self, request, service_id, *args, **kwargs):
+    # NOTE: put has code paths that fall through without returning (latent missing-return bug); backlog
+    def put(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:  # type: ignore[return]
         secret_key = request.data.get("secret_key")
         # 加密
         deploy_key = deploy_repo.get_secret_key_by_service_id(service_id=service_id)
@@ -193,7 +197,7 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
             if res.status != 200:
                 return Response(general_message(412, "region error", "数据中心查询失败"), status=412)
 
-            endpoint_list = body["list"]
+            endpoint_list = body["list"]  # type: ignore[index]
             # 添加
             if not endpoint_list:
                 res, body = region_api.post_third_party_service_endpoints(service_obj.service_region, tenant_obj.tenant_name,
@@ -231,10 +235,11 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
                     return Response(result, status=200)
         except region_api.CallApiFrequentError as e:
             logger.exception(e)
-            return 409, "操作过于频繁，请稍后再试"
+            # NOTE: returns a (int, str) tuple instead of a Response; latent bug; backlog
+            return 409, "操作过于频繁，请稍后再试"  # type: ignore[return-value]
 
     # 删除实例endpoint
-    def delete(self, request, service_id, *args, **kwargs):
+    def delete(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         secret_key = request.data.get("secret_key")
         # 加密
         deploy_key = deploy_repo.get_secret_key_by_service_id(service_id=service_id)
@@ -254,7 +259,7 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
         if res.status != 200:
             return Response(general_message(412, "region error", "数据中心查询失败"), status=412)
 
-        endpoint_list = body["list"]
+        endpoint_list = body["list"]  # type: ignore[index]
         if not endpoint_list:
             return Response(general_message(412, "ip is null", "ip不存在"), status=412)
         addresses = []
@@ -278,7 +283,7 @@ class ThirdPartyServiceApiView(AlowAnyApiView):
 # 第三方组件中api注册方式重置秘钥
 class ThirdPartyUpdateSecretKeyView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         key_repo = deploy_repo.get_service_key_by_service_id(service_id=self.service.service_id)
         if not key_repo:
             return Response(general_message(412, "service_key is null", "秘钥不存在"), status=412)
@@ -293,7 +298,7 @@ class ThirdPartyUpdateSecretKeyView(AppBaseView):
 # 第三方组件pod信息
 class ThirdPartyAppPodsView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取第三方组件实例信息
         ---
@@ -313,7 +318,7 @@ class ThirdPartyAppPodsView(AppBaseView):
                                                             self.service.service_alias)
         if res.status != 200:
             return Response(general_message(412, "region error", "数据中心查询失败"), status=412)
-        endpoint_list = body["list"]
+        endpoint_list = body["list"]  # type: ignore[index]
         for endpoint in endpoint_list:
             endpoint["ip"] = endpoint["address"]
         bean = {"endpoint_num": len(endpoint_list)}
@@ -322,7 +327,7 @@ class ThirdPartyAppPodsView(AppBaseView):
         return Response(result)
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加endpoint实例
         :param request:
@@ -341,7 +346,7 @@ class ThirdPartyAppPodsView(AppBaseView):
 
     @never_cache
     @atomic
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除endpoint实例
         :param request:
@@ -358,7 +363,7 @@ class ThirdPartyAppPodsView(AppBaseView):
                                                                     self.service.service_alias, endpoint_dict)
         res, new_body = region_api.get_third_party_service_pods(self.service.service_region, self.tenant.tenant_name,
                                                                 self.service.service_alias)
-        new_endpoint_list = new_body.get("list", [])
+        new_endpoint_list = new_body.get("list", [])  # type: ignore[union-attr]
         new_endpoints = [endpoint.address for endpoint in new_endpoint_list]
         service_endpoints_repo.update_or_create_endpoints(self.tenant, self.service, new_endpoints)
         logger.debug('-------res------->{0}'.format(res))
@@ -371,7 +376,7 @@ class ThirdPartyAppPodsView(AppBaseView):
         return Response(result)
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改实例上下线
         :param request:
@@ -408,7 +413,7 @@ class ThirdPartyAppPodsView(AppBaseView):
 # 第三方组件健康检测
 class ThirdPartyHealthzView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取第三方组件健康检测结果
         :param request:
@@ -420,14 +425,14 @@ class ThirdPartyHealthzView(AppBaseView):
                                                               self.service.service_alias)
         if res.status != 200:
             return Response(general_message(412, "region error", "数据中心查询失败"), status=412)
-        bean = body["bean"]
+        bean = body["bean"]  # type: ignore[index]
         if not bean:
             return Response(general_message(200, "success", "查询成功"))
         result = general_message(200, "success", "查询成功", bean=bean)
         return Response(result)
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         编辑第三方组件的健康检测
         :param request:

--- a/console/views/app_create/vm_run.py
+++ b/console/views/app_create/vm_run.py
@@ -3,8 +3,10 @@
   Created by leon on 18/1/5.
 """
 import logging
+from typing import Any, List, Optional
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.exception.bcode import ErrK8sComponentNameExists, ErrVMImageNameExists
 from console.exception.main import ResourceNotEnoughException, ServiceHandleException
@@ -44,7 +46,7 @@ PUBLIC_VM_IMAGE_NAMES = set(PUBLIC_VM_IMAGES.keys())
 
 class VMRunCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         vm image 创建组件
         ---
@@ -204,7 +206,8 @@ class VMRunCreateView(RegionTenantHeaderView):
                 asset.boot_mode = boot_mode
                 asset.save(update_fields=["boot_mode"])
             code, msg_show, new_service = app_service.create_vm_run_app(
-                self.response_region, self.tenant, self.user, service_cname, k8s_component_name, image, arch, event_id, vm_url)
+                self.response_region, self.tenant, self.user, service_cname,  # type: ignore[arg-type]
+                k8s_component_name, image, arch, event_id, vm_url)
             if code != 200:
                 return Response(general_message(code, "service create fail", msg_show), status=code)
             runtime_disk_layout = restore_plan.get("disk_layout") if restore_plan else None
@@ -218,7 +221,7 @@ class VMRunCreateView(RegionTenantHeaderView):
             # Region-side service registration happens later and will sync these attrs.
             vms.save_vm_runtime_config(
                 self.tenant.tenant_id,
-                new_service.service_id,
+                new_service.service_id,  # type: ignore[union-attr] # NOTE: create_vm_run_app may return None
                 {
                     **runtime_config,
                     "asset_id": asset_id,
@@ -249,14 +252,14 @@ class VMRunCreateView(RegionTenantHeaderView):
             if disk_imports:
                 vms.save_vm_disk_imports(
                     self.tenant.tenant_id,
-                    new_service.service_id,
+                    new_service.service_id,  # type: ignore[union-attr]
                     disk_imports
                 )
             code, msg_show = group_service.add_service_to_group(self.tenant, self.response_region, group_id,
-                                                                new_service.service_id)
+                                                                new_service.service_id)  # type: ignore[union-attr]
             if code != 200:
                 logger.debug("service.create", msg_show)
-            result = general_message(200, "success", "创建成功", bean=new_service.to_dict())
+            result = general_message(200, "success", "创建成功", bean=new_service.to_dict())  # type: ignore[union-attr]
         except ResourceNotEnoughException as re:
             raise re
         except ServiceHandleException as err:
@@ -266,14 +269,15 @@ class VMRunCreateView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @staticmethod
-    def find_root_disk_import(restore_plan):
+    def find_root_disk_import(restore_plan: Optional[dict]) -> Optional[dict]:
         for disk in (restore_plan or {}).get("disk_imports", []) or []:
             if (disk.get("volume_name") or "") == "disk":
                 return disk
         return None
 
     @staticmethod
-    def resolve_disk_imports(asset=None, restore_plan=None, image_name="", image_url="", source_uri=""):
+    def resolve_disk_imports(asset: Any = None, restore_plan: Optional[dict] = None, image_name: str = "",
+                             image_url: str = "", source_uri: str = "") -> List:
         if restore_plan:
             return list(restore_plan.get("disk_imports") or [])
         return vms.build_vm_create_disk_imports(

--- a/console/views/app_event.py
+++ b/console/views/app_event.py
@@ -4,6 +4,9 @@
 """
 import json
 import logging
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.constants import LogConstants
 from console.services.app_actions import event_service, log_service, ws_service
@@ -20,7 +23,7 @@ logger = logging.getLogger("default")
 
 class AppEventView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的event事件
         ---
@@ -68,7 +71,9 @@ class AppEventView(AppBaseView):
             # 若出现异常，回退到原有逻辑，避免影响原功能
             logger.exception(f"KubeBlocks 合并事件失败: {e}")
 
-        events, has_next = event_service.get_service_event(self.tenant, self.service, int(page), int(page_size), start_time)
+        # NOTE: start_time GET param is Optional; service expects str (legacy mismatch, backlog).
+        events, has_next = event_service.get_service_event(self.tenant, self.service, int(page), int(page_size),
+                                                           start_time)  # type: ignore[arg-type]
 
         result = general_message(200, "success", "查询成功", list=events, has_next=has_next)
         return Response(result, status=result["code"])
@@ -76,7 +81,7 @@ class AppEventView(AppBaseView):
 
 class AppEventLogView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的event的详细日志
         ---
@@ -114,7 +119,7 @@ class AppEventLogView(AppBaseView):
 
 class AppLogView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的日志
         ---
@@ -153,7 +158,7 @@ class AppLogView(AppBaseView):
 
 class AppLogInstanceView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取日志websocket信息
         ---
@@ -171,7 +176,7 @@ class AppLogInstanceView(AppBaseView):
         """
         code, msg, host_id = log_service.get_docker_log_instance(self.tenant, self.service)
         web_socket_url = ws_service.get_log_instance_ws(request, self.service.service_region)
-        bean = {"web_socket_url": web_socket_url}
+        bean: dict = {"web_socket_url": web_socket_url}
         if code == 200:
             web_socket_url += "?host_id={0}".format(host_id)
             bean["host_id"] = host_id
@@ -182,7 +187,7 @@ class AppLogInstanceView(AppBaseView):
 
 class AppHistoryLogView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件历史日志
         ---
@@ -212,7 +217,7 @@ class AppHistoryLogView(AppBaseView):
 
 class AppEventsView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取作用对象的event事件
         ---
@@ -275,8 +280,9 @@ class AppEventsView(RegionTenantHeaderView):
                                 service = TenantServiceInfo.objects.filter(
                                     service_alias=ali, tenant_id=self.tenant.tenant_id).first()
                                 relys.append({
-                                    "service_cname": service.service_cname,
-                                    "serivce_alias": service.service_alias,
+                                    # NOTE: .first() may return None; legacy code accesses attrs directly (backlog).
+                                    "service_cname": service.service_cname,  # type: ignore[union-attr]
+                                    "serivce_alias": service.service_alias,  # type: ignore[union-attr]
                                 })
                             event["Message"] = "依赖的其他组件暂未运行 {0}".format(json.dumps(relys, ensure_ascii=False))
                     result = general_message(200, "success", "查询成功", list=events, total=total, has_next=has_next)
@@ -293,7 +299,7 @@ class AppEventsView(RegionTenantHeaderView):
 
 class AppEventsLogView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取作用对象的event事件
         ---
@@ -318,5 +324,5 @@ class AppEventsLogView(RegionTenantHeaderView):
             result = general_message(200, "success", "查询成功", list=log_content)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]  # NOTE: py2 Exception.message
         return Response(result, status=result["code"])

--- a/console/views/app_manage.py
+++ b/console/views/app_manage.py
@@ -5,8 +5,10 @@
 import json
 import logging
 from datetime import datetime
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.enum.component_enum import is_state, is_support, ComponentType, is_kubeblocks
@@ -42,7 +44,7 @@ group_service_relation_repo = GroupServiceRelationRepository()
 
 
 class AppsPorConsoletView(RegionTenantHeaderView):
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         app_id = req.GET.get('appID')
         ports = port_repo.get_tenant_services(self.team.tenant_id)
         component_list = service_repo.get_service_by_tenant(self.team.tenant_id)
@@ -53,7 +55,7 @@ class AppsPorConsoletView(RegionTenantHeaderView):
             tenant_groups = group_service_relation_repo.get_relation_by_tenant_id(self.team.tenant_id)
             component_groups_dict = {tg.service_id: tg.group_id for tg in tenant_groups}
             for port in ports:
-                port_dict = dict()
+                port_dict: dict = dict()
                 if not port.is_inner_service:
                     continue
                 port_dict["port"] = port.container_port
@@ -79,7 +81,7 @@ class AppsPorConsoletView(RegionTenantHeaderView):
 
 class StartAppView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         启动组件
         ---
@@ -100,7 +102,7 @@ class StartAppView(AppBaseCloudEnterpriseCenterView):
             code, msg = app_manage_service.start(self.tenant, self.service, self.user, oauth_instance=self.oauth_instance)
             if is_kubeblocks(self.service.extend_method):
                 code, msg = kubeblocks_service.manage_cluster_status(self.service, self.region_name, oauth_instance=self.oauth_instance, operation="start")
-            bean = {}
+            bean: dict = {}
             if code != 200:
                 return Response(general_message(code, "start app error", msg, bean=bean), status=code)
             result = general_message(code, "success", "操作成功", bean=bean)
@@ -123,13 +125,16 @@ class StartAppView(AppBaseCloudEnterpriseCenterView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            # NOTE: py2-era Exception.message; absent in py3 (backlog, behavior preserved).
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 class StopAppView(AppBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         停止组件
         ---
@@ -171,7 +176,7 @@ class StopAppView(AppBaseView):
 
 class PauseAppView(AppBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         挂起组件
         ---
@@ -200,7 +205,7 @@ class PauseAppView(AppBaseView):
 
 class UNPauseAppView(AppBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         恢复组件
         ---
@@ -229,7 +234,7 @@ class UNPauseAppView(AppBaseView):
 
 class ReStartAppView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         重启组件
         ---
@@ -249,7 +254,7 @@ class ReStartAppView(AppBaseCloudEnterpriseCenterView):
         code, msg = app_manage_service.restart(self.tenant, self.service, self.user, oauth_instance=self.oauth_instance)
         if is_kubeblocks(self.service.extend_method):
             kubeblocks_service.manage_cluster_status(self.service, self.region_name, oauth_instance=self.oauth_instance, operation="restart")
-        bean = {}
+        bean: dict = {}
         if code != 200:
             return Response(general_message(code, "restart app error", msg, bean=bean), status=code)
         result = general_message(code, "success", "操作成功", bean=bean)
@@ -273,7 +278,7 @@ class ReStartAppView(AppBaseCloudEnterpriseCenterView):
 
 class DeployAppView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         部署组件
         ---
@@ -294,17 +299,18 @@ class DeployAppView(AppBaseCloudEnterpriseCenterView):
         try:
             group_version = request.data.get("group_version", None)
             tracker = enterprise_first_deploy_service.begin_tracking(
-                enterprise_id=self.tenant.enterprise_id,
+                enterprise_id=self.tenant.enterprise_id,  # type: ignore[arg-type]
                 tenant_name=self.tenant.tenant_name,
                 region_name=self.service.service_region,
-                deploy_type=enterprise_first_deploy_service.get_deploy_type(self.service.service_source),
-                operator=self.user.nick_name,
+                deploy_type=enterprise_first_deploy_service.get_deploy_type(
+                    self.service.service_source),  # type: ignore[arg-type]
+                operator=self.user.nick_name,  # type: ignore[arg-type]
                 source_language=self.service.language or "",
                 service_id=self.service.service_id,
                 service_alias=self.service.service_alias)
             code, msg, event_id = app_deploy_service.deploy(
                 self.tenant, self.service, self.user, version=group_version, oauth_instance=self.oauth_instance)
-            bean = {}
+            bean: dict = {}
             if code != 200:
                 enterprise_first_deploy_service.mark_failure(tracker, reason=msg)
                 return Response(general_message(code, "deploy app error", msg, bean=bean), status=code)
@@ -328,20 +334,24 @@ class DeployAppView(AppBaseCloudEnterpriseCenterView):
         except ErrServiceSourceNotFound as e:
             enterprise_first_deploy_service.mark_failure(tracker, reason=getattr(e, "message", str(e)))
             logger.exception(e)
-            return Response(general_message(412, e.message, "无法找到云市应用的构建源"), status=412)
+            return Response(
+                general_message(412, e.message, "无法找到云市应用的构建源"),  # type: ignore[attr-defined]
+                status=412)
         except ResourceNotEnoughException as re:
             enterprise_first_deploy_service.mark_failure(tracker, reason=getattr(re, "message", str(re)))
             raise re
         except AccountOverdueException as re:
             enterprise_first_deploy_service.mark_failure(tracker, reason=getattr(re, "message", str(re)))
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 class RollBackAppView(AppBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         回滚组件
         ---
@@ -370,7 +380,7 @@ class RollBackAppView(AppBaseView):
                 return Response(general_message(400, "deploy version is not found", "请指明版本及操作类型"), status=400)
 
             code, msg = app_manage_service.roll_back(self.tenant, self.service, self.user, deploy_version, upgrade_or_rollback)
-            bean = {}
+            bean: dict = {}
             if code != 200:
                 return Response(general_message(code, "roll back app error", msg, bean=bean), status=code)
             result = general_message(code, "success", "操作成功", bean=bean)
@@ -393,13 +403,15 @@ class RollBackAppView(AppBaseView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 class VerticalExtendAppView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         垂直升级组件
         ---
@@ -451,7 +463,7 @@ class VerticalExtendAppView(AppBaseCloudEnterpriseCenterView):
                 oauth_instance=self.oauth_instance,
                 new_gpu=new_gpu,
                 new_cpu=new_cpu)
-            bean = {}
+            bean: dict = {}
             if code != 200:
                 return Response(general_message(code, "vertical upgrade error", msg, bean=bean), status=code)
             result = general_message(code, "success", "操作成功", bean=bean)
@@ -476,13 +488,15 @@ class VerticalExtendAppView(AppBaseCloudEnterpriseCenterView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 class HorizontalExtendAppView(AppBaseView, CloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         水平升级组件
         ---
@@ -534,13 +548,15 @@ class HorizontalExtendAppView(AppBaseView, CloudEnterpriseCenterView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 class ScalingAppView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件伸缩（支持水平和垂直伸缩）
         ---
@@ -607,14 +623,17 @@ class ScalingAppView(AppBaseCloudEnterpriseCenterView):
             # 执行水平伸缩
             if has_horizontal_params and new_node != self.service.min_node:
                 app_manage_service.horizontal_upgrade(
-                    self.tenant, self.service, self.user, int(new_node), oauth_instance=self.oauth_instance)
+                    self.tenant, self.service, self.user, int(new_node),  # type: ignore[arg-type]
+                    oauth_instance=self.oauth_instance)
             self.service.update_time = datetime.now()
             self.service.save()
         except ResourceNotEnoughException as re:
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         except ServiceHandleException as e:
             # 节点没有变化的错误码为 10104，不需要抛出异常
             if e.error_code != 10104:
@@ -626,7 +645,7 @@ class ScalingAppView(AppBaseCloudEnterpriseCenterView):
 class BatchActionView(RegionTenantHeaderCloudEnterpriseCenterView):
     @never_cache
     # TODO 修改权限验证
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         批量操作组件
         ---
@@ -668,12 +687,15 @@ class BatchActionView(RegionTenantHeaderCloudEnterpriseCenterView):
         if action == "deploy":
             action_zh = "构建"
         comment = "批量" + action_zh + "了应用{app}下的组件"
-        service_id_list = service_ids.split(",")
+        # NOTE: service_ids comes from request body (Any|None); legacy code assumes str (backlog).
+        service_id_list = service_ids.split(",")  # type: ignore[union-attr]
         app = group_service.get_service_group_info(service_id_list[0])
         code, msg, services = app_manage_service.batch_action(self.region_name, self.tenant, self.user, action, service_id_list,
                                                     move_group_id, self.oauth_instance)
 
-        app_name = operation_log_service.process_app_name(app.app_name, self.region_name, self.team_name, app.app_id)
+        # NOTE: get_service_group_info may return None; legacy code assumes present (backlog).
+        app_name = operation_log_service.process_app_name(
+            app.app_name, self.region_name, self.team_name, app.app_id)  # type: ignore[union-attr]
         comment = comment.format(app=app_name)
         component_names = []
         idx = 0
@@ -703,9 +725,10 @@ class BatchActionView(RegionTenantHeaderCloudEnterpriseCenterView):
             self.user,
             operation_type=OperationType.APPLICATION_MANAGE,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            # NOTE: enterprise_id nullable on model; service expects str (backlog).
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.team_name,
-            app_id=app.app_id,
+            app_id=app.app_id,  # type: ignore[union-attr]
             new_information=new_information,
             information_type=InformationType.INFORMATION_ADDS.value)
 
@@ -714,7 +737,7 @@ class BatchActionView(RegionTenantHeaderCloudEnterpriseCenterView):
 
 class DeleteAppView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件
         ---
@@ -739,7 +762,7 @@ class DeleteAppView(AppBaseView):
         is_force = request.data.get("is_force", False)
 
         code, msg = app_manage_service.delete(self.user, self.tenant, self.service, is_force)
-        bean = {}
+        bean: dict = {}
         if code != 200:
             return Response(general_message(code, "delete service error", msg, bean=bean), status=code)
 
@@ -763,7 +786,7 @@ class DeleteAppView(AppBaseView):
 
 class BatchDelete(RegionTenantHeaderView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         批量删除组件
         ---
@@ -780,7 +803,7 @@ class BatchDelete(RegionTenantHeaderView):
               paramType: form
         """
         service_ids = request.data.get("service_ids", None)
-        service_id_list = service_ids.split(",")
+        service_id_list = service_ids.split(",")  # type: ignore[union-attr]
         services = service_repo.get_services_by_service_ids(service_id_list)
 
         if not services:
@@ -798,14 +821,15 @@ class BatchDelete(RegionTenantHeaderView):
                     component_names.append(svc.service_cname)
                     old_information.append({"组件名": svc.service_cname, "操作": "删除"})
                 if len(component_names) > 2:
-                    component_names = ",".join(component_names[0:2]) + "等"
+                    # NOTE: list var reassigned to joined str; legacy reuse (behavior preserved).
+                    component_names = ",".join(component_names[0:2]) + "等"  # type: ignore[assignment]
                 else:
-                    component_names = ",".join(component_names)
+                    component_names = ",".join(component_names)  # type: ignore[assignment]
                 comment = "批量删除应用 {app} 中的组件 {component_names}".format(app=app_name, component_names=component_names)
         msg_list = []
         for service in services:
             code, msg = app_manage_service.batch_delete(self.user, self.tenant, service, is_force=True)
-            msg_dict = dict()
+            msg_dict: dict = dict()
             msg_dict['status'] = code
             msg_dict['msg'] = msg
             msg_dict['service_id'] = service.service_id
@@ -816,8 +840,11 @@ class BatchDelete(RegionTenantHeaderView):
                 kubeblocks_service.delete_kubeblocks_cluster([service.service_id], service.service_region)
         if app:
             self.app = app
-            old_information = json.dumps(old_information, ensure_ascii=False)
-            operation_log_service.create_app_log(ctx=self, comment=comment, format_app=False, old_information=old_information)
+            # NOTE: list var reassigned to json str; legacy reuse (behavior preserved).
+            old_information = json.dumps(old_information, ensure_ascii=False)  # type: ignore[assignment]
+            operation_log_service.create_app_log(
+                ctx=self, comment=comment, format_app=False,
+                old_information=old_information)  # type: ignore[arg-type]
         code = 200
         result = general_message(code, "success", "操作成功", list=msg_list)
         return Response(result, status=result['code'])
@@ -825,7 +852,7 @@ class BatchDelete(RegionTenantHeaderView):
 
 class AgainDelete(RegionTenantHeaderView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         二次确认删除组件
         ---
@@ -842,26 +869,28 @@ class AgainDelete(RegionTenantHeaderView):
               paramType: form
         """
         service_id = request.data.get("service_id", None)
-        service = service_repo.get_service_by_service_id(service_id)
-        app = group_service.get_service_group_info(service_id)
-        app_manage_service.delete_again(self.user, self.tenant, service, is_force=True)
+        # NOTE: service_id from request body (Any|None); repo/service expect str (backlog).
+        service = service_repo.get_service_by_service_id(service_id)  # type: ignore[arg-type]
+        app = group_service.get_service_group_info(service_id)  # type: ignore[arg-type]
+        # NOTE: get_service_by_service_id may return None; legacy code assumes present (backlog).
+        app_manage_service.delete_again(self.user, self.tenant, service, is_force=True)  # type: ignore[arg-type]
         result = general_message(200, "success", "操作成功", bean={})
         comment = operation_log_service.generate_component_comment(
-            operation=Operation.DELETE, module_name=service.service_cname)
+            operation=Operation.DELETE, module_name=service.service_cname)  # type: ignore[union-attr]
         operation_log_service.create_component_log(
             user=self.user,
             comment=comment,
             enterprise_id=self.user.enterprise_id,
             team_name=self.tenant.tenant_name,
             app_id=app.ID if app else 0,
-            service_alias=service.service_alias,
-            service_cname=service.service_cname)
+            service_alias=service.service_alias,  # type: ignore[union-attr]
+            service_cname=service.service_cname)  # type: ignore[union-attr]
         return Response(result, status=result["code"])
 
 
 class ChangeServiceTypeView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件的组件类型标签
         :param request:
@@ -881,14 +910,16 @@ class ChangeServiceTypeView(AppBaseView):
                 "组件部署类型": app_manage_service.get_extend_method_name(self.service.extend_method)
             },
                                          ensure_ascii=False)
-            app_manage_service.change_service_type(self.tenant, self.service, extend_method, self.user.nick_name)
+            app_manage_service.change_service_type(
+                self.tenant, self.service, extend_method, self.user.nick_name)  # type: ignore[arg-type]
             old_information = json.dumps({
                 "组件": self.service.service_cname,
                 "组件部署类型": app_manage_service.get_extend_method_name(self.service.extend_method)
             },
                                          ensure_ascii=False)
             logger.debug("tenant: {0}, service:{1}, extend_method:{2}".format(self.tenant, self.service, extend_method))
-            app_manage_service.change_service_type(self.tenant, self.service, extend_method, self.user.nick_name)
+            app_manage_service.change_service_type(
+                self.tenant, self.service, extend_method, self.user.nick_name)  # type: ignore[arg-type]
             result = general_message(200, "success", "操作成功")
             comment = operation_log_service.generate_component_comment(
                 operation=Operation.CHANGE,
@@ -907,20 +938,20 @@ class ChangeServiceTypeView(AppBaseView):
                 old_information=old_information,
                 new_information=new_information)
         except CallRegionAPIException as e:
-            result = general_message(e.code, "failure", e.message)
+            result = general_message(e.code, "failure", e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 # 更新组件组件
 class UpgradeAppView(AppBaseView, CloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         更新
         """
         try:
             code, msg, _ = app_manage_service.upgrade(self.tenant, self.service, self.user, oauth_instance=self.oauth_instance)
-            bean = {}
+            bean: dict = {}
             if code != 200:
                 return Response(general_message(code, "upgrade app error", msg, bean=bean), status=code)
             result = general_message(code, "success", "操作成功", bean=bean)
@@ -943,14 +974,16 @@ class UpgradeAppView(AppBaseView, CloudEnterpriseCenterView):
             raise re
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            return Response(
+                general_message(10410, "resource is not enough", re.message),  # type: ignore[attr-defined]
+                status=412)
         return Response(result, status=result["code"])
 
 
 # 修改组件名称
 class ChangeServiceNameView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         :param request:
         :param args:
@@ -972,7 +1005,7 @@ class ChangeServiceNameView(AppBaseView):
 # 修改组件名称
 class ChangeServiceUpgradeView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         :param request:
         :param args:
@@ -1004,10 +1037,11 @@ class ChangeServiceUpgradeView(AppBaseView):
 # 判断云市安装的组件是否有（小版本，大版本）更新
 class MarketServiceUpgradeView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
-        versions = []
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        versions: list = []
         try:
-            versions = market_app_service.list_upgradeable_versions(self.tenant, self.service)
+            # NOTE: service may return None; legacy code assumes a list (backlog).
+            versions = market_app_service.list_upgradeable_versions(self.tenant, self.service)  # type: ignore[assignment]
         except RbdAppNotFound:
             return Response(status=404, data=general_message(404, "service lost", "未找到该组件"))
         except Exception as e:
@@ -1015,7 +1049,7 @@ class MarketServiceUpgradeView(AppBaseView):
             return Response(status=200, data=general_message(200, "success", "查询成功", list=versions))
         return Response(status=200, data=general_message(200, "success", "查询成功", list=versions))
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         version = parse_item(request, "group_version", required=True)
 
         # get app
@@ -1026,23 +1060,23 @@ class MarketServiceUpgradeView(AppBaseView):
 
 
 class TeamAppsCloseView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = request.data.get("region_name")
         if region_name:
             app_manage_service.close_all_component_in_tenant(self.team, region_name, self.user)
         else:
             app_manage_service.close_all_component_in_team(self.team, self.user)
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.CLOSE, module_name=self.team.tenant_alias, team_name=self.team.tenant_name,
-            suffix=" 下所有组件")
+            operation=Operation.CLOSE, module_name=self.team.tenant_alias,  # type: ignore[arg-type]
+            team_name=self.team.tenant_name, suffix=" 下所有组件")
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(status=200, data=general_message(200, "success", "操作成功"))
 
 
 class PackageToolView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         设置语言和依赖包
         ---
@@ -1101,7 +1135,7 @@ class PackageToolView(AppBaseCloudEnterpriseCenterView):
         return Response(status=200, data=general_message(200, "succeed", "操作成功"))
 class TarImageView(AppBaseCloudEnterpriseCenterView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         设置语言和依赖包
         ---

--- a/console/views/app_market.py
+++ b/console/views/app_market.py
@@ -1,7 +1,9 @@
 # -*- coding: utf8 -*-
 
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.app import app_market_service
@@ -13,11 +15,13 @@ logger = logging.getLogger("default")
 
 
 class BindableMarketsView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         market_name = request.GET.get("market_name", None)
         market_url = request.GET.get("market_url", None)
         access_key = request.GET.get("access_key", None)
         if market_url is None and market_name is None:
             raise AbortRequest("the field 'market_name' or 'market_url' is required")
-        markets = app_market_service.list_bindable_markets(enterprise_id, market_name, market_url, access_key)
+        # NOTE: GET params are Optional[str] but service expects str (systemic mismatch; backlog).
+        markets = app_market_service.list_bindable_markets(
+            enterprise_id, market_name, market_url, access_key)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "获取成功", list=markets))

--- a/console/views/app_monitor.py
+++ b/console/views/app_monitor.py
@@ -3,7 +3,10 @@
   Created on 18/1/29.
 """
 import logging
+from typing import Any, List, Tuple
 from urllib.parse import urlencode
+
+from rest_framework.request import Request
 
 from console.services.app_config import env_var_service
 from console.services.app_config.promql_service import promql_service
@@ -20,7 +23,7 @@ region_api = RegionInvokeApi()
 logger = logging.getLogger("default")
 
 
-def get_sufix_path(request, query=""):
+def get_sufix_path(request: Any, query: str = "") -> str:
     """获取get请求参数路径部分的数据"""
     full_url = request.get_full_path()
     index = full_url.find("?")
@@ -41,7 +44,7 @@ def get_sufix_path(request, query=""):
 
 
 class AppMonitorQueryView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         监控信息查询
         ---
@@ -64,7 +67,8 @@ class AppMonitorQueryView(AppBaseView):
                 query = promql_service.add_or_update_label(self.service.service_id, query, self.service.arch)
             sufix = "?" + get_sufix_path(request, query)
             res, body = region_api.get_query_data(self.service.service_region, self.tenant.tenant_name, sufix)
-            result = general_message(200, "success", "查询成功", bean=body["data"])
+            # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+            result = general_message(200, "success", "查询成功", bean=body["data"])  # type: ignore[index]
         except Exception as e:
             logger.debug(e)
             result = general_message(200, "success", "查询成功", bean=[])
@@ -72,7 +76,7 @@ class AppMonitorQueryView(AppBaseView):
 
 
 class AppMonitorQueryRangeView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         监控信息范围查询
         ---
@@ -96,7 +100,8 @@ class AppMonitorQueryRangeView(AppBaseView):
                 query = promql_service.add_or_update_label(self.service.service_id, query, self.service.arch)
             sufix = "?" + get_sufix_path(request, query)
             res, body = region_api.get_query_range_data(self.service.service_region, self.tenant.tenant_name, sufix)
-            result = general_message(200, "success", "查询成功", bean=body["data"])
+            # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+            result = general_message(200, "success", "查询成功", bean=body["data"])  # type: ignore[index]
         except Exception as e:
             logger.exception(e)
             result = general_message(200, "success", "查询成功", bean=[])
@@ -104,7 +109,7 @@ class AppMonitorQueryRangeView(AppBaseView):
 
 
 class AppResourceQueryView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件资源查询
         ---
@@ -123,18 +128,19 @@ class AppResourceQueryView(AppBaseView):
         """
         data = {"service_ids": [self.service.service_id]}
         body = region_api.get_service_resources(self.tenant.tenant_name, self.service.service_region, data)
-        bean = body["bean"]
-        result = bean.get(self.service.service_id)
+        # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+        bean = body["bean"]  # type: ignore[index]
+        service_resource = bean.get(self.service.service_id)
         resource = dict()
-        resource["memory"] = result.get("memory", 0) if result else 0
-        resource["disk"] = result.get("disk", 0) if result else 0
-        resource["cpu"] = result.get("cpu", 0) if result else 0
+        resource["memory"] = service_resource.get("memory", 0) if service_resource else 0
+        resource["disk"] = service_resource.get("disk", 0) if service_resource else 0
+        resource["cpu"] = service_resource.get("cpu", 0) if service_resource else 0
         result = general_message(200, "success", "查询成功", bean=resource)
         return Response(result, status=result["code"])
 
 
 class BatchAppMonitorQueryView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         监控信息查询
         ---
@@ -176,9 +182,11 @@ class BatchAppMonitorQueryView(RegionTenantHeaderView):
             id_service_map[s.service_id] = s
             id_name_map[s.service_id] = s.service_cname
 
+        # NOTE: enterprise_id is nullable but region API expects str (systemic mismatch; backlog).
         pods_info = region_api.get_services_pods(self.response_region, self.tenant.tenant_name, service_id_list,
-                                                 self.tenant.enterprise_id)
-        pod_info_list = pods_info["list"]
+                                                 self.tenant.enterprise_id)  # type: ignore[arg-type]
+        # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+        pod_info_list = pods_info["list"]  # type: ignore[index]
         ip_service_map = {}
         all_ips = []
         if pod_info_list:
@@ -196,15 +204,16 @@ class BatchAppMonitorQueryView(RegionTenantHeaderView):
 
         res, throughput_body = region_api.get_query_data(self.response_region, self.tenant.tenant_name,
                                                          prefix + throughput_rate)
-        response_data = response_body["data"]["result"]
-        throughput_data = throughput_body["data"]["result"]
+        # NOTE: region API results may be None; indexing them is a latent risk (backlog).
+        response_data = response_body["data"]["result"]  # type: ignore[index]
+        throughput_data = throughput_body["data"]["result"]  # type: ignore[index]
 
         for r in response_data:
             res_union_key = r["metric"]["client"] + "+" + r["metric"]["service_id"]
             for t in throughput_data:
                 thr_union_key = t["metric"]["client"] + "+" + t["metric"]["service_id"]
                 if res_union_key == thr_union_key:
-                    result_bean = {"is_web": False}
+                    result_bean: dict = {"is_web": False}
                     source = res_union_key.split("+")[0]
                     target = res_union_key.split("+")[1]
                     source_service = ip_service_map.get(source, None)
@@ -228,7 +237,7 @@ class BatchAppMonitorQueryView(RegionTenantHeaderView):
 
         return Response(result, status=result["code"])
 
-    def get_query_statements(self, service_id_list, all_pod_ips):
+    def get_query_statements(self, service_id_list: List[Any], all_pod_ips: List[Any]) -> Tuple[str, str]:
         # 响应时间语句： avg(app_client_requesttime{client="17216189100",
         # service_id=~"968f6919a1bb4cc988d48fd4ebf6303f"}) by (service_id,client)
         # 吞吐率 sum(ceil(increase(app_client_request{service_id=~"968f6919a1bb4cc988d48fd4ebf6303f",
@@ -247,7 +256,7 @@ class BatchAppMonitorQueryView(RegionTenantHeaderView):
 
 
 class AppTraceView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         envs = env_var_service.get_all_envs_incloud_depend_env(self.tenant, self.service)
         trace_status = {"collector_host": "", "collector_port": "", "enable_apm": False}
         for env in envs:
@@ -260,7 +269,7 @@ class AppTraceView(AppBaseView):
         result = general_message(200, "success", "查询成功", bean=trace_status)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         enable_env = env_var_service.get_env_by_attr_name(self.tenant, self.service, "ES_ENABLE_APM")
         if enable_env:
             enable_env.attr_value = "true"
@@ -273,7 +282,7 @@ class AppTraceView(AppBaseView):
         result = general_message(200, "success", "设置成功")
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         enable_env = env_var_service.get_env_by_attr_name(self.tenant, self.service, "ES_ENABLE_APM")
         if enable_env:
             env_var_service.delete_env_by_attr_name(self.tenant, self.service, "ES_ENABLE_APM")
@@ -285,7 +294,7 @@ class AppTraceView(AppBaseView):
 
 
 class MonitorQueryOverConsoleView(AlowAnyApiView):
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         query = req.GET.get("query", "")
         start = req.GET.get("start", "")
@@ -299,7 +308,7 @@ class MonitorQueryOverConsoleView(AlowAnyApiView):
 
 
 class MonitorQueryView(AlowAnyApiView):
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         query = req.GET.get("query", "")
         query = "?"+"query="+query

--- a/console/views/app_overview.py
+++ b/console/views/app_overview.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import pickle
+from typing import Any
 
 from console.constants import AppConstants, PluginCategoryConstants
 from console.enum.component_enum import is_kubeblocks
@@ -38,6 +39,7 @@ from console.views.app_config.base import AppBaseView
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import error_message, general_message
@@ -46,7 +48,7 @@ logger = logging.getLogger("default")
 region_api = RegionInvokeApi()
 
 
-def build_vm_vnc_url(tenant, service, app_k8s_name, vm_url):
+def build_vm_vnc_url(tenant: Any, service: Any, app_k8s_name: str, vm_url: str) -> str:
     if service.extend_method != "vm" or not vm_url:
         return ""
     namespace = tenant.namespace
@@ -59,7 +61,7 @@ def build_vm_vnc_url(tenant, service, app_k8s_name, vm_url):
 
 class AppDetailView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件详情信息
         ---
@@ -76,7 +78,7 @@ class AppDetailView(AppBaseView):
               paramType: path
         """
         vm_url = request.GET.get("vm_url", "")
-        bean = dict()
+        bean: dict = dict()
         namespace = self.tenant.namespace
         service_model = self.service.to_dict()
         group_map = group_service.get_services_group_name([self.service.service_id])
@@ -89,8 +91,9 @@ class AppDetailView(AppBaseView):
         volumes = volume_repo.get_service_volumes_with_config_file(self.service.service_id)
         service_model["disk_cap"] = 30 if self.service.extend_method == "vm" else 10
         if self.service.extend_method == "vm":
+            # NOTE: enterprise_id is nullable on the model but the service expects str (backlog).
             vm_url = rbd_plugin_service.get_vm_plugin_url(
-                self.tenant.enterprise_id,
+                self.tenant.enterprise_id,  # type: ignore[arg-type]
                 self.service.service_region,
                 request=request
             ) or vm_url
@@ -118,7 +121,8 @@ class AppDetailView(AppBaseView):
                 result = general_message(200, "success", "查询成功", bean=bean)
                 return Response(result, status=result["code"])
             rainbond_app, rainbond_app_version = rainbond_app_repo.get_rainbond_app_and_version(
-                self.tenant.enterprise_id, service_source.group_key, service_source.version)
+                self.tenant.enterprise_id, service_source.group_key,  # type: ignore[arg-type]
+                service_source.version)  # type: ignore[arg-type]
             if not rainbond_app:
                 result = general_message(200, "success", "当前组件安装源模版已删除", bean=bean)
                 return Response(result, status=result["code"])
@@ -189,12 +193,12 @@ class AppDetailView(AppBaseView):
 
 class AppVMProfileView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         vm_url = request.GET.get("vm_url", "")
         group_map = group_service.get_services_group_name([self.service.service_id])
         app_k8s_name = group_map.get(self.service.service_id)["k8s_app"]
         vm_url = rbd_plugin_service.get_vm_plugin_url(
-            self.tenant.enterprise_id,
+            self.tenant.enterprise_id,  # type: ignore[arg-type]
             self.service.service_region,
             request=request
         ) or vm_url
@@ -216,7 +220,7 @@ class AppVMProfileView(AppBaseView):
 
 class AppVMDiskView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         volumes = volume_service.get_service_volumes(self.tenant, self.service)
         result = general_message(
             200,
@@ -227,7 +231,7 @@ class AppVMDiskView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         disks = request.data.get("disks", [])
         if not isinstance(disks, list):
             return Response(general_message(400, "param error", "磁盘列表格式错误"), status=400)
@@ -247,7 +251,7 @@ class AppVMDiskView(AppBaseView):
 
 class AppBriefView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件详情信息
         ---
@@ -277,7 +281,7 @@ class AppBriefView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件名称
         ---
@@ -302,16 +306,20 @@ class AppBriefView(AppBaseView):
         k8s_component_name = request.data.get("k8s_component_name", "")
         app = group_service.get_service_group_info(self.service.service_id)
         if app:
-            if app_service.is_k8s_component_name_duplicate(app.ID, k8s_component_name, self.service.service_id):
+            # NOTE: ServiceGroup.ID is an int AutoField but the service expects str (systemic int-as-str).
+            if app_service.is_k8s_component_name_duplicate(app.ID, k8s_component_name,  # type: ignore[arg-type]
+                                                           self.service.service_id):
                 raise ErrK8sComponentNameExists
         original_component_name = self.service.service_cname
-        is_pass, msg = app_service.check_service_cname(self.tenant, service_cname, self.service.service_region)
+        is_pass, msg = app_service.check_service_cname(
+            self.tenant, service_cname, self.service.service_region)  # type: ignore[arg-type]
         if not is_pass:
             return Response(general_message(400, "param error", msg), status=400)
         self.service.k8s_component_name = k8s_component_name
         old_information = json.dumps({"组件名称": self.service.service_cname}, ensure_ascii=False)
         new_information = json.dumps({"组件名称": service_cname}, ensure_ascii=False)
-        self.service.service_cname = service_cname
+        # NOTE: request body value (Any|None) assigned to a model CharField (backlog).
+        self.service.service_cname = service_cname  # type: ignore[assignment]
         region_api.update_service(self.service.service_region, self.tenant.tenant_name, self.service.service_alias,
                                   {"k8s_component_name": k8s_component_name})
 
@@ -340,7 +348,7 @@ class AppBriefView(AppBaseView):
 
 class AppStatusView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件状态
         ---
@@ -372,7 +380,7 @@ class AppStatusView(AppBaseView):
 
 class ListAppPodsView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件实例
         ---
@@ -390,11 +398,12 @@ class ListAppPodsView(AppBaseView):
         """
 
         data = region_api.get_service_pods(self.service.service_region, self.tenant.tenant_name, self.service.service_alias,
-                                           self.tenant.enterprise_id)
+                                           self.tenant.enterprise_id)  # type: ignore[arg-type]
         result = {}
-        if data["bean"]:
+        # NOTE: regionapi result is typed dict|None; legacy code assumes dict (backlog).
+        if data["bean"]:  # type: ignore[index]
 
-            def foobar(data):
+            def foobar(data: Any) -> Any:
                 if data is None:
                     return
                 res = []
@@ -414,7 +423,7 @@ class ListAppPodsView(AppBaseView):
                         memory_usage = float(val["memory_usage"]) / 1024 / 1024
                         usage_rate = 0
                         if memory_limit:
-                            usage_rate = memory_usage * 100 / memory_limit
+                            usage_rate = memory_usage * 100 / memory_limit  # type: ignore[assignment]
                         container_dict["memory_limit"] = round(memory_limit, 2)
                         container_dict["memory_usage"] = round(memory_usage, 2)
                         container_dict["usage_rate"] = round(usage_rate, 2)
@@ -428,7 +437,7 @@ class ListAppPodsView(AppBaseView):
                     res.append(bean)
                 return res
 
-            pods = data["bean"]
+            pods = data["bean"]  # type: ignore[index]
             newpods = foobar(pods.get("new_pods", None))
             old_pods = foobar(pods.get("old_pods", None))
             result = {"new_pods": newpods, "old_pods": old_pods}
@@ -436,7 +445,7 @@ class ListAppPodsView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         进入组件实例
         ---
@@ -463,7 +472,7 @@ class ListAppPodsView(AppBaseView):
               paramType: form
 
         """
-        bean = dict()
+        bean: dict = dict()
         c_id = request.data.get("c_id", "")
         h_id = request.data.get("h_id", "")
         logger.info("c_id = {0} h_id = {1}".format(c_id, h_id))
@@ -478,7 +487,7 @@ class ListAppPodsView(AppBaseView):
 
 class AppVisitView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件访问信息
         ---
@@ -503,7 +512,7 @@ class AppVisitView(AppBaseView):
 
 
 class AppGroupVisitView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件访问信息
         ---
@@ -534,20 +543,21 @@ class AppGroupVisitView(RegionTenantHeaderView):
             for service_alias in service_list:
                 bean = dict()
                 service = service_repo.get_service_by_service_alias(service_alias)
-                access_type, data = port_service.get_access_info(team, service)
+                access_type, data = port_service.get_access_info(team, service)  # type: ignore[arg-type]
                 bean["access_type"] = access_type
                 bean["access_info"] = data
                 service_access_list.append(bean)
             result = general_message(200, "success", "操作成功", list=service_access_list)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2-era Exception.message; absent in py3 (backlog, behavior preserved).
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class AppPluginsBriefView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件安装的插件的简要信息
         ---
@@ -563,7 +573,7 @@ class AppPluginsBriefView(AppBaseView):
               type: string
               paramType: path
         """
-        bean = dict()
+        bean: dict = dict()
         service_abled_plugins = app_plugin_service.get_service_abled_plugin(self.service)
         plugin_list = [p.to_dict() for p in service_abled_plugins]
         result = general_message(200, "success", "操作成功", bean=bean, list=plugin_list)
@@ -572,7 +582,7 @@ class AppPluginsBriefView(AppBaseView):
 
 class AppGroupView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件所在组
         ---
@@ -603,10 +613,11 @@ class AppGroupView(AppBaseView):
             group_service.delete_service_group_relation_by_service_id(self.service.service_id)
         else:
             # check target app exists or not
-            app = group_service.get_group_by_id(self.tenant, self.service.service_region, group_id)
+            # NOTE: group_id is an int here but the service signature expects str (systemic int-as-str).
+            app = group_service.get_group_by_id(self.tenant, self.service.service_region, group_id)  # type: ignore[arg-type]
             app_old = group_service.get_group_by_id(self.tenant, self.service.service_region, self.app.ID)
             # update service relation
-            group_service.update_or_create_service_group_relation(self.tenant, self.service, group_id)
+            group_service.update_or_create_service_group_relation(self.tenant, self.service, group_id)  # type: ignore[arg-type]
             app_name = operation_log_service.process_app_name(
                 app.get("group_name", ""), self.service.service_region, self.tenant.tenant_name, group_id)
             old_information = json.dumps({"组件所属应用": app_old["group_name"]}, ensure_ascii=False)
@@ -633,7 +644,7 @@ class AppGroupView(AppBaseView):
 
 class AppAnalyzePluginView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询组件的性能分析插件
         ---
@@ -661,7 +672,7 @@ class AppAnalyzePluginView(AppBaseView):
 
 class ImageAppView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改镜像源地址
         ---
@@ -685,13 +696,13 @@ class ImageAppView(AppBaseView):
             result = general_message(200, "success", "修改成功")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class BuildSourceinfo(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询构建源信息
         ---
@@ -713,13 +724,14 @@ class BuildSourceinfo(AppBaseView):
             if package_names:
                 bean["package_name"] = package_names[0]
         res, body = region_api.get_cluster_nodes_arch(self.region_name)
-        bean["arch"] = list(set(body.get("list")))
+        # NOTE: regionapi body typed Optional; legacy code assumes dict (backlog).
+        bean["arch"] = list(set(body.get("list")))  # type: ignore[union-attr, arg-type]
         result = general_message(200, "success", "查询成功", bean=bean)
         return Response(result, status=result["code"])
 
     @never_cache
     @transaction.atomic
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改构建源
         ---
@@ -734,7 +746,8 @@ class BuildSourceinfo(AppBaseView):
             user_name = request.data.get("user_name", None)
             password = request.data.get("password", None)
             is_oauth = request.data.get("is_oauth", False)
-            user_id = request.user.user_id
+            # NOTE: request.user typed User|AnonymousUser; user_id only on authed user (backlog).
+            user_id = request.user.user_id  # type: ignore[union-attr]
             oauth_service_id = request.data.get("service_id")
             git_full_name = request.data.get("full_name")
             server_type = request.data.get("server_type", "")
@@ -744,8 +757,9 @@ class BuildSourceinfo(AppBaseView):
 
             service_source_user = service_source_repo.get_service_source(
                 team_id=self.service.tenant_id, service_id=self.service.service_id)
-            new_information = service_source_repo.json_service_source(image=image, cmd=cmd)
-            old_information = service_source_repo.json_service_source(image=self.service.image, cmd=self.service.cmd)
+            new_information = service_source_repo.json_service_source(image=image, cmd=cmd)  # type: ignore[arg-type]
+            old_information = service_source_repo.json_service_source(
+                image=self.service.image, cmd=self.service.cmd)  # type: ignore[arg-type]
             if not service_source_user:
                 service_source_info = {
                     "service_id": self.service.service_id,
@@ -771,13 +785,17 @@ class BuildSourceinfo(AppBaseView):
                     if is_oauth:
                         try:
                             oauth_service = oauth_repo.get_oauth_services_by_service_id(service_id=oauth_service_id)
-                            oauth_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=oauth_service_id, user_id=user_id)
+                            oauth_user = oauth_user_repo.get_user_oauth_by_user_id(
+                                service_id=oauth_service_id,  # type: ignore[arg-type]
+                                user_id=user_id)
                         except Exception as e:
                             logger.debug(e)
                             rst = {"data": {"bean": None}, "status": 400, "msg_show": "Oauth服务可能已被删除，请重新配置"}
                             return Response(rst, status=200)
                         try:
-                            instance = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+                            # NOTE: get_oauth_services_by_service_id may return None (backlog).
+                            instance = get_oauth_instance(
+                                oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
                         except Exception as e:
                             logger.debug(e)
                             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务"}
@@ -785,7 +803,7 @@ class BuildSourceinfo(AppBaseView):
                         if not instance.is_git_oauth():
                             rst = {"data": {"bean": None}, "status": 400, "msg_show": "该OAuth服务不是代码仓库类型"}
                             return Response(rst, status=200)
-                        service_code_from = "oauth_" + oauth_service.oauth_type
+                        service_code_from = "oauth_" + oauth_service.oauth_type  # type: ignore[operator, union-attr]
                         self.service.code_from = service_code_from
                         self.service.git_url = git_url
                         self.service.git_full_name = git_full_name
@@ -849,20 +867,22 @@ class BuildSourceinfo(AppBaseView):
             result = general_message(200, "success", "修改成功")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             transaction.savepoint_rollback(s_id)
         return Response(result, status=result["code"])
 
 
 class AppKeywordView(AppBaseView):
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件触发自动部署关键字
         """
         keyword = request.data.get("keyword", "")
 
-        is_pass, msg = app_service.check_service_cname(self.tenant, self.service.service_region, None)
+        # NOTE: latent bug — args appear swapped (service_region passed as cname, None as
+        # region) vs check_service_cname(tenant, name, region); behavior preserved (backlog).
+        is_pass, msg = app_service.check_service_cname(self.tenant, self.service.service_region, None)  # type: ignore[arg-type]
         if not is_pass:
             return Response(general_message(400, "param error", msg), status=400)
         service_webhook = service_webhooks_repo.get_service_webhooks_by_service_id_and_type(
@@ -878,17 +898,18 @@ class AppKeywordView(AppBaseView):
 # 修改job、cronjob策略配置
 class JobStrategy(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         res = service_repo.get_service_by_service_id(self.service.service_id)
-        if res.job_strategy:
-            bean = json.loads(res.job_strategy)
+        # NOTE: repo result typed Optional; legacy code assumes non-None (backlog).
+        if res.job_strategy:  # type: ignore[union-attr]
+            bean = json.loads(res.job_strategy)  # type: ignore[union-attr]
             result = general_message(200, "success", "查询成功", bean=bean)
             return Response(result, status=result["code"])
         result = general_message(200, "success", "查询成功", bean={})
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         job_strategy = {
             'schedule': request.data.get("schedule", ""),
             'backoff_limit': request.data.get("backoff_limit", ""),
@@ -905,7 +926,7 @@ class JobStrategy(AppBaseView):
 
 # 存储文件管理
 class ManageFile(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         host_path = request.GET.get("host_path", "")
         pod_name = request.GET.get("pod_name", "")
         container_name = request.GET.get("container_name", "")
@@ -919,7 +940,7 @@ class ManageFile(AppBaseView):
             raise e
         bean = {
             "host_path": host_path,
-            "ws_url": region.wsurl,
+            "ws_url": region.wsurl,  # type: ignore[union-attr]
             "namespace": self.tenant.namespace,
             "container_name": container_name or self.service.k8s_component_name
         }

--- a/console/views/app_server_proxy.py
+++ b/console/views/app_server_proxy.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import requests
 from django.http import HttpResponse
 from django.views import View
@@ -7,11 +9,11 @@ from django.utils.decorators import method_decorator
 
 @method_decorator(csrf_exempt, name='dispatch')
 class AppServerProxyView(View):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super(AppServerProxyView, self).__init__(**kwargs)
         self.target_base_url = 'https://hub.grapps.cn'
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: Any, *args: Any, **kwargs: Any) -> HttpResponse:
         # 获取原始请求路径
         path = request.get_full_path()
         # 构建目标URL

--- a/console/views/app_upgrade.py
+++ b/console/views/app_upgrade.py
@@ -2,6 +2,9 @@
 """升级从云市安装的应用"""
 import logging
 from enum import Enum
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.exception.main import ServiceHandleException
 from console.repositories.upgrade_repo import upgrade_repo
@@ -21,10 +24,11 @@ logger = logging.getLogger('default')
 
 
 class GroupAppView(RegionTenantHeaderView):
-    def get(self, request, group_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         """查询当前应用下的应用模版列表及可升级性"""
-        group_id = int(group_id)
-        group = group_service.get_group_or_404(self.tenant, self.response_region, group_id)
+        group_id = int(group_id)  # type: ignore[assignment]
+        # NOTE: group_id is reassigned to int but service expects str (systemic int-as-str; backlog).
+        group = group_service.get_group_or_404(self.tenant, self.response_region, group_id)  # type: ignore[arg-type]
         apps = []
         try:
             apps = market_app_service.get_market_apps_in_app(self.response_region, self.tenant, group)
@@ -35,7 +39,7 @@ class GroupAppView(RegionTenantHeaderView):
 
 
 class AppUpgradeVersion(RegionTenantHeaderView):
-    def get(self, request, group_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         """获取安装的应用模版的可升级版本"""
         group_key = parse_argument(
             request, 'group_key', value_type=str, required=True, error='group_key is a required parameter')
@@ -46,13 +50,15 @@ class AppUpgradeVersion(RegionTenantHeaderView):
         if upgrade_group_id == 0 or upgrade_group_id == "0":
             upgrade_group_id = None
         # get app model upgrade versions
-        versions = market_app_service.get_models_upgradeable_version(self.tenant.enterprise_id, group_key, group_id,
-                                                                     upgrade_group_id)
-        return MessageResponse(msg="success", list=list(versions))
+        # NOTE: enterprise_id is nullable but service expects str (systemic mismatch; backlog).
+        versions = market_app_service.get_models_upgradeable_version(
+            self.tenant.enterprise_id, group_key, group_id, upgrade_group_id)  # type: ignore[arg-type]
+        # NOTE: get_models_upgradeable_version may return None; list() would fail (latent risk; backlog).
+        return MessageResponse(msg="success", list=list(versions))  # type: ignore[arg-type]
 
 
 class AppLastUpgradeRecordView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         upgrade_group_id = parse_argument(request, "upgrade_group_id")
         record_type = parse_argument(request, "record_type")
         record = upgrade_service.get_latest_upgrade_record(self.team, self.app, upgrade_group_id, record_type)
@@ -60,21 +66,23 @@ class AppLastUpgradeRecordView(ApplicationView):
 
 
 class AppUpgradeRecordsView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         page = parse_argument(request, 'page', value_type=int, default=1)
         page_size = parse_argument(request, 'page_size', value_type=int, default=10)
         records, total = upgrade_service.list_records(self.tenant_name, self.region_name, self.app_id,
                                                       AppUpgradeRecordType.UPGRADE.value, page, page_size)
         return MessageResponse(msg="success", bean={"total": total}, list=records)
 
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         upgrade_group_id = parse_item(request, 'upgrade_group_id', required=True)
-        record = upgrade_service.create_upgrade_record(self.user.enterprise_id, self.tenant, self.app, upgrade_group_id)
+        # NOTE: enterprise_id is nullable but service expects str (systemic mismatch; backlog).
+        record = upgrade_service.create_upgrade_record(
+            self.user.enterprise_id, self.tenant, self.app, upgrade_group_id)  # type: ignore[arg-type]
         return MessageResponse(msg="success", bean=record)
 
 
 class AppUpgradeRecordDetailView(RegionTenantHeaderView):
-    def get(self, request, group_id, record_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         record = upgrade_service.get_app_upgrade_record(self.tenant_name, self.region_name, record_id)
         return MessageResponse(msg="success", bean=record)
 
@@ -85,7 +93,7 @@ class UpgradeType(Enum):
 
 
 class AppUpgradeInfoView(ApplicationView):
-    def get(self, request, group_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         upgrade_group_id = parse_argument(
             request, 'upgrade_group_id', default=None, value_type=int, error='upgrade_group_id is a required parameter')
         version = parse_argument(request, 'version', value_type=str, required=True, error='version is a required parameter')
@@ -97,7 +105,7 @@ class AppUpgradeInfoView(ApplicationView):
 
 
 class AppUpgradeRollbackView(AppUpgradeRecordView):
-    def post(self, request, group_id, record_id, *args, **kwargs):
+    def post(self, request: Request, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         if not check_account_quota(self.tenant.creater, self.region_name, app_manage_service.ResourceOperationROLLBACK):
             raise ServiceHandleException(error_code=20002, msg="not enough quota")
         record, _ = upgrade_service.restore(self.tenant, self.region, self.user, self.app, self.app_upgrade_record)
@@ -105,27 +113,30 @@ class AppUpgradeRollbackView(AppUpgradeRecordView):
 
 
 class AppUpgradeDetailView(ApplicationView):
-    def get(self, request, upgrade_group_id, *args, **kwargs):
+    def get(self, request: Request, upgrade_group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         record_id = parse_argument(
             request, 'record_id', value_type=str, required=True, error='record_id is a required parameter')
         record = upgrade_repo.get_by_record_id(record_id)
         # get app model upgrade versions
-        versions = market_app_service.list_app_upgradeable_versions(self.tenant.enterprise_id, record)
+        # NOTE: enterprise_id is nullable but service expects str (systemic mismatch; backlog).
+        versions = market_app_service.list_app_upgradeable_versions(self.tenant.enterprise_id, record)  # type: ignore[arg-type]
         return MessageResponse(msg="success", bean={'record': record.to_dict(), 'versions': versions})
 
 
 class AppUpgradeComponentListView(ApplicationView):
-    def get(self, request, upgrade_group_id, *args, **kwargs):
+    def get(self, request: Request, upgrade_group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         # same as app_key or group_key
         app_model_key = parse_argument(
             request, 'app_model_key', value_type=str, required=True, error='app_model_key is a required parameter')
-        components = market_app_service.list_rainbond_app_components(self.user.enterprise_id, self.tenant, self.app_id,
-                                                                     app_model_key, upgrade_group_id)
+        # NOTE: enterprise_id is nullable but service expects str (systemic mismatch; backlog).
+        components = market_app_service.list_rainbond_app_components(
+            self.user.enterprise_id, self.tenant, self.app_id,  # type: ignore[arg-type]
+            app_model_key, upgrade_group_id)
         return MessageResponse(msg="success", list=components)
 
 
 class AppUpgradeView(AppUpgradeRecordView):
-    def post(self, request, app_id, record_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         if not check_account_quota(self.tenant.creater, self.region_name, app_manage_service.ResourceOperationUPGRADE):
             raise ServiceHandleException(error_code=20002, msg="not enough quota")
         version = parse_item(request, "version", required=True)
@@ -145,7 +156,7 @@ class AppUpgradeView(AppUpgradeRecordView):
 
 
 class AppUpgradeDeployView(AppUpgradeRecordView):
-    def post(self, request, app_id, record_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         if not check_account_quota(self.tenant.creater, self.region_name, app_manage_service.ResourceOperationDeploy):
             raise ServiceHandleException(error_code=20002, msg="not enough quota")
         upgrade_service.deploy(self.tenant, self.region_name, self.user, self.app_upgrade_record)
@@ -153,6 +164,6 @@ class AppUpgradeDeployView(AppUpgradeRecordView):
 
 
 class AppRollbackRecordsView(AppUpgradeRecordView):
-    def get(self, request, app_id, upgrade_record_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, upgrade_record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         records = upgrade_service.list_rollback_record(self.app_upgrade_record)
         return MessageResponse(msg="success", msg_show="获取成功", list=records)

--- a/console/views/app_version.py
+++ b/console/views/app_version.py
@@ -1,6 +1,10 @@
 # coding: utf-8
 """应用版本"""
 
+from typing import Any
+
+from rest_framework.request import Request
+
 from console.exception.main import ServiceHandleException
 from console.services.app_version_service import app_version_service
 from console.utils.reqparse import parse_item
@@ -9,21 +13,22 @@ from console.views.base import ApplicationView
 
 
 class AppVersionOverviewView(ApplicationView):
-    def get(self, request, group_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         overview = app_version_service.get_overview(self.tenant, self.region, self.user, self.app)
         return MessageResponse(msg="success", bean=overview)
 
 
 class AppVersionSnapshotListView(ApplicationView):
-    def get(self, request, group_id, *args, **kwargs):
-        versions = app_version_service.list_snapshot_versions(self.app.ID)
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        # NOTE: ServiceGroup.ID is an int AutoField but service expects str (systemic int-as-str; backlog).
+        versions = app_version_service.list_snapshot_versions(self.app.ID)  # type: ignore[arg-type]
         return MessageResponse(
             msg="success",
             list=versions,
-            bean={"has_template": bool(app_version_service.get_relation(self.app.ID))}
+            bean={"has_template": bool(app_version_service.get_relation(self.app.ID))}  # type: ignore[arg-type]
         )
 
-    def post(self, request, group_id, *args, **kwargs):
+    def post(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         version = parse_item(request, "version", default="")
         version_alias = parse_item(request, "version_alias", default="")
         app_version_info = parse_item(request, "app_version_info", default="")
@@ -46,19 +51,19 @@ class AppVersionSnapshotListView(ApplicationView):
 
 
 class AppVersionSnapshotDetailView(ApplicationView):
-    def get(self, request, group_id, version_id, *args, **kwargs):
-        detail = app_version_service.get_snapshot_detail(self.app.ID, version_id)
+    def get(self, request: Request, group_id: str, version_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        detail = app_version_service.get_snapshot_detail(self.app.ID, version_id)  # type: ignore[arg-type]
         if not detail:
             raise ServiceHandleException("snapshot not found", "快照不存在", status_code=404)
         return MessageResponse(msg="success", bean=detail)
 
-    def delete(self, request, group_id, version_id, *args, **kwargs):
-        app_version_service.delete_snapshot(self.app.ID, version_id)
+    def delete(self, request: Request, group_id: str, version_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        app_version_service.delete_snapshot(self.app.ID, version_id)  # type: ignore[arg-type]
         return MessageResponse(msg="success", msg_show="删除成功")
 
 
 class AppVersionSnapshotRollbackView(ApplicationView):
-    def post(self, request, group_id, version_id, *args, **kwargs):
+    def post(self, request: Request, group_id: str, version_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
         record = app_version_service.rollback_snapshot(self.tenant, self.region, self.user, self.app, version_id)
         if not record:
             raise ServiceHandleException("snapshot rollback not supported", "当前快照暂不支持回滚", status_code=400)
@@ -66,18 +71,20 @@ class AppVersionSnapshotRollbackView(ApplicationView):
 
 
 class AppVersionRollbackRecordListView(ApplicationView):
-    def get(self, request, group_id, *args, **kwargs):
-        records = app_version_service.list_rollback_records(self.tenant_name, self.region_name, self.app.ID)
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        records = app_version_service.list_rollback_records(
+            self.tenant_name, self.region_name, self.app.ID)  # type: ignore[arg-type]
         return MessageResponse(msg="success", list=records)
 
 
 class AppVersionRollbackRecordDetailView(ApplicationView):
-    def get(self, request, group_id, record_id, *args, **kwargs):
-        record = app_version_service.get_rollback_record(self.tenant_name, self.region_name, self.app.ID, record_id)
+    def get(self, request: Request, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        record = app_version_service.get_rollback_record(
+            self.tenant_name, self.region_name, self.app.ID, record_id)  # type: ignore[arg-type]
         if not record:
             raise ServiceHandleException("rollback record not found", "回滚记录不存在", status_code=404)
         return MessageResponse(msg="success", bean=record)
 
-    def delete(self, request, group_id, record_id, *args, **kwargs):
-        app_version_service.delete_rollback_record(self.app.ID, record_id)
+    def delete(self, request: Request, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> MessageResponse:
+        app_version_service.delete_rollback_record(self.app.ID, record_id)  # type: ignore[arg-type]
         return MessageResponse(msg="success", msg_show="删除成功")

--- a/console/views/backup_data.py
+++ b/console/views/backup_data.py
@@ -1,23 +1,27 @@
 # -*- coding: utf-8 -*-
+from typing import Any
+
 from console.services.backup_data_service import platform_data_services
 from console.views.base import EnterpriseAdminView
 from django.contrib.auth import authenticate
+from django.http import HttpResponse
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
 
 class BackupDataCView(EnterpriseAdminView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         backups = platform_data_services.list_backups()
         result = general_message(200, "success", "数据上传成功", list=backups)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         platform_data_services.create_backup()
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
         if not name:
             result = general_message(200, "backup file can not be empty", "备份文件名称不能为空")
@@ -28,12 +32,12 @@ class BackupDataCView(EnterpriseAdminView):
 
 
 class BackupDateDownload(EnterpriseAdminView):
-    def get(self, request, backup_name, *args, **kwargs):
+    def get(self, request: Request, backup_name: str, *args: Any, **kwargs: Any) -> HttpResponse:
         return platform_data_services.download_file(backup_name)
 
 
 class BackupUploadCView(EnterpriseAdminView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         if not request.FILES or not request.FILES.get('file'):
             return Response(general_message(400, "param error", "请指定需要上传的文件"), status=400)
 
@@ -48,7 +52,7 @@ class BackupUploadCView(EnterpriseAdminView):
 
 
 class BackupRecoverCView(EnterpriseAdminView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
         password = request.data.get("password")
         u = authenticate(username=request.user.get_username(), password=password)

--- a/console/views/base.py
+++ b/console/views/base.py
@@ -3,12 +3,14 @@ import copy
 import logging
 import os
 import traceback
+from typing import Any, List, Optional
 
 from addict import Dict
 from console.exception.exceptions import AuthenticationInfoHasExpiredError
 from console.exception.main import (BusinessException, NoPermissionsError, ResourceNotEnoughException, ServiceHandleException,
                                     AbortRequest)
-from console.models.main import (EnterpriseUserPerm, OAuthServices, PermsInfo, RoleInfo, RolePerms, UserOAuthServices, UserRole)
+from console.models.main import (EnterpriseUserPerm, OAuthServices, PermsInfo, RoleInfo, RolePerms, UserOAuthServices, UserRole,
+                                  RegionConfig)
 # repository
 from console.repositories.enterprise_repo import (enterprise_repo, enterprise_user_perm_repo)
 from console.repositories.group import group_repo
@@ -32,10 +34,11 @@ from goodrain_web import errors
 from rest_framework import exceptions, status
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView, set_rollback
 from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient
-from www.models.main import TenantEnterprise, Tenants, TenantServiceInfo, ServiceGroup
+from www.models.main import TenantEnterprise, Tenants, TenantServiceInfo, ServiceGroup, Users
 from console.login.jwt_authentication import (JSONWebTokenAuthentication, JWTAuthenticationSafe)  # noqa: F401
 from console.services.auth.authentication import InternalTokenAuthentication
 
@@ -46,7 +49,7 @@ class BaseApiView(APIView):
     permission_classes = (AllowAny, )
     authentication_classes = (JWTAuthenticationSafe, )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(BaseApiView, self).__init__(*args, **kwargs)
         self.report = Dict({"ok": True})
 
@@ -58,12 +61,14 @@ class AlowAnyApiView(APIView):
     permission_classes = (AllowAny, )
     authentication_classes = ()
 
-    def __init__(self, *args, **kwargs):
+    user: Any
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(AlowAnyApiView, self).__init__(*args, **kwargs)
         self.report = Dict({"ok": True})
         self.user = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         self.user = request.user
 
 
@@ -71,15 +76,26 @@ class JWTAuthApiView(APIView):
     permission_classes = (IsAuthenticated, )
     authentication_classes = (InternalTokenAuthentication, JSONWebTokenAuthentication)
 
-    def __init__(self, *args, **kwargs):
+    # Context attributes are populated in initial() before any handler runs; type them
+    # to the runtime contract so subclass views get clean self.<attr> access. The None
+    # defaults in __init__ are a transient pre-initial state (see P5 progress doc).
+    user: Users
+    enterprise: TenantEnterprise
+    user_perms: List[Any]
+    is_enterprise_admin: bool
+    tenant_name: str
+    tenant: Tenants
+    team: Tenants
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(JWTAuthApiView, self).__init__(*args, **kwargs)
         self.report = Dict({"ok": True})
-        self.user = None
-        self.enterprise = None
+        self.user = None  # type: ignore[assignment]
+        self.enterprise = None  # type: ignore[assignment]
         self.is_enterprise_admin = False
-        self.user_perms = None
+        self.user_perms = None  # type: ignore[assignment]
 
-    def check_perms(self, request, *args, **kwargs):
+    def check_perms(self, request: Request, *args: Any, **kwargs: Any) -> None:
         """
         校验用户是否具有指定的权限。
         Args:
@@ -91,10 +107,10 @@ class JWTAuthApiView(APIView):
         """
         if kwargs.get("__message"):
             # 如果消息中没有当前请求方法对应的权限，则抛出权限错误
-            if kwargs["__message"].get(request.META.get("REQUEST_METHOD").lower()) is None:
+            if kwargs["__message"].get(request.META.get("REQUEST_METHOD").lower()) is None:  # type: ignore[union-attr]
                 raise NoPermissionsError
             # 获取当前请求方法需要的权限
-            request_perms = kwargs["__message"][request.META.get("REQUEST_METHOD").lower()]["perms"]
+            request_perms = kwargs["__message"][request.META.get("REQUEST_METHOD").lower()]["perms"]  # type: ignore[union-attr]
             if kwargs.get("app_id"):
                 pass
             # 检查用户是否具有请求所需的所有权限
@@ -102,24 +118,26 @@ class JWTAuthApiView(APIView):
                 logger.info("no permission. request perms: {}. user perms: {}".format(request_perms, self.user_perms))
                 raise NoPermissionsError
 
-    def has_perms(self, request_perms):
+    def has_perms(self, request_perms: Any) -> None:
         if request_perms and (len(set(request_perms) & set(self.user_perms)) != len(set(request_perms))):
             print("---------------")
             logger.info("no permission. request perms: {}. user perms: {}".format(request_perms, self.user_perms))
             raise NoPermissionsError
 
-    def get_perms(self):
+    def get_perms(self) -> None:
         self.user_perms = []
-        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)
+        # NOTE: Users.user_id is an int AutoField and enterprise_id is nullable, but the
+        # service signatures take str — systemic int-as-str / nullable mismatch (backlog).
+        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         self.user_perms = list(perms.list_enterprise_perm_codes_by_roles(admin_roles))
 
-    def initial(self, request, *args, **kwargs):
-        self.user = request.user
-        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.user.enterprise_id).first()
-        self.is_enterprise_admin = enterprise_user_perm_repo.is_admin(self.user.enterprise_id, self.user.user_id)
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
+        self.user = request.user  # type: ignore[assignment]
+        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.user.enterprise_id).first()  # type: ignore[assignment]
+        self.is_enterprise_admin = enterprise_user_perm_repo.is_admin(self.user.enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         self.get_perms()
         self.check_perms(request, *args, **kwargs)
-        self.tenant_name = kwargs.get("tenantName", None)
+        self.tenant_name = kwargs.get("tenantName", None)  # type: ignore[assignment]
         if self.tenant_name:
             try:
                 self.tenant = Tenants.objects.get(tenant_name=self.tenant_name, enterprise_id=self.user.enterprise_id)
@@ -129,11 +147,13 @@ class JWTAuthApiView(APIView):
 
 
 class EnterpriseAdminView(JWTAuthApiView):
-    def __init__(self, *args, **kwargs):
-        super(EnterpriseAdminView, self).__init__(*args, **kwargs)
-        self.ent_user = None
+    ent_user: Users
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(EnterpriseAdminView, self).__init__(*args, **kwargs)
+        self.ent_user = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(EnterpriseAdminView, self).initial(request, *args, **kwargs)
         user_id = kwargs.get("user_id")
         if user_id:
@@ -144,13 +164,13 @@ class EnterpriseAdminView(JWTAuthApiView):
 
 
 class CloudEnterpriseCenterView(JWTAuthApiView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(CloudEnterpriseCenterView, self).__init__(*args, **kwargs)
         self.oauth_instance = None
         self.oauth = None
         self.oauth_user = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(CloudEnterpriseCenterView, self).initial(request, *args, **kwargs)
         if not os.getenv("IS_PUBLIC", False):
             return
@@ -172,19 +192,23 @@ class CloudEnterpriseCenterView(JWTAuthApiView):
 
 
 class TenantHeaderView(JWTAuthApiView):
-    def __init__(self, *args, **kwargs):
+    team_name: str
+    perm_app_id: Any
+    perm_apps: List[Any]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(TenantHeaderView, self).__init__(*args, **kwargs)
-        self.tenant_name = None
-        self.team_name = None
-        self.tenant = None
-        self.team = None
+        self.tenant_name = None  # type: ignore[assignment]
+        self.team_name = None  # type: ignore[assignment]
+        self.tenant = None  # type: ignore[assignment]
+        self.team = None  # type: ignore[assignment]
         self.report = Dict({"ok": True})
-        self.user = None
+        self.user = None  # type: ignore[assignment]
         self.is_team_owner = False
         self.perm_app_id = ""
         self.perm_apps = []
 
-    def get_perms(self):
+    def get_perms(self) -> None:
         """
         获取用户的权限列表。
 
@@ -202,7 +226,8 @@ class TenantHeaderView(JWTAuthApiView):
         self.user_perms = []
 
         # 获取用户拥有的管理员角色
-        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)
+        # NOTE: systemic int-as-str / nullable enterprise_id mismatch (backlog).
+        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         self.user_perms = list(perms.list_enterprise_perm_codes_by_roles(admin_roles))
 
         # 如果用户是团队所有者，添加团队权限和团队所有者权限
@@ -215,7 +240,7 @@ class TenantHeaderView(JWTAuthApiView):
             # ========== 优化：使用 JOIN 查询替代嵌套子查询 ==========
             # 一次性获取用户在团队中的所有权限（全局 + 应用）
             all_perms = optimized_role_perm_repo.get_user_team_all_perms(
-                user_id=self.user.user_id,
+                user_id=self.user.user_id,  # type: ignore[arg-type]
                 tenant_id=self.tenant.tenant_id
             )
 
@@ -248,13 +273,13 @@ class TenantHeaderView(JWTAuthApiView):
                     if 300002 in perm_codes
                 ]
                 # 添加用户创建的应用
-                app = ServiceGroup.objects.filter(tenant_id=self.tenant.tenant_id,
-                                                  username=self.user.nick_name).values_list("ID", flat=True)
-                self.perm_apps.extend(app)
+                created_app_ids = ServiceGroup.objects.filter(tenant_id=self.tenant.tenant_id,
+                                                              username=self.user.nick_name).values_list("ID", flat=True)
+                self.perm_apps.extend(created_app_ids)
                 self.perm_apps = list(set(self.perm_apps))
         self.user_perms = list(set(self.user_perms))
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         """
         初始化请求相关的实例变量，包括用户信息、企业信息、团队信息和权限信息。
 
@@ -269,10 +294,10 @@ class TenantHeaderView(JWTAuthApiView):
         request_path = getattr(request, 'path', '') or getattr(request, 'path_info', '')
         is_resource_center_log_request = '/resource-center/pods/' in request_path and request_path.endswith('/logs')
         # 设置当前用户
-        self.user = request.user
+        self.user = request.user  # type: ignore[assignment]
 
         # 根据用户的enterprise_id获取企业信息
-        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.user.enterprise_id).first()
+        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.user.enterprise_id).first()  # type: ignore[assignment]
 
         # 根据企业ID和用户ID获取用户权限信息，设置企业管理员标识
         enterprise_user_perms = EnterpriseUserPerm.objects.filter(
@@ -281,17 +306,17 @@ class TenantHeaderView(JWTAuthApiView):
             self.is_enterprise_admin = True
 
         # 获取租户名称
-        self.tenant_name = kwargs.get("tenantName", None)
+        self.tenant_name = kwargs.get("tenantName", None)  # type: ignore[assignment]
         if not self.tenant_name:
-            self.tenant_name = kwargs.get("team_name", None)
+            self.tenant_name = kwargs.get("team_name", None)  # type: ignore[assignment]
         if not self.tenant_name:
-            self.tenant_name = request.META.get('HTTP_X_TEAM_NAME', None)
+            self.tenant_name = request.META.get('HTTP_X_TEAM_NAME', None)  # type: ignore[assignment]
         if not self.tenant_name:
-            self.tenant_name = self.request.COOKIES.get('team', None)
+            self.tenant_name = self.request.COOKIES.get('team', None)  # type: ignore[assignment]
         if not self.tenant_name:
-            self.tenant_name = self.request.COOKIES.get('team_name', None)
+            self.tenant_name = self.request.COOKIES.get('team_name', None)  # type: ignore[assignment]
         if not self.tenant_name:
-            self.tenant_name = self.request.GET.get('team_name', None)
+            self.tenant_name = self.request.GET.get('team_name', None)  # type: ignore[assignment]
         self.team_name = self.tenant_name
 
         # 如果租户名称不存在，抛出异常
@@ -325,22 +350,22 @@ class TenantHeaderView(JWTAuthApiView):
         # 获取权限应用ID
         if kwargs.get("app_id"):
             try:
-                self.perm_app_id = int(kwargs.get("app_id"))
+                self.perm_app_id = int(kwargs.get("app_id"))  # type: ignore[arg-type]
             except Exception as e:
                 self.perm_app_id = -1
         if request.GET.get("group_id"):
             try:
-                self.perm_app_id = int(request.GET.get("group_id"))
+                self.perm_app_id = int(request.GET.get("group_id"))  # type: ignore[arg-type]
             except Exception as e:
                 self.perm_app_id = -1
         if request.GET.get("app_id"):
             try:
-                self.perm_app_id = int(request.GET.get("app_id"))
+                self.perm_app_id = int(request.GET.get("app_id"))  # type: ignore[arg-type]
             except Exception as e:
                 self.perm_app_id = -1
         if kwargs.get("group_id"):
             try:
-                self.perm_app_id = int(kwargs.get("group_id"))
+                self.perm_app_id = int(kwargs.get("group_id"))  # type: ignore[arg-type]
             except Exception as e:
                 self.perm_app_id = -1
         request_data = None
@@ -353,12 +378,12 @@ class TenantHeaderView(JWTAuthApiView):
                 self.perm_app_id = -1
             else:
                 try:
-                    self.perm_app_id = int(request_data.get("group_id"))
+                    self.perm_app_id = int(request_data.get("group_id"))  # type: ignore[arg-type]
                 except Exception as e:
                     self.perm_app_id = -1
         if isinstance(request_data, dict) and request_data.get("app_id"):
             try:
-                self.perm_app_id = int(request_data.get("app_id"))
+                self.perm_app_id = int(request_data.get("app_id"))  # type: ignore[arg-type]
             except Exception as e:
                 self.perm_app_id = -1
         # 根据服务别名获取服务信息，并设置权限应用ID
@@ -372,7 +397,7 @@ class TenantHeaderView(JWTAuthApiView):
 
         if self.user.user_id == self.tenant.creater:
             self.is_team_owner = True
-        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.tenant.enterprise_id).first()
+        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.tenant.enterprise_id).first()  # type: ignore[assignment]
         self.is_enterprise_admin = False
         enterprise_user_perms = EnterpriseUserPerm.objects.filter(
             enterprise_id=self.tenant.enterprise_id, user_id=self.user.user_id).first()
@@ -383,23 +408,27 @@ class TenantHeaderView(JWTAuthApiView):
 
 
 class RegionTenantHeaderView(TenantHeaderView):
-    def __init__(self, *args, **kwargs):
-        super(RegionTenantHeaderView, self).__init__(*args, **kwargs)
-        self.response_region = None
-        self.region_name = None
-        self.region = None
+    response_region: str
+    region_name: str
+    region: RegionConfig
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(RegionTenantHeaderView, self).__init__(*args, **kwargs)
+        self.response_region = None  # type: ignore[assignment]
+        self.region_name = None  # type: ignore[assignment]
+        self.region = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(RegionTenantHeaderView, self).initial(request, *args, **kwargs)
-        self.response_region = kwargs.get("region_name", None)
+        self.response_region = kwargs.get("region_name", None)  # type: ignore[assignment]
         if not self.response_region:
-            self.response_region = request.GET.get("region_name", None)
+            self.response_region = request.GET.get("region_name", None)  # type: ignore[assignment]
         if not self.response_region:
-            self.response_region = request.GET.get("region", None)
+            self.response_region = request.GET.get("region", None)  # type: ignore[assignment]
         if not self.response_region:
-            self.response_region = request.META.get('HTTP_X_REGION_NAME', None)
+            self.response_region = request.META.get('HTTP_X_REGION_NAME', None)  # type: ignore[assignment]
         if not self.response_region:
-            self.response_region = self.request.COOKIES.get('region_name', None)
+            self.response_region = self.request.COOKIES.get('region_name', None)  # type: ignore[assignment]
         self.region_name = self.response_region
         if not self.response_region:
             raise ImportError("region_name not found !")
@@ -410,21 +439,24 @@ class RegionTenantHeaderView(TenantHeaderView):
 
 
 class RegionTenantHeaderCloudEnterpriseCenterView(RegionTenantHeaderView, CloudEnterpriseCenterView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(RegionTenantHeaderCloudEnterpriseCenterView, self).__init__(*args, **kwargs)
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         RegionTenantHeaderView.initial(self, request, *args, **kwargs)
         CloudEnterpriseCenterView.initial(self, request, *args, **kwargs)
 
 
 class ApplicationView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
+    app: ServiceGroup
+    app_id: Any
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(ApplicationView, self).__init__(*args, **kwargs)
-        self.app = None
+        self.app = None  # type: ignore[assignment]
         self.app_id = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(ApplicationView, self).initial(request, *args, **kwargs)
         app_id = kwargs.get("app_id") if kwargs.get("app_id") else kwargs.get("group_id")
         app_id = app_id if app_id else request.data.get("group_id")
@@ -440,22 +472,24 @@ class ApplicationView(RegionTenantHeaderView):
                     tenant_id=self.tenant.tenant_id, region_name=self.region_name, k8s_app="sourcecode-demo")
                 if k8s_apps:
                     k8s_app_name += make_uuid()[:6]
+                # NOTE: demo path passes None for several create_app str params and a
+                # nullable enterprise_id; legacy caller-side mismatch (behavior preserved).
                 data = group_service.create_app(
                     self.tenant,
                     self.region_name,
                     "源码构建示例",
-                    None,
+                    None,  # type: ignore[arg-type]
                     self.user.get_username(),
-                    None,
-                    None,
-                    None,
-                    None,
-                    self.user.enterprise_id,
-                    None,
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
+                    self.user.enterprise_id,  # type: ignore[arg-type]
+                    None,  # type: ignore[arg-type]
                     k8s_app=k8s_app_name)
                 app_id = data["group_id"]
 
-        app = group_repo.get_group_by_pk(self.tenant.tenant_id, self.region_name, app_id)
+        app = group_repo.get_group_by_pk(self.tenant.tenant_id, self.region_name, app_id)  # type: ignore[arg-type]
         if not app:
             raise ServiceHandleException("app not found", "应用不存在", status_code=404)
         self.app = app
@@ -463,58 +497,62 @@ class ApplicationView(RegionTenantHeaderView):
 
         # update update_time if the http method is not a get.
         if request.method != 'GET':
-            group_repo.update_group_time(app_id)
+            group_repo.update_group_time(app_id)  # type: ignore[arg-type]
 
 
 class AppUpgradeRecordView(ApplicationView):
-    def __init__(self, *args, **kwargs):
+    app_upgrade_record: Any
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(AppUpgradeRecordView, self).__init__(*args, **kwargs)
         self.app_upgrade_record = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(AppUpgradeRecordView, self).initial(request, *args, **kwargs)
         record_id = kwargs.get("record_id") if kwargs.get("record_id") else kwargs.get("upgrade_record_id")
-        self.app_upgrade_record = upgrade_repo.get_by_record_id(record_id)
+        self.app_upgrade_record = upgrade_repo.get_by_record_id(record_id)  # type: ignore[arg-type]
 
 
 class ApplicationViewCloudEnterpriseCenterView(ApplicationView, CloudEnterpriseCenterView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(ApplicationViewCloudEnterpriseCenterView, self).__init__(*args, **kwargs)
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         ApplicationView.initial(self, request, *args, **kwargs)
         CloudEnterpriseCenterView.initial(self, request, *args, **kwargs)
 
 
 class TeamOwnerView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(TeamOwnerView, self).__init__(*args, **kwargs)
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(TeamOwnerView, self).initial(request, *args, **kwargs)
         if not self.is_team_owner:
             raise NoPermissionsError
 
 
 class EnterpriseHeaderView(JWTAuthApiView):
-    def __init__(self, *args, **kwargs):
-        super(EnterpriseHeaderView, self).__init__(*args, **kwargs)
-        self.enterprise = None
-        self.enterprise_id = None
+    enterprise_id: str
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(EnterpriseHeaderView, self).__init__(*args, **kwargs)
+        self.enterprise = None  # type: ignore[assignment]
+        self.enterprise_id = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(EnterpriseHeaderView, self).initial(request, *args, **kwargs)
         eid = kwargs.get("eid", None)
         enterprise_id = kwargs.get("enterprise_id", eid)
         if not enterprise_id:
             raise ImportError("enterprise_id not found !")
-        self.enterprise = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id)
+        self.enterprise = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id)  # type: ignore[assignment]
         if not self.enterprise:
             raise NotFound("enterprise id: {};enterprise not found".format(enterprise_id))
         self.enterprise_id = enterprise_id
 
 
-def custom_exception_handler(exc, context):
+def custom_exception_handler(exc: Exception, context: Any) -> Optional[Response]:
     """
         Returns the response that should be used for any given exception.
 
@@ -530,7 +568,7 @@ def custom_exception_handler(exc, context):
     if isinstance(exc, ServiceHandleException):
         return exc.response
     elif isinstance(exc, ResourceNotEnoughException):
-        data = {"code": 10406, "msg": "resource is not enough", "msg_show": exc.message}
+        data = {"code": 10406, "msg": "resource is not enough", "msg_show": exc.message}  # type: ignore[attr-defined]
         return Response(data, status=412)
     elif isinstance(exc, RegionApiBaseHttpClient.CallApiFrequentError):
         data = {"code": 409, "msg": "wait a moment please", "msg_show": "操作过于频繁，请稍后再试"}
@@ -545,7 +583,7 @@ def custom_exception_handler(exc, context):
             else:
                 core_error = str(exc.message)
             data = {"code": 400, "msg": exc.message, "msg_show": "数据中心操作故障 {}".format(core_error)}
-        return Response(data, status=data["code"])
+        return Response(data, status=data["code"])  # type: ignore[arg-type]
     elif isinstance(exc, ValidationError):
         logger.error(exc)
         return Response({
@@ -558,12 +596,12 @@ def custom_exception_handler(exc, context):
     elif isinstance(exc, exceptions.APIException):
         headers = {}
         if getattr(exc, 'auth_header', None):
-            headers['WWW-Authenticate'] = exc.auth_header
+            headers['WWW-Authenticate'] = exc.auth_header  # type: ignore[attr-defined]
         if getattr(exc, 'wait', None):
-            headers['Retry-After'] = '%d' % exc.wait
+            headers['Retry-After'] = '%d' % exc.wait  # type: ignore[attr-defined]
 
         if isinstance(exc.detail, dict):
-            data = exc.detail
+            data = exc.detail  # type: ignore[assignment]
         else:
             data = {'detail': exc.detail}
 

--- a/console/views/bill_proxy.py
+++ b/console/views/bill_proxy.py
@@ -1,6 +1,9 @@
 import os
+from typing import Any
+
 import requests
 from django.http import HttpResponse
+from django.http import HttpRequest
 from django.views import View
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
@@ -8,11 +11,11 @@ from django.utils.decorators import method_decorator
 
 @method_decorator(csrf_exempt, name='dispatch')
 class BillProxyView(View):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super(BillProxyView, self).__init__(**kwargs)
         self.bill_service_url = os.getenv('BILL_SERVICE_URL', '')
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         # 获取原始请求路径
         path = request.get_full_path()
         # 构建目标URL
@@ -37,8 +40,8 @@ class BillProxyView(View):
         try:
             # 检查是否是文件上传请求
             content_type = request.META.get('CONTENT_TYPE', '')
-            request_data = None
-            request_files = None
+            request_data: Any = None
+            request_files: Any = None
 
             if request.method in ('POST', 'PUT', 'PATCH'):
                 if content_type.startswith('multipart/form-data'):
@@ -56,7 +59,8 @@ class BillProxyView(View):
 
                     # 添加文件字段
                     for key, file_obj in request.FILES.items():
-                        request_files[key] = (file_obj.name, file_obj.read(), file_obj.content_type)
+                        # NOTE: MultiValueDict.items() typed as UploadedFile|list; runtime is UploadedFile (backlog).
+                        request_files[key] = (file_obj.name, file_obj.read(), file_obj.content_type)  # type: ignore[union-attr]
                 else:
                     # 非文件上传请求，使用原始body
                     request_data = request.body

--- a/console/views/center_pool/app_export.py
+++ b/console/views/center_pool/app_export.py
@@ -3,8 +3,10 @@
   Created on 18/5/5.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.app_import_and_export_service import export_service
@@ -18,7 +20,7 @@ logger = logging.getLogger('default')
 
 class CenterAppExportView(JWTAuthApiView):
     @never_cache
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取应用导出状态
         ---
@@ -37,17 +39,19 @@ class CenterAppExportView(JWTAuthApiView):
         result_list = []
         app_version_list = app_version.split("#")
         for version in app_version_list:
-            app, app_version = market_app_service.get_rainbond_app_and_version(self.user.enterprise_id, app_id, version)
-            if not app or not app_version:
+            # NOTE: systemic int-as-str / request str-as-arg legacy mismatch
+            app, app_version_obj = market_app_service.get_rainbond_app_and_version(
+                self.user.enterprise_id, app_id, version)  # type: ignore[arg-type]
+            if not app or not app_version_obj:
                 return Response(general_message(404, "not found", "云市应用不存在"), status=404)
-            result = export_service.get_export_status(enterprise_id, app, app_version)
+            result = export_service.get_export_status(enterprise_id, app, app_version_obj)
             result_list.append(result)
 
         result = general_message(200, "success", "查询成功", list=result_list)
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         导出应用市场应用
         ---
@@ -77,11 +81,13 @@ class CenterAppExportView(JWTAuthApiView):
         new_export_record_list.append(record.to_dict())
 
         result = general_message(200, "success", "操作成功，正在导出", list=new_export_record_list)
-        app, app_version = market_app_service.get_rainbond_app_and_version(enterprise_id, app_id, app_versions[0])
+        app, app_version = market_app_service.get_rainbond_app_and_version(
+            enterprise_id, app_id, app_versions[0])  # type: ignore[arg-type]
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.EXPORT,
             module=OperationModule.APPMODEL,
-            module_name="{} 的 {} 版本".format(app.app_name, app_version.version))
+            # NOTE: get_rainbond_app_and_version may return None; backlog
+            module_name="{} 的 {} 版本".format(app.app_name, app_version.version))  # type: ignore[union-attr]
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=result["code"])

--- a/console/views/center_pool/app_import.py
+++ b/console/views/center_pool/app_import.py
@@ -4,6 +4,9 @@
 """
 import json
 import logging
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.exception.main import AbortRequest, RegionNotFound
 from console.services.app_import_and_export_service import import_service
@@ -20,7 +23,7 @@ logger = logging.getLogger('default')
 
 class EnterpriseAppImportInitView(JWTAuthApiView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询导入记录，如果有未完成的记录返回未完成的记录，如果没有，创建新的导入记录
         ---
@@ -45,7 +48,8 @@ class EnterpriseAppImportInitView(JWTAuthApiView):
             new = True
         if new:
             try:
-                r = import_service.create_app_import_record_2_enterprise(eid, self.user.nick_name)
+                r = import_service.create_app_import_record_2_enterprise(
+                    eid, self.user.nick_name)  # type: ignore[arg-type]
             except RegionNotFound:
                 return Response(general_message(200, "success", "查询成功", bean={"region_name": ''}), status=200)
         upload_url = import_service.get_upload_url(r.region, r.event_id)
@@ -62,7 +66,7 @@ class EnterpriseAppImportInitView(JWTAuthApiView):
 
 class CenterAppImportView(JWTAuthApiView):
     @never_cache
-    def post(self, request, event_id, *args, **kwargs):
+    def post(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         导入应用包
         ---
@@ -107,12 +111,14 @@ class CenterAppImportView(JWTAuthApiView):
             operation=Operation.IMPORT, module=OperationModule.APPMODEL, module_name="")
         new_information = json.dumps({"导入团队": team_name, "导入文件": file_name, "可见范围": scope}, ensure_ascii=False)
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, new_information=new_information)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            new_information=new_information)
         return Response(result, status=result["code"])
 
     @never_cache
     @transaction.atomic
-    def get(self, request, event_id, *args, **kwargs):
+    def get(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询应用包导入状态
         ---
@@ -132,7 +138,8 @@ class CenterAppImportView(JWTAuthApiView):
         arch = request.GET.get("arch")
         try:
             sid = transaction.savepoint()
-            record, apps_status = import_service.get_and_update_import_by_event_id(event_id, arch)
+            record, apps_status = import_service.get_and_update_import_by_event_id(
+                event_id, arch)  # type: ignore[arg-type]
             transaction.savepoint_commit(sid)
             result = general_message(200, 'success', "查询成功", bean=record.to_dict(), list=apps_status)
         except Exception as e:
@@ -141,7 +148,7 @@ class CenterAppImportView(JWTAuthApiView):
             raise e
         return Response(result, status=result["code"])
 
-    def delete(self, request, event_id, *args, **kwargs):
+    def delete(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         放弃导入
         ---
@@ -162,13 +169,13 @@ class CenterAppImportView(JWTAuthApiView):
             result = general_message(200, "success", "操作成功")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class CenterAppTarballDirView(JWTAuthApiView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询应用包目录
         ---
@@ -192,7 +199,7 @@ class CenterAppTarballDirView(JWTAuthApiView):
         result = general_message(200, "success", "查询成功", list=apps)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         批量导入时创建一个目录
         ---
@@ -203,12 +210,14 @@ class CenterAppTarballDirView(JWTAuthApiView):
               type: string
               paramType: path
         """
-        import_record = import_service.create_import_app_dir(self.tenant, self.user, self.response_region)
+        # NOTE: view extends JWTAuthApiView which lacks tenant/response_region (latent bug)
+        import_record = import_service.create_import_app_dir(
+            self.tenant, self.user, self.response_region)  # type: ignore[attr-defined]
 
         result = general_message(200, "success", "查询成功", bean=import_record.to_dict())
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除导入
         ---
@@ -228,7 +237,9 @@ class CenterAppTarballDirView(JWTAuthApiView):
         if not event_id:
             return Response(general_message(400, "event id is null", "请指明需要查询的event id"), status=400)
 
-        import_record = import_service.delete_import_app_dir(self.tenant, self.response_region, event_id)
+        # NOTE: response_region missing on JWTAuthApiView; delete_import_app_dir returns None (latent bugs)
+        import_record = import_service.delete_import_app_dir(
+            self.tenant, self.response_region, event_id)  # type: ignore[attr-defined,func-returns-value]
 
-        result = general_message(200, "success", "查询成功", bean=import_record.to_dict())
+        result = general_message(200, "success", "查询成功", bean=import_record.to_dict())  # type: ignore[union-attr]
         return Response(result, status=result["code"])

--- a/console/views/center_pool/apps.py
+++ b/console/views/center_pool/apps.py
@@ -6,6 +6,9 @@ import datetime
 import json
 import logging
 import re
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.cloud.services import check_account_quota
 from console.exception.main import ServiceHandleException
@@ -31,7 +34,7 @@ logger = logging.getLogger('default')
 
 class CenterAppListView(JWTAuthApiView):
     @never_cache
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取本地市场应用
         ---
@@ -59,13 +62,15 @@ class CenterAppListView(JWTAuthApiView):
         """
         scope = request.GET.get("scope", None)
         app_name = request.GET.get("app_name", None)
-        tags = request.GET.get("tags", [])
+        tags: Any = request.GET.get("tags", [])
         if tags:
             tags = json.loads(tags)
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         app_list = []
-        apps = rainbond_app_repo.get_rainbond_apps_versions_by_eid(enterprise_id, app_name, tags, scope, page, page_size)
+        # NOTE: repo method not in stub; request.GET.get yields str|None args
+        apps = rainbond_app_repo.get_rainbond_apps_versions_by_eid(  # type: ignore[attr-defined]
+            enterprise_id, app_name, tags, scope, page, page_size)
         if apps and apps[0].app_name:
             for app in apps:
                 versions_info = (json.loads(app.versions_info) if app.versions_info else [])
@@ -96,7 +101,7 @@ class CenterAppListView(JWTAuthApiView):
 
 class CenterAppView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         创建应用市场应用
         ---
@@ -131,8 +136,10 @@ class CenterAppView(RegionTenantHeaderView):
         market_name = request.data.get("market_name", None)
         if not check_account_quota(self.tenant.creater, self.region_name, app_manage_service.ResourceOperationDeploy):
             raise ServiceHandleException(error_code=20002, msg="not enough quota")
-        app_name = market_app_service.install_app(self.tenant, self.region, self.user, app_id, app_model_key, version, market_name,
-                                       install_from_cloud, is_deploy, dry_run)
+        app_name = market_app_service.install_app(
+            self.tenant, self.region, self.user, app_id,
+            app_model_key, version, market_name,  # type: ignore[arg-type]
+            install_from_cloud, is_deploy, dry_run)
         comment = "从应用市场{}安装了应用{}".format(market_name, app_name)
         operation_log_service.create_app_log(ctx=self, comment=comment, format_app=False)
         return Response(general_message(200, "success", "创建成功"), status=200)
@@ -140,7 +147,7 @@ class CenterAppView(RegionTenantHeaderView):
 
 class CmdInstallAppView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         命令行创建应用
         """
@@ -173,7 +180,7 @@ class CmdInstallAppView(RegionTenantHeaderView):
 
 class CenterAppCLView(JWTAuthApiView):
     @never_cache
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取本地市场应用
         ---
@@ -208,8 +215,14 @@ class CenterAppCLView(JWTAuthApiView):
         is_plugin = request.GET.get("is_plugin", None)
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
-        apps, count, app_ids = market_app_service.get_visiable_apps(scope, app_name, is_complete, page,
-                                                           page_size, need_install, arch, tenant_name, is_plugin)
+        apps, count, app_ids = market_app_service.get_visiable_apps(
+            scope,  # type: ignore[arg-type]
+            app_name,  # type: ignore[arg-type]
+            is_complete,  # type: ignore[arg-type]
+            page,
+            page_size, need_install, arch,
+            tenant_name,  # type: ignore[arg-type]
+            is_plugin)
         list = []
         for a in apps:
             app = a.to_dict()
@@ -219,7 +232,7 @@ class CenterAppCLView(JWTAuthApiView):
         return MessageResponse("success", msg_show="查询成功", list=list, total=count, next_page=int(page) + 1)
 
     @never_cache
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
         describe = request.data.get("describe", 'This is a default description.')
         pic = request.data.get("pic")
@@ -259,12 +272,15 @@ class CenterAppCLView(JWTAuthApiView):
             return Response(general_message(400, "创建失败：应用已存在", None), status=400)
         tags = app_tag_repo.get_tags(tag_ids)
         tag_names = [tag.name for tag in tags]
-        new_information = market_app_service.json_rainbond_app(name, scope, tag_names, describe, pic)
+        new_information = market_app_service.json_rainbond_app(
+            name, scope, tag_names, describe, pic)  # type: ignore[arg-type]
         result = general_message(200, "success", None)
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.CREATE, module=OperationModule.APPMODEL, module_name="{}".format(name))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, new_information=new_information)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            new_information=new_information)
         return Response(result, status=200)
 
 
@@ -274,7 +290,7 @@ class CenterAppUDView(JWTAuthApiView):
         ---
     """
 
-    def put(self, request, enterprise_id, app_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
         if not validate_name(name):
             result = general_message(400, "error params", "应用名称只支持中文、字母、数字和-_组合,并且必须以中文、字母、数字开始和结束")
@@ -304,12 +320,17 @@ class CenterAppUDView(JWTAuthApiView):
         tags = rainbond_app_repo.get_app_tag_by_id(enterprise_id, app_id)
         old_tag_ids = [tag.tag_id for tag in tags]
         tags = app_tag_repo.get_tags(old_tag_ids)
+        # NOTE: get_rainbond_app may return None; request.data.get yields Any|None
         old_information = market_app_service.json_rainbond_app(
-            name=app.app_name, scope=app.scope, tag_names=[tag.name for tag in tags], describe=app.describe,
-            logo=app.pic)
+            name=app.app_name,  # type: ignore[union-attr]
+            scope=app.scope,  # type: ignore[union-attr]
+            tag_names=[tag.name for tag in tags],
+            describe=app.describe,  # type: ignore[union-attr,arg-type]
+            logo=app.pic)  # type: ignore[union-attr,arg-type]
         tags = app_tag_repo.get_tags(tag_ids)
         tag_names = [tag.name for tag in tags]
-        new_information = market_app_service.json_rainbond_app(name, scope, tag_names, describe, pic)
+        new_information = market_app_service.json_rainbond_app(
+            name, scope, tag_names, describe, pic)  # type: ignore[arg-type]
         market_app_service.update_rainbond_app(enterprise_id, app_id, app_info)
         result = general_message(200, "success", None)
         comment = operation_log_service.generate_generic_comment(
@@ -317,28 +338,35 @@ class CenterAppUDView(JWTAuthApiView):
         operation_log_service.create_component_library_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             old_information=old_information,
             new_information=new_information)
         return Response(result, status=200)
 
-    def delete(self, request, enterprise_id, app_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         app = rainbond_app_repo.get_rainbond_app_by_app_id(app_id)
         tags = rainbond_app_repo.get_app_tag_by_id(enterprise_id, app_id)
         tag_ids = [tag.tag_id for tag in tags]
         tags = app_tag_repo.get_tags(tag_ids)
         tag_names = [tag.name for tag in tags]
+        # NOTE: get_rainbond_app_by_app_id may return None; backlog
         old_information = market_app_service.json_rainbond_app(
-            name=app.app_name, scope=app.scope, tag_names=tag_names, describe=app.describe, logo=app.pic)
+            name=app.app_name,  # type: ignore[union-attr]
+            scope=app.scope,  # type: ignore[union-attr]
+            tag_names=tag_names,
+            describe=app.describe,  # type: ignore[union-attr,arg-type]
+            logo=app.pic)  # type: ignore[union-attr,arg-type]
         market_app_service.delete_rainbond_app_all_info_by_id(enterprise_id, app_id)
         result = general_message(200, "success", None)
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.APPMODEL, module_name="{}".format(app.app_name if app else ""))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, old_information=old_information)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            old_information=old_information)
         return Response(result, status=200)
 
-    def get(self, request, enterprise_id, app_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         app, versions, total = market_app_service.get_rainbond_app_and_versions(enterprise_id, app_id, page, page_size)
@@ -346,7 +374,7 @@ class CenterAppUDView(JWTAuthApiView):
 
 
 class TagCLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         data = []
         app_tag_list = app_tag_repo.get_all_tag_list(enterprise_id)
         if app_tag_list:
@@ -355,13 +383,13 @@ class TagCLView(JWTAuthApiView):
         result = general_message(200, "success", None, list=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name", None)
         result = general_message(200, "success", "创建成功")
         if not name:
             result = general_message(400, "fail", "参数不正确")
         try:
-            rst = app_tag_repo.create_tag(enterprise_id, name)
+            rst = app_tag_repo.create_tag(enterprise_id, name)  # type: ignore[arg-type]
             if not rst:
                 result = general_message(400, "fail", "标签已存在")
         except Exception as e:
@@ -371,17 +399,17 @@ class TagCLView(JWTAuthApiView):
 
 
 class TagUDView(JWTAuthApiView):
-    def put(self, request, enterprise_id, tag_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, tag_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name", None)
         result = general_message(200, "success", "更新成功")
         if not name:
             result = general_message(400, "fail", "参数不正确")
-        rst = app_tag_repo.update_tag_name(enterprise_id, tag_id, name)
+        rst = app_tag_repo.update_tag_name(enterprise_id, tag_id, name)  # type: ignore[arg-type]
         if not rst:
             result = general_message(400, "fail", "更新失败")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, tag_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, tag_id: str, *args: Any, **kwargs: Any) -> Response:
         result = general_message(200, "success", "删除成功")
         rst = app_tag_repo.delete_tag(enterprise_id, tag_id)
         if not rst:
@@ -390,7 +418,7 @@ class TagUDView(JWTAuthApiView):
 
 
 class AppTagCDView(JWTAuthApiView):
-    def post(self, request, enterprise_id, app_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         tag_id = request.data.get("tag_id", None)
         result = general_message(200, "success", "创建成功")
         if not tag_id:
@@ -399,13 +427,13 @@ class AppTagCDView(JWTAuthApiView):
         if not app:
             result = general_message(404, "fail", "该应用不存在")
         try:
-            app_tag_repo.create_app_tag_relation(app, tag_id)
+            app_tag_repo.create_app_tag_relation(app, tag_id)  # type: ignore[arg-type]
         except Exception as e:
             logger.debug(e)
             result = general_message(404, "fail", "创建失败")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, app_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         tag_id = request.data.get("tag_id", None)
         result = general_message(200, "success", "删除成功")
         if not tag_id:
@@ -414,7 +442,7 @@ class AppTagCDView(JWTAuthApiView):
         if not app:
             result = general_message(404, "fail", "该应用不存在")
         try:
-            app_tag_repo.delete_app_tag_relation(app, tag_id)
+            app_tag_repo.delete_app_tag_relation(app, tag_id)  # type: ignore[arg-type]
         except Exception as e:
             logger.debug(e)
             result = general_message(404, "fail", "删除失败")
@@ -422,7 +450,7 @@ class AppTagCDView(JWTAuthApiView):
 
 
 class AppVersionUDView(JWTAuthApiView):
-    def put(self, request, enterprise_id, app_id, version, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, app_id: str, version: str, *args: Any, **kwargs: Any) -> Response:
         dev_status = request.data.get("dev_status", "")
         version_alias = request.data.get("version_alias", None)
         app_version_info = request.data.get("app_version_info", None)
@@ -442,17 +470,19 @@ class AppVersionUDView(JWTAuthApiView):
         if dev_status == "release":
             op = Operation.Set
             module_name = "{}的{}版本为release状态".format(app.app_name if app else "", version.version)
-        if dev_status == "" and app_version.dev_status == "release":
+        # NOTE: get_rainbond_app_and_version may return None app_version; backlog
+        if dev_status == "" and app_version.dev_status == "release":  # type: ignore[union-attr]
             op = Operation.CANCEL
             module_name = "{}的{}版本release状态".format(app.app_name if app else "", version.version)
         comment = operation_log_service.generate_generic_comment(
             operation=op, module=OperationModule.APPMODEL, module_name=module_name)
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, app_id, version, *args, **kwargs):
-        app = rainbond_app_repo.get_rainbond_app_by_app_id(enterprise_id, app_id)
+    def delete(self, request: Request, enterprise_id: str, app_id: str, version: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: get_rainbond_app_by_app_id takes 1 arg; called with 2 (latent bug)
+        app = rainbond_app_repo.get_rainbond_app_by_app_id(enterprise_id, app_id)  # type: ignore[call-arg]
         result = general_message(200, "success", "删除成功")
         market_app_service.delete_rainbond_app_version(enterprise_id, app_id, version)
         comment = operation_log_service.generate_generic_comment(
@@ -460,20 +490,20 @@ class AppVersionUDView(JWTAuthApiView):
             module=OperationModule.APPMODEL,
             module_name="{}的{}版本".format(app.app_name if app else "", version))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=result.get("code", 200))
 
 
 # Whether you need to be reminded to configure mirror repositories
 class LocalComponentLibraryConfigCheck(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         regions = region_services.get_regions_by_enterprise_id(enterprise_id)
         remind = False
         if regions and len(regions) > 1:
-            ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)
+            ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
             data = ent_cfg_svc.get_config_by_key("APPSTORE_IMAGE_HUB")
             if data and data.enable:
-                image_config_dict = eval(data.value)
+                image_config_dict = eval(data.value)  # type: ignore[arg-type]
                 hub_url = image_config_dict.get("hub_url", None)
                 if not hub_url:
                     remind = True
@@ -485,7 +515,7 @@ class LocalComponentLibraryConfigCheck(JWTAuthApiView):
 
 class CenterPluginAppView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         创建应用市场插件型应用
         ---
@@ -517,17 +547,22 @@ class CenterPluginAppView(RegionTenantHeaderView):
         install_from_cloud = request.data.get("install_from_cloud", False)
         market_name = request.data.get("market_name", None)
 
-        market_app_service.install_plugin_app(self.tenant, self.region, self.user, app_model_key, version, market_name,
-                                              install_from_cloud, self.tenant.tenant_id, self.region_name, is_deploy)
+        market_app_service.install_plugin_app(
+            self.tenant, self.region, self.user,
+            app_model_key, version, market_name,  # type: ignore[arg-type]
+            install_from_cloud, self.tenant.tenant_id, self.region_name, is_deploy)
         return Response(general_message(200, "success", "安装成功"), status=200)
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_model_key = request.GET.get("app_id", None)
         version = request.GET.get("app_version", None)
         install_from_cloud = request.GET.get("install_from_cloud", False)
         market_name = request.GET.get("market_name", None)
 
-        status = market_app_service.get_plugin_install_status(self.tenant, self.region, self.user, app_model_key, version,
-                                                              market_name, install_from_cloud)
+        status = market_app_service.get_plugin_install_status(
+            self.tenant, self.region, self.user,
+            app_model_key, version,  # type: ignore[arg-type]
+            market_name,  # type: ignore[arg-type]
+            install_from_cloud)
         return Response(general_message(200, "success", "查询成功", bean={"version": version, "status": status}), status=200)

--- a/console/views/center_pool/groupapp_backup.py
+++ b/console/views/center_pool/groupapp_backup.py
@@ -6,6 +6,9 @@ import json
 import logging
 import io
 import urllib
+from typing import Any
+
+from rest_framework.request import Request
 
 from django.http import StreamingHttpResponse
 from console.utils.cache_decorators import never_cache
@@ -28,7 +31,7 @@ logger = logging.getLogger('default')
 
 class GroupAppsBackupView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用备份
         ---
@@ -54,7 +57,8 @@ class GroupAppsBackupView(RegionTenantHeaderView):
               type: string
               paramType: form
         """
-        group_id = int(kwargs.get("group_id", None))
+        # NOTE: systemic int-as-str group_id; kwargs.get returns Any|None
+        group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
         if not group_id:
             return Response(general_message(400, "group id is null", "请选择需要备份的组"), status=400)
         note = request.data.get("note", None)
@@ -68,21 +72,23 @@ class GroupAppsBackupView(RegionTenantHeaderView):
         if not force:
             # state service can't backup while it is running
             code, running_state_services = groupapp_backup_service.check_backup_condition(
-                self.tenant, self.region_name, group_id)
+                self.tenant, self.region_name, group_id)  # type: ignore[arg-type]
             if running_state_services:
                 return Response(
                     general_message(
                         code=4121, msg="state service is running", msg_show="有状态组件未关闭", list=running_state_services),
                     status=412)
             # if service use custom service, can't backup
-            use_custom_svc = groupapp_backup_service.check_backup_app_used_custom_volume(group_id, self.tenant, self.region_name)
+            use_custom_svc = groupapp_backup_service.check_backup_app_used_custom_volume(
+                group_id, self.tenant, self.region_name)  # type: ignore[arg-type]
             if use_custom_svc:
                 logger.info("use custom volume: {}".format(use_custom_svc))
                 return Response(
                     general_message(code=4122, msg="use custom volume", msg_show="组件使用了自定义存储", list=use_custom_svc), status=412)
 
-        back_up_record = groupapp_backup_service.backup_group_apps(self.tenant, self.user, self.region_name, group_id, mode,
-                                                                   note, force)
+        back_up_record = groupapp_backup_service.backup_group_apps(
+            self.tenant, self.user, self.region_name, group_id, mode,  # type: ignore[arg-type]
+            note, force)
 
         bean = back_up_record.to_dict()
         result = general_message(200, "success", "操作成功，正在备份中", bean=bean)
@@ -92,7 +98,7 @@ class GroupAppsBackupView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         根据应用备份ID查询备份状态
         ---
@@ -114,7 +120,7 @@ class GroupAppsBackupView(RegionTenantHeaderView):
               paramType: query
         """
         try:
-            group_id = int(kwargs.get("group_id", None))
+            group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
             if not group_id:
                 return Response(general_message(400, "group id is null", "请选择需要备份的组"), status=400)
             backup_id = request.GET.get("backup_id", None)
@@ -124,18 +130,19 @@ class GroupAppsBackupView(RegionTenantHeaderView):
                 self.tenant, self.response_region, backup_id)
             if code != 200:
                 return Response(general_message(code, "get backup status error", msg), status=code)
-            bean = backup_record.to_dict()
+            # NOTE: get_groupapp_backup_status_by_backup_id may return None record; backlog
+            bean = backup_record.to_dict()  # type: ignore[union-attr]
             bean.pop("backup_server_info")
 
             result = general_message(200, "success", "查询成功", bean=bean)
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         根据应用备份ID删除备份
         """
@@ -148,8 +155,8 @@ class GroupAppsBackupView(RegionTenantHeaderView):
         if code != 200:
             return Response(general_message(code, "get backup status error", msg), status=code)
         old_information = json.dumps({
-            "备份类型": "本地备份" if backup_record.mode == "full-offline" else "云端备份",
-            "备份说明": backup_record.note
+            "备份类型": "本地备份" if backup_record.mode == "full-offline" else "云端备份",  # type: ignore[union-attr]
+            "备份说明": backup_record.note  # type: ignore[union-attr]
         },
             ensure_ascii=False)
         groupapp_backup_service.delete_group_backup_by_backup_id(self.tenant, self.response_region, backup_id)
@@ -161,7 +168,7 @@ class GroupAppsBackupView(RegionTenantHeaderView):
 
 class GroupAppsBackupStatusView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         一个组的备份状态查询
         ---
@@ -178,11 +185,11 @@ class GroupAppsBackupStatusView(RegionTenantHeaderView):
               paramType: path
         """
         try:
-            group_id = int(kwargs.get("group_id", None))
+            group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
             if not group_id:
                 return Response(general_message(400, "group id is null", "请选择需要备份的组"), status=400)
             code, msg, backup_records = groupapp_backup_service.get_group_backup_status_by_group_id(
-                self.tenant, self.response_region, group_id)
+                self.tenant, self.response_region, group_id)  # type: ignore[arg-type]
             if code == 404:
                 return Response(general_message(200, "success", "查询成功"), status=200)
             if code != 200:
@@ -198,13 +205,13 @@ class GroupAppsBackupStatusView(RegionTenantHeaderView):
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class TeamGroupAppsBackupView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询备份信息
         ---
@@ -239,7 +246,8 @@ class TeamGroupAppsBackupView(RegionTenantHeaderView):
         backups = groupapp_backup_service.get_group_back_up_info(self.tenant, self.region_name, group_id)
         paginator = JuncheePaginator(backups, int(page_size))
         backup_records = paginator.page(int(page))
-        obj_storage = EnterpriseConfigService(self.user.enterprise_id, self.user.user_id).get_cloud_obj_storage_info()
+        obj_storage = EnterpriseConfigService(
+            self.user.enterprise_id, self.user.user_id).get_cloud_obj_storage_info()  # type: ignore[arg-type]
         bean = {"is_configed": obj_storage is not None}
         result = general_message(
             200, "success", "查询成功", bean=bean, list=[backup.to_dict() for backup in backup_records], total=paginator.count)
@@ -248,7 +256,7 @@ class TeamGroupAppsBackupView(RegionTenantHeaderView):
 
 class AllTeamGroupAppsBackupView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询当前团队 数据中心下所有备份信息
         ---
@@ -290,13 +298,13 @@ class AllTeamGroupAppsBackupView(RegionTenantHeaderView):
             result = general_message(200, "success", "查询成功", list=backup_list, total=paginator.count)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class GroupAppsBackupExportView(AlowAnyApiView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         """
         一个组的备份导出
         ---
@@ -319,7 +327,7 @@ class GroupAppsBackupExportView(AlowAnyApiView):
 
         """
         try:
-            group_id = int(kwargs.get("group_id", None))
+            group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
             if not group_id:
                 return Response(general_message(400, "group id is null", "请选择需要导出备份的组"), status=400)
             team_name = kwargs.get("tenantName", None)
@@ -328,7 +336,7 @@ class GroupAppsBackupExportView(AlowAnyApiView):
             team = team_services.get_tenant_by_tenant_name(team_name)
             if not team:
                 return Response(general_message(404, "team not found", "团队{0}不存在".format(team_name)), status=404)
-            group = group_repo.get_group_by_id(group_id)
+            group = group_repo.get_group_by_id(group_id)  # type: ignore[arg-type]
             if not group:
                 return Response(general_message(404, "group not found", "组{0}不存在".format(group_id)), status=404)
             backup_id = request.GET.get("backup_id", None)
@@ -347,19 +355,21 @@ class GroupAppsBackupExportView(AlowAnyApiView):
 
             app = operation_log_service.process_app_name(group.group_name, group.region_name, team.tenant_name, group.app_id)
             comment = "导出了应用{}的备份".format(app)
-            operation_log_service.create_log("", OperationType.APPLICATION_MANAGE, comment, team.enterprise_id,
-                                             team.tenant_name, group.app_id)
+            operation_log_service.create_log(
+                "", OperationType.APPLICATION_MANAGE, comment,
+                team.enterprise_id,  # type: ignore[arg-type]
+                team.tenant_name, group.app_id)
 
             return res
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=result["code"])
 
 
 class GroupAppsBackupImportView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         导入备份
         ---
@@ -376,7 +386,7 @@ class GroupAppsBackupImportView(RegionTenantHeaderView):
               paramType: form
         """
         try:
-            group_id = int(kwargs.get("group_id", None))
+            group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
             if not group_id:
                 return Response(general_message(400, "group id is null", "请选择需要导出备份的组"), status=400)
             if not request.FILES or not request.FILES.get('file'):
@@ -384,13 +394,14 @@ class GroupAppsBackupImportView(RegionTenantHeaderView):
             upload_file = request.FILES.get('file')
             if upload_file.size > StorageUnit.ONE_MB * 2:
                 return Response(general_message(400, "file is too large", "文件大小不能超过2M"), status=400)
-            code, msg, record = groupapp_backup_service.import_group_backup(self.tenant, self.response_region, group_id,
-                                                                            upload_file)
+            code, msg, record = groupapp_backup_service.import_group_backup(
+                self.tenant, self.response_region, group_id,  # type: ignore[arg-type]
+                upload_file)
             if code != 200:
                 return Response(general_message(code, "backup import failed", msg), status=code)
             result = general_message(200, "success", "导入成功", bean=record.to_dict())
             operation_log_service.create_app_log(self, "导入了应用{app}的备份")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])

--- a/console/views/center_pool/groupapp_copy.py
+++ b/console/views/center_pool/groupapp_copy.py
@@ -3,6 +3,9 @@
   Created on 18/5/23.
 """
 import logging
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.exception.main import ServiceHandleException
 from console.services.groupcopy_service import groupapp_copy_service
@@ -18,13 +21,13 @@ logger = logging.getLogger('default')
 
 class GroupAppsCopyView(ApplicationView):
     @never_cache
-    def get(self, request, tenantName, group_id, **kwargs):
+    def get(self, request: Request, tenantName: str, group_id: str, **kwargs: Any) -> Response:
         group_services = groupapp_copy_service.get_group_services_with_build_source(self.tenant, self.region_name, group_id)
         result = general_message(200, "success", "获取成功", list=group_services)
         return Response(result, status=200)
 
     @never_cache
-    def post(self, request, tenantName, group_id, *args, **kwargs):
+    def post(self, request: Request, tenantName: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         应用复制
         ---
@@ -65,9 +68,11 @@ class GroupAppsCopyView(ApplicationView):
             status = 200
             comment = groupapp_copy_service.generate_comment(self.app, self.region_name, self.tenant_name, tar_group,
                                                              tar_region_name, tar_team_name, services)
-            operation_log_service.create_log(self.user, OperationType.APPLICATION_MANAGE, comment,
-                                             self.user.enterprise_id,
-                                             self.tenant_name, self.app.app_id)
+            operation_log_service.create_log(
+                self.user, OperationType.APPLICATION_MANAGE, comment,
+                self.user.enterprise_id,  # type: ignore[arg-type] # NOTE: enterprise_id is str|None
+                self.tenant_name,
+                self.app.app_id)
         except HttpClient.CallApiError as e:
             logger.exception(e)
             if e.status == 403:

--- a/console/views/center_pool/groupapp_migration.py
+++ b/console/views/center_pool/groupapp_migration.py
@@ -3,7 +3,7 @@
   Created on 18/5/23.
 """
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from rest_framework.request import Request
 

--- a/console/views/center_pool/groupapp_migration.py
+++ b/console/views/center_pool/groupapp_migration.py
@@ -3,6 +3,9 @@
   Created on 18/5/23.
 """
 import logging
+from typing import Any, Optional
+
+from rest_framework.request import Request
 
 from console.repositories.group import group_repo
 from console.repositories.migration_repo import migrate_repo
@@ -23,7 +26,7 @@ logger = logging.getLogger('default')
 
 class GroupAppsMigrateView(ApplicationView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用迁移
         ---
@@ -71,15 +74,20 @@ class GroupAppsMigrateView(ApplicationView):
         migrate_team = team_services.get_tenant_by_tenant_name(team)
         if not migrate_team:
             return Response(general_message(404, "team is not found", "需要迁移的团队{0}不存在".format(team)), status=404)
-        regions = region_services.get_team_usable_regions(migrate_team.tenant_name, self.tenant.enterprise_id)
+        regions = region_services.get_team_usable_regions(
+            migrate_team.tenant_name, self.tenant.enterprise_id)  # type: ignore[arg-type]
         if not regions:
             return Response(general_message(412, "region is not usable", "团队未开通任何集群"), status=412)
         if migrate_region not in [r.region_name for r in regions]:
             msg_cn = "无法迁移至集群{0},请确保该集群可用且团队{1}已开通该集群权限".format(migrate_region, migrate_team.tenant_name)
             return Response(general_message(412, "region is not usable", msg_cn), status=412)
 
-        migrate_record = migrate_service.start_migrate(self.user, self.tenant, self.region_name, migrate_team, migrate_region,
-                                                       backup_id, migrate_type, event_id, restore_id)
+        migrate_record = migrate_service.start_migrate(
+            self.user, self.tenant, self.region_name, migrate_team, migrate_region,
+            backup_id,  # type: ignore[arg-type]
+            migrate_type,
+            event_id,  # type: ignore[arg-type]
+            restore_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "操作成功，开始迁移应用", bean=migrate_record.to_dict())
         comment = "迁移应用{app}到团队".format(
             app=operation_log_service.process_app_name(self.app.app_name, self.region_name, self.tenant_name,
@@ -90,7 +98,7 @@ class GroupAppsMigrateView(ApplicationView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询迁移状态
         ---
@@ -126,7 +134,7 @@ class GroupAppsMigrateView(ApplicationView):
 
 class GroupAppsView(RegionTenantHeaderView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用数据删除
         ---
@@ -149,7 +157,7 @@ class GroupAppsView(RegionTenantHeaderView):
 
         """
         try:
-            group_id = int(kwargs.get("group_id", None))
+            group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
             if not group_id:
                 return Response(general_message(400, "group id is null", "请确认需要删除的组"), status=400)
             new_group_id = request.data.get("new_group_id", None)
@@ -157,14 +165,15 @@ class GroupAppsView(RegionTenantHeaderView):
                 return Response(general_message(400, "new group id is null", "请确认新恢复的组"), status=400)
             if group_id == new_group_id:
                 return Response(general_message(200, "success", "恢复到当前组无需删除"), status=200)
-            group = group_repo.get_group_by_id(group_id)
+            # NOTE: systemic int-as-str group_id arg
+            group = group_repo.get_group_by_id(group_id)  # type: ignore[arg-type]
             if not group:
                 return Response(general_message(400, "group is delete", "该备份组已删除"), status=400)
 
             new_group = group_repo.get_group_by_id(new_group_id)
             if not new_group:
                 return Response(general_message(400, "new group not exist", "组ID {0} 不存在".format(new_group_id)), status=400)
-            services = group_service.get_group_services(group_id)
+            services = group_service.get_group_services(group_id)  # type: ignore[arg-type]
             for service in services:
                 try:
                     app_manage_service.truncate_service(self.tenant, service)
@@ -176,13 +185,13 @@ class GroupAppsView(RegionTenantHeaderView):
             result = general_message(200, "success", "操作成功")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined] # NOTE: py2 Exception.message
         return Response(result, status=result["code"])
 
 
 class MigrateRecordView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, group_id, *args, **kwargs):
+    def get(self, request: Request, group_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询当前用户是否有未完成的恢复和迁移
         ---

--- a/console/views/code_repo.py
+++ b/console/views/code_repo.py
@@ -3,8 +3,10 @@
   Created on 18/1/9.
 """
 import logging
+from typing import Any
 
 from django.shortcuts import redirect
+from rest_framework.request import Request
 from console.utils.cache_decorators import never_cache
 from rest_framework.response import Response
 
@@ -19,7 +21,7 @@ logger = logging.getLogger("default")
 git_service = GitCodeService()
 
 class ServiceCodeBranch(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件代码仓库分支
         ---
@@ -40,7 +42,7 @@ class ServiceCodeBranch(AppBaseView):
         result = general_message(200, "success", "查询成功", bean=bean, list=branches)
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改组件代码仓库分支
         ---

--- a/console/views/custom_configs.py
+++ b/console/views/custom_configs.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+from typing import Any
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
@@ -8,12 +10,12 @@ from console.services.custom_configs import custom_configs_service
 
 
 class CustomConfigsCLView(BaseApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         configs = custom_configs_service.list()
         result = general_message(200, "success", msg_show="操作成功", list=configs)
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = request.data
         if type(data) != list:
             raise AbortRequest(msg="The request parameter must be a list", msg_show="请求参数必须为列表")
@@ -23,12 +25,13 @@ class CustomConfigsCLView(BaseApiView):
 
 
 class CustomConfigsUserCLView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
-        configs = custom_configs_service.list(self.user.nick_name)
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: Users.nick_name is nullable but service expects str (systemic mismatch; backlog).
+        configs = custom_configs_service.list(self.user.nick_name)  # type: ignore[arg-type]
         result = general_message(200, "success", msg_show="操作成功", list=configs)
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = request.data
         if type(data) != list:
             raise AbortRequest(msg="The request parameter must be a list", msg_show="请求参数必须为列表")

--- a/console/views/enterprise.py
+++ b/console/views/enterprise.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import time
+from typing import Any
 
 import requests
 from django.http import StreamingHttpResponse, FileResponse
@@ -28,6 +29,7 @@ from console.services.region_services import region_services
 from console.services.team_services import team_services
 from console.views.base import EnterpriseAdminView, JWTAuthApiView, EnterpriseHeaderView, AlowAnyApiView
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.services.app_actions import event_service
 from console.services.group_service import group_service
@@ -50,7 +52,7 @@ EVENT_ID = "event_id"
 FILE_NAME = "file_name"
 
 
-def _websocket_url_to_http_base(wsurl):
+def _websocket_url_to_http_base(wsurl: str) -> str:
     if not wsurl:
         return ""
     if "://" in wsurl:
@@ -65,7 +67,7 @@ def _websocket_url_to_http_base(wsurl):
 
 
 class UploadLongVersion(AlowAnyApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             enterprise_id = request.data.get("enterprise_id")
             region_id = request.data.get("region_id")
@@ -73,7 +75,9 @@ class UploadLongVersion(AlowAnyApiView):
             if not upload_file:
                 return Response(general_message(400, "get file failure.", "获取文件失败"), status=400)
 
-            region = region_repo.get_region_by_id(enterprise_id, region_id)
+            # NOTE: request body values typed Any|None; repo/service signatures expect str —
+            # systemic int-as-str / nullable mismatch suppressed throughout this file (backlog).
+            region = region_repo.get_region_by_id(enterprise_id, region_id)  # type: ignore[arg-type]
             if not region or not region.wsurl:
                 return Response(general_message(404, "region not found", "数据中心不存在"), status=404)
 
@@ -97,10 +101,12 @@ class UploadLongVersion(AlowAnyApiView):
             return Response(general_message(500, "Proxy error: {0}".format(str(e)), "文件处理异常"), status=500)
 
 class Enterprises(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         enterprises_list = []
         try:
-            enterprises = enterprise_repo.get_enterprises_by_user_id(request.user.user_id)
+            # NOTE: request.user typed User|AnonymousUser; .user_id/.enterprise_id only on the
+            # authed user — recurring union-attr suppressed throughout this file (backlog).
+            enterprises = enterprise_repo.get_enterprises_by_user_id(request.user.user_id)  # type: ignore[union-attr]
         except ExterpriseNotExistError as e:
             logger.debug(e)
             data = general_message(404, "success", "该用户未加入任何团队")
@@ -125,26 +131,28 @@ class Enterprises(JWTAuthApiView):
 
 
 class EnterpriseRUDView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         enter = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id=enterprise_id)
-        ent = enter.to_dict()
+        ent = enter.to_dict()  # type: ignore[union-attr]
         if ent:
-            regions = region_repo.get_regions_by_enterprise_id(self.enterprise.enterprise_id, 1)
+            regions = region_repo.get_regions_by_enterprise_id(self.enterprise.enterprise_id, 1)  # type: ignore[arg-type]
             default_region = {}
             if os.getenv("ENABLE_CLUSTER") == "true" and not regions:
-                region = region_services.create_default_region(self.enterprise.enterprise_id, request.user)
+                region = region_services.create_default_region(
+                    self.enterprise.enterprise_id, request.user)  # type: ignore[arg-type]
                 if region:
                     ent["disable_install_cluster_log"] = True
                     _, total = team_services.get_enterprise_teams(self.enterprise.enterprise_id)
                     if total == 0:
-                        region_services.create_sample_application(enter, region, request.user)
-                default_region = region.to_dict()
+                        region_services.create_sample_application(enter, region, request.user)  # type: ignore[arg-type]
+                default_region = region.to_dict()  # type: ignore[union-attr]
             ent["default_region"] = default_region
-            ent.update(EnterpriseConfigService(enterprise_id, self.user.user_id).initialization_or_get_config)
+            ent.update(EnterpriseConfigService(
+                enterprise_id, self.user.user_id).initialization_or_get_config)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean=ent)
         return Response(result, status=result["code"])
 
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         key = request.GET.get("key")
         if not key:
             result = general_message(404, "no found config key {0}".format(key), "更新失败")
@@ -153,7 +161,7 @@ class EnterpriseRUDView(JWTAuthApiView):
         if not value:
             result = general_message(404, "no found config value", "更新失败")
             return Response(result, status=result.get("code", 200))
-        ent_config_servier = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        ent_config_servier = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         key = key.upper()
         if key in ent_config_servier.base_cfg_keys + ent_config_servier.cfg_keys:
             try:
@@ -162,7 +170,7 @@ class EnterpriseRUDView(JWTAuthApiView):
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.CHANGE, module=OperationModule.CERTSIGN, module_name="的配置")
                 operation_log_service.create_enterprise_log(
-                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
             except Exception as e:
                 logger.debug(e)
                 raise ServiceHandleException(msg="update enterprise config failed", msg_show="更新失败")
@@ -170,7 +178,7 @@ class EnterpriseRUDView(JWTAuthApiView):
             result = general_message(404, "no found config key", "更新失败")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         key = request.GET.get("key")
         if not key:
             result = general_message(404, "no found config key", "重置失败")
@@ -179,7 +187,7 @@ class EnterpriseRUDView(JWTAuthApiView):
         if not value:
             result = general_message(404, "no found config value", "重置失败")
             return Response(result, status=result.get("code", 200))
-        ent_config_servier = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        ent_config_servier = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         key = key.upper()
         if key in ent_config_servier.cfg_keys:
             data = ent_config_servier.delete_config(key)
@@ -194,7 +202,7 @@ class EnterpriseRUDView(JWTAuthApiView):
 
 
 class EnterpriseAppOverView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         regions = region_repo.get_usable_regions(enterprise_id)
         if not regions:
             result = general_message(404, "no found regions", "查询成功")
@@ -206,7 +214,7 @@ class EnterpriseAppOverView(JWTAuthApiView):
 
 # 等待优化
 class EnterpriseOverview(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         users = enterprise_repo.get_enterprise_users(enterprise_id)
         user_nums = len(users)
         team = enterprise_repo.get_enterprise_teams(enterprise_id)
@@ -218,7 +226,7 @@ class EnterpriseOverview(JWTAuthApiView):
 
 
 class EnterpriseTeamNames(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         tenants = Tenants.objects.filter()
         tenant_namespaces = [tenant.namespace for tenant in tenants]
         data = {"tenant_names": tenant_namespaces}
@@ -227,7 +235,7 @@ class EnterpriseTeamNames(JWTAuthApiView):
 
 
 class EnterpriseTeams(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         name = request.GET.get("name", None)
@@ -240,7 +248,7 @@ class EnterpriseTeams(JWTAuthApiView):
 
 
 class EnterpriseUserTeams(EnterpriseAdminView):
-    def get(self, request, enterprise_id, user_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.GET.get("name", None)
         user = user_repo.get_user_by_user_id(user_id)
         teams = team_services.list_user_teams(enterprise_id, user, name)
@@ -249,24 +257,28 @@ class EnterpriseUserTeams(EnterpriseAdminView):
 
 
 class EnterpriseMyTeams(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.GET.get("name", None)
         use_region = request.GET.get("use_region", False)
-        tenants = team_services.get_teams_region_by_user_id(enterprise_id, self.user, name, use_region=use_region)
+        tenants = team_services.get_teams_region_by_user_id(
+            enterprise_id, self.user, name, use_region=use_region)  # type: ignore[arg-type]
         result = general_message(200, "team query success", "查询成功", list=tenants)
         return Response(result, status=200)
 
 
 class EnterpriseTeamOverView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         code = 200
         new_join_team = []
         request_join_team = []
         try:
-            tenants = enterprise_repo.get_enterprise_user_teams(enterprise_id, request.user.user_id)
-            join_tenants = enterprise_repo.get_enterprise_user_join_teams(enterprise_id, request.user.user_id)
-            active_tenants = enterprise_repo.get_enterprise_user_active_teams(enterprise_id, request.user.user_id)
-            request_tenants = enterprise_repo.get_enterprise_user_request_join(enterprise_id, request.user.user_id)
+            tenants = enterprise_repo.get_enterprise_user_teams(enterprise_id, request.user.user_id)  # type: ignore[union-attr]
+            join_tenants = enterprise_repo.get_enterprise_user_join_teams(
+                enterprise_id, request.user.user_id)  # type: ignore[union-attr]
+            active_tenants = enterprise_repo.get_enterprise_user_active_teams(
+                enterprise_id, request.user.user_id)  # type: ignore[union-attr]
+            request_tenants = enterprise_repo.get_enterprise_user_request_join(
+                enterprise_id, request.user.user_id)  # type: ignore[union-attr]
             if tenants:
                 for tenant in tenants[:3]:
                     region_name_list = []
@@ -274,7 +286,7 @@ class EnterpriseTeamOverView(JWTAuthApiView):
                     user_role_list = user_kind_role_service.get_user_roles(
                         kind="team", kind_id=tenant.tenant_id, user=request.user)
                     roles = [x["role_name"] for x in user_role_list["roles"]]
-                    if tenant.creater == request.user.user_id:
+                    if tenant.creater == request.user.user_id:  # type: ignore[union-attr]
                         roles.append("owner")
                     owner = user_repo.get_by_user_id(tenant.creater)
                     if len(region_name_list) > 0:
@@ -297,7 +309,7 @@ class EnterpriseTeamOverView(JWTAuthApiView):
                     region_name_list = team_repo.get_team_region_names(tenant.team_id)
                     tenant_info = team_repo.get_team_by_team_id(tenant.team_id)
                     try:
-                        user = user_repo.get_user_by_user_id(tenant_info.creater)
+                        user = user_repo.get_user_by_user_id(tenant_info.creater)  # type: ignore[arg-type]
                         nick_name = user.nick_name
                     except UserNotExistError:
                         nick_name = None
@@ -321,7 +333,7 @@ class EnterpriseTeamOverView(JWTAuthApiView):
                     region_name_list = team_repo.get_team_region_names(request_tenant.team_id)
                     tenant_info = team_repo.get_team_by_team_id(request_tenant.team_id)
                     try:
-                        user = user_repo.get_user_by_user_id(tenant_info.creater)
+                        user = user_repo.get_user_by_user_id(tenant_info.creater)  # type: ignore[arg-type]
                         nick_name = user.nick_name
                     except UserNotExistError:
                         nick_name = None
@@ -356,7 +368,7 @@ class EnterpriseTeamOverView(JWTAuthApiView):
 
 
 class EnterpriseMonitor(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         regions = region_repo.get_usable_regions(enterprise_id)
         region_memory_total = 0
         region_memory_used = 0
@@ -370,10 +382,12 @@ class EnterpriseMonitor(JWTAuthApiView):
             try:
                 res, body = region_api.get_region_resources(enterprise_id, region=region.region_name)
                 if res.get("status") == 200:
-                    region_memory_total += body["bean"]["cap_mem"]
-                    region_memory_used += body["bean"]["req_mem"]
-                    region_cpu_total += body["bean"]["cap_cpu"]
-                    region_cpu_used += body["bean"]["req_cpu"]
+                    # NOTE: regionapi body typed Optional; legacy code assumes dict —
+                    # recurring index suppressed throughout this file (backlog).
+                    region_memory_total += body["bean"]["cap_mem"]  # type: ignore[index]
+                    region_memory_used += body["bean"]["req_mem"]  # type: ignore[index]
+                    region_cpu_total += body["bean"]["cap_cpu"]  # type: ignore[index]
+                    region_cpu_used += body["bean"]["req_cpu"]  # type: ignore[index]
             except Exception as e:
                 logger.debug(e)
                 continue
@@ -393,7 +407,7 @@ class EnterpriseMonitor(JWTAuthApiView):
 
 
 class EnterpriseAppsLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         data = []
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
@@ -403,7 +417,8 @@ class EnterpriseAppsLView(JWTAuthApiView):
                 try:
                     tenant = team_services.get_team_by_team_id(app.tenant_id)
                     tenant_name = tenant.tenant_name
-                except TenantNotExistError:
+                # NOTE: mypy can't confirm TenantNotExistError derives from BaseException (backlog).
+                except TenantNotExistError:  # type: ignore[misc]
                     tenant_name = None
                 data.append({
                     "ID": app.ID,
@@ -417,7 +432,7 @@ class EnterpriseAppsLView(JWTAuthApiView):
 
 
 class EnterpriseRegionsLCView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         region_status = request.GET.get("status", "")
         check_status = request.GET.get("check_status", "")
         data = region_services.get_enterprise_regions(
@@ -425,19 +440,19 @@ class EnterpriseRegionsLCView(JWTAuthApiView):
         result = general_message(200, "success", "获取成功", list=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         token = request.data.get("token")
         region_name = request.data.get("region_name")
         region_alias = request.data.get("region_alias")
         desc = request.data.get("desc")
         region_type = json.dumps(request.data.get("region_type", []))
-        region_data = region_services.parse_token(token, region_name, region_alias, region_type)
+        region_data = region_services.parse_token(token, region_name, region_alias, region_type)  # type: ignore[arg-type]
         region_data["enterprise_id"] = enterprise_id
         region_data["desc"] = desc
         region_data["provider"] = request.data.get("provider", "")
         region_data["provider_cluster_id"] = request.data.get("provider_cluster_id", "")
         region_data["status"] = "1"
-        region = region_services.add_region(region_data, request.user)
+        region = region_services.add_region(region_data, request.user)  # type: ignore[arg-type]
         new_information = json.dumps({"集群ID": region_name, "集群名称": region_alias, "备注": desc, "配置文件": token}, ensure_ascii=False)
         if region:
             data = region_services.get_enterprise_region(enterprise_id, region.region_id, check_status=False)
@@ -445,7 +460,8 @@ class EnterpriseRegionsLCView(JWTAuthApiView):
             comment = operation_log_service.generate_generic_comment(
                 operation=Operation.CREATE, module=OperationModule.CLUSTER, module_name="{}".format(region_alias))
             operation_log_service.create_cluster_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, new_information=new_information)
+                user=self.user, comment=comment, new_information=new_information,
+                enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
             return Response(result, status=status.HTTP_200_OK)
         else:
             result = general_message(500, "failed", "创建失败")
@@ -453,14 +469,14 @@ class EnterpriseRegionsLCView(JWTAuthApiView):
 
 
 class EnterpriseRegionGatewayBatch(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         data = gateway_api.list_gateways(enterprise_id, region_name)
-        result = general_message(200, "success", "获取成功", list=data["list"])
+        result = general_message(200, "success", "获取成功", list=data["list"])  # type: ignore[index]
         return Response(result, status=status.HTTP_200_OK)
 
 
 class EnterpriseRegionNamespace(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         content = request.GET.get("content", "all")
         data = region_resource.get_namespaces(enterprise_id, region_id, content)
         result = general_message(200, "success", "获取成功", bean=data["list"])
@@ -468,13 +484,13 @@ class EnterpriseRegionNamespace(JWTAuthApiView):
 
 
 class EnterpriseRegionLangVersion(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.GET.get("language", "")
         data = region_lang_version.show_long_version(enterprise_id, region_id, language)
         result = general_message(200, "success", "获取成功", list=data["list"])
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, region_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get("language", "")
         version = request.data.get("version", "")
         event_id = request.data.get("event_id", "")
@@ -495,14 +511,16 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
             data = {"code": 400, "msg": "package format mistake", "msg_show": "文件上传格式不正确，支持zip, war, jar, tar, tar.gz, rar"}
             return Response(data, status=400)
 
-    def put(self, request, enterprise_id, region_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get("language", "")
         version = request.data.get("version", "")
-        region_lang_version.update_long_version(enterprise_id, region_id, language, version)
+        # NOTE: latent bug — update_long_version requires show and first_choice which are
+        # not passed (TypeError if reached); behavior preserved (backlog).
+        region_lang_version.update_long_version(enterprise_id, region_id, language, version)  # type: ignore[call-arg]
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, region_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get("language", "")
         version = request.data.get("version", "")
         use_components = region_lang_version.delete_long_version(enterprise_id, region_id, language, version)
@@ -514,7 +532,7 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
 
 
 class EnterpriseNamespaceResource(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         content = request.GET.get("content", "all")
         namespace = request.GET.get("namespace", "")
         data = region_resource.get_namespaces_resource(enterprise_id, region_id, content, namespace)
@@ -525,7 +543,7 @@ class EnterpriseNamespaceResource(JWTAuthApiView):
 
 
 class EnterpriseConvertResource(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         content = request.GET.get("content", "all")
         namespace = request.GET.get("namespace", "")
         data = region_resource.convert_resource(enterprise_id, region_id, namespace, content)
@@ -534,7 +552,7 @@ class EnterpriseConvertResource(JWTAuthApiView):
         result = general_message(200, "success", "获取成功", bean=data["bean"])
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, region_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         content = request.data.get("content", "all")
         namespace = request.data.get("namespace", "")
         data = region_resource.resource_import(enterprise_id, region_id, namespace, content)
@@ -553,16 +571,16 @@ class EnterpriseConvertResource(JWTAuthApiView):
 
 
 class EnterpriseRegionsRUDView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         data = region_services.get_enterprise_region(enterprise_id, region_id, check_status=False)
         result = general_message(200, "success", "获取成功", bean=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def put(self, request, enterprise_id, region_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         old_region = region_services.get_enterprise_region(enterprise_id, region_id)
         region = region_services.update_enterprise_region(enterprise_id, region_id, request.data)
         result = general_message(200, "success", "更新成功", bean=region)
-        old_information = region_services.json_region(old_region)
+        old_information = region_services.json_region(old_region)  # type: ignore[arg-type]
         new_information = region_services.json_region(region)
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.UPDATE, module=OperationModule.CLUSTER,
@@ -570,12 +588,12 @@ class EnterpriseRegionsRUDView(JWTAuthApiView):
         operation_log_service.create_cluster_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             old_information=old_information,
             new_information=new_information)
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, region_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         # Get region information before deletion for logging
         region = region_services.get_enterprise_region(enterprise_id, region_id, check_status=False)
         if not region:
@@ -590,15 +608,17 @@ class EnterpriseRegionsRUDView(JWTAuthApiView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.CLUSTER, module_name="{}".format(region.get("region_alias", "")))
         operation_log_service.create_cluster_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, old_information=old_information)
+            user=self.user, comment=comment, old_information=old_information,
+            enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=result.get("code", 200))
 
 
 class EnterpriseRegionTenantRUDView(EnterpriseAdminView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         page = request.GET.get("page", 1)
         page_size = request.GET.get("pageSize", 10)
-        tenants, total = team_services.get_tenant_list_by_region(enterprise_id, region_id, page, page_size)
+        tenants, total = team_services.get_tenant_list_by_region(
+            enterprise_id, region_id, page, page_size)  # type: ignore[arg-type]
         result = general_message(
             200, "success", "获取成功", bean={
                 "tenants": tenants,
@@ -608,21 +628,24 @@ class EnterpriseRegionTenantRUDView(EnterpriseAdminView):
 
 
 class EnterpriseRegionTenantLimitView(EnterpriseAdminView):
-    def post(self, request, enterprise_id, region_id, tenant_name, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_id: str, tenant_name: str,
+             *args: Any, **kwargs: Any) -> Response:
         team_services.set_tenant_resource_limit(enterprise_id, region_id, tenant_name, request.data)
         team = team_services.get_tenant_by_tenant_name(tenant_name)
         limit = request.data.get("limit_memory", 0)
-        team_alias = operation_log_service.process_team_name(team.tenant_alias, region_id, tenant_name)
+        team_alias = operation_log_service.process_team_name(
+            team.tenant_alias, region_id, tenant_name)  # type: ignore[union-attr]
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.LIMIT, module=OperationModule.TEAM,
             module_name="{} 的内存使用量为 {} MB".format(team_alias, limit))
-        operation_log_service.create_cluster_log(user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+        operation_log_service.create_cluster_log(
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response({}, status=status.HTTP_200_OK)
 
 
 
 class EnterpriseAppComponentsLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, app_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         data = []
@@ -651,7 +674,9 @@ class EnterpriseAppComponentsLView(JWTAuthApiView):
 
 
 class EnterpriseRegionDashboard(EnterpriseAdminView):
-    def dispatch(self, request, enterprise_id, region_id, *args, **kwargs):
+    # NOTE: dispatch overrides with extra path params; signature differs from base (pre-existing).
+    def dispatch(  # type: ignore[override]
+            self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Any:
         self.args = args
         self.kwargs = kwargs
         request = self.initialize_request(request, *args, **kwargs)
@@ -661,7 +686,9 @@ class EnterpriseRegionDashboard(EnterpriseAdminView):
             self.initial(request, *args, **kwargs)
             region = region_services.get_enterprise_region(enterprise_id, region_id, check_status=False)
             if not region:
-                return Response({}, status=status.HTTP_404_NOTFOUND)
+                # NOTE: latent bug — status.HTTP_404_NOTFOUND is a typo for HTTP_404_NOT_FOUND
+                # (AttributeError if reached); behavior preserved (backlog).
+                return Response({}, status=status.HTTP_404_NOTFOUND)  # type: ignore[attr-defined]
             full_path = request.get_full_path()
             path = full_path[full_path.index("/dashboard/") + 11:len(full_path)]
             response = region_api.proxy(request, '/kubernetes/dashboard/' + path, region['region_name'])
@@ -672,7 +699,7 @@ class EnterpriseRegionDashboard(EnterpriseAdminView):
 
 
 class EnterpriseUserTeamRoleView(EnterpriseHeaderView):
-    def post(self, request, eid, user_id, tenant_name, *args, **kwargs):
+    def post(self, request: Request, eid: str, user_id: str, tenant_name: str, *args: Any, **kwargs: Any) -> Response:
         role_ids = request.data.get('role_ids', [])
         res = enterprise_services.create_user_roles(eid, user_id, tenant_name, role_ids)
         result = general_message(200, "ok", "设置成功", bean=res)
@@ -680,17 +707,17 @@ class EnterpriseUserTeamRoleView(EnterpriseHeaderView):
 
 
 class HelmTokenView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         eid = request.GET.get("eid")
         timestamp = str(int(time.time()))
         token = make_uuid()
-        cfg_repo.create_token_record("token-" + timestamp, token, eid)
+        cfg_repo.create_token_record("token-" + timestamp, token, eid)  # type: ignore[arg-type]
         result = general_message(200, "ok", "获取token成功", bean=token)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class HelmAddReginInfo(AlowAnyApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         token = request.data.get("token")
         enterprise_id = request.data.get("enterpriseId", "")
         try:
@@ -730,7 +757,7 @@ class HelmAddReginInfo(AlowAnyApiView):
 
 
 class HelmInstallStatus(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         apiHost = request.GET.get("api_host")
         token = request.GET.get("token")
         try:
@@ -771,7 +798,7 @@ class HelmInstallStatus(JWTAuthApiView):
 
 
 class Goodrainlog(EnterpriseAdminView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         filepath = LOG_PATH + '/goodrain.log'
         res = list()
         with open(filepath, 'r', errors='ignore') as f:
@@ -783,8 +810,8 @@ class Goodrainlog(EnterpriseAdminView):
 
 
 class Downlodlog(EnterpriseAdminView):
-    def get(self, request):
-        def file_iterator(fn, chunk_size=512):
+    def get(self, request: Request) -> Any:
+        def file_iterator(fn: Any, chunk_size: int = 512) -> Any:
             while True:
                 c = fn.read(chunk_size)
                 if c:
@@ -801,14 +828,14 @@ class Downlodlog(EnterpriseAdminView):
 
 
 class RbdPods(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         pods_info = region_api.get_rbd_pods(region_name)
         result = general_message(200, "success", "获取成功", bean=pods_info)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class RbdPodLog(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Any:
         pod_name = request.GET.get("pod_name", "")
         if not pod_name:
             raise AbortRequest("the field 'pod_name' is required")
@@ -821,20 +848,20 @@ class RbdPodLog(EnterpriseAdminView):
 
 
 class RbdComponentLogs(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         lines = request.GET.get("lines", 100)
         rbd_name = request.GET.get("rbd_name", "")
-        body = region_api.get_rbd_component_logs(region_name, rbd_name, lines)
-        log_list = body["list"]
+        body = region_api.get_rbd_component_logs(region_name, rbd_name, lines)  # type: ignore[arg-type]
+        log_list = body["list"]  # type: ignore[index]
         result = general_message(200, "success", "获取成功", bean=log_list)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class RbdLogFiles(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         rbd_name = request.GET.get("rbd_name", "")
         body = region_api.get_rbd_log_files(region_name, rbd_name)
-        file_list = body["list"]
+        file_list = body["list"]  # type: ignore[index]
         log_domain_url = ws_service.get_log_domain(request, region_name)
         file_urls = [{"file_name": f["filename"], "file_url": log_domain_url + "/" + f["relative_path"]} for f in file_list]
         result = general_message(200, "success", "获取成功", bean=file_urls)
@@ -842,13 +869,13 @@ class RbdLogFiles(EnterpriseAdminView):
 
 
 class ShellPod(EnterpriseAdminView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = request.data.get("region_name", "")
         body = region_api.create_shell_pod(region_name)
         result = general_message(200, "success", "创建成功", bean=body)
         return Response(result, status=status.HTTP_200_OK)
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = request.data.get("region_name", "")
         pod_name = request.data.get("pod_name", "")
         body = region_api.delete_shell_pod(region_name, pod_name)
@@ -857,14 +884,15 @@ class ShellPod(EnterpriseAdminView):
 
 
 class MyEventsView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         eid = kwargs.get("enterprise_id", "")
         region_names = request.GET.get("region_names", "")
         page = request.GET.get("page", 1)
         page_size = request.GET.get("page_size", 10)
         res_events = []
         for region_name in eval(region_names):
-            my_tenant_ids = team_repo.get_tenants_by_user_id(self.user.user_id).values_list("tenant_id", flat=True)
+            my_tenant_ids = team_repo.get_tenants_by_user_id(
+                self.user.user_id).values_list("tenant_id", flat=True)  # type: ignore[arg-type]
             tenant_id_list = {"tenant_ids": list(my_tenant_ids)}
             events = event_service.get_myteams_events("tenant", json.dumps(tenant_id_list), eid, region_name, int(page),
                                                       int(page_size))
@@ -875,7 +903,7 @@ class MyEventsView(JWTAuthApiView):
 
 
 class ServiceAlarm(EnterpriseAdminView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         res_service = []
         # 获取企业下团队数量
         if team_repo.get_team_by_enterprise_id(enterprise_id).count() > 0:
@@ -885,7 +913,7 @@ class ServiceAlarm(EnterpriseAdminView):
             all_abnormal_service_id = []
             for usable_region in usable_regions:
                 abnormal_service_id = region_api.get_user_service_abnormal_status(usable_region.region_name, enterprise_id)
-                all_abnormal_service_id += abnormal_service_id["service_ids"]
+                all_abnormal_service_id += abnormal_service_id["service_ids"]  # type: ignore[index]
             # 根据组件id获取应用信息
             result_map = group_service.get_services_group_name(all_abnormal_service_id)
             # 根据组件id获取组件信息
@@ -909,21 +937,21 @@ class ServiceAlarm(EnterpriseAdminView):
 
 
 class GetNodes(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         nodes, cluster_role_count = enterprise_services.get_nodes(region_name)
         result = general_message(200, "success", "获取成功", bean=cluster_role_count, list=nodes)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class GetNode(EnterpriseAdminView):
-    def get(self, request, region_name, node_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         res = enterprise_services.get_node_detail(region_name, node_name)
         result = general_message(200, "success", "获取成功", bean=res)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class NodeAction(EnterpriseAdminView):
-    def post(self, request, region_name, node_name, *args, **kwargs):
+    def post(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         action = request.data.get("action", "")
         support_action = ["unschedulable", "reschedulable", "down", "up", "evict"]
         if action not in support_action:
@@ -934,44 +962,44 @@ class NodeAction(EnterpriseAdminView):
 
 
 class NodeLabelsOperate(EnterpriseAdminView):
-    def get(self, request, region_name, node_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         res, body = region_api.get_node_labels(region_name, node_name)
-        result = general_message(200, "success", "获取成功", bean=body["bean"])
+        result = general_message(200, "success", "获取成功", bean=body["bean"])  # type: ignore[index]
         return Response(result, status=status.HTTP_200_OK)
 
-    def put(self, request, region_name, node_name, *args, **kwargs):
+    def put(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         labels = request.data.get("labels", {})
         res, body = region_api.update_node_labels(region_name, node_name, labels)
-        result = general_message(200, "success", "操作成功", bean=body["bean"])
+        result = general_message(200, "success", "操作成功", bean=body["bean"])  # type: ignore[index]
         return Response(result, status=status.HTTP_200_OK)
 
 
 class NodeTaintOperate(EnterpriseAdminView):
-    def get(self, request, region_name, node_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         res, body = region_api.get_node_taints(region_name, node_name)
-        result = general_message(200, "success", "获取成功", bean=body["list"])
+        result = general_message(200, "success", "获取成功", bean=body["list"])  # type: ignore[index]
         return Response(result, status=status.HTTP_200_OK)
 
-    def put(self, request, region_name, node_name, *args, **kwargs):
+    def put(self, request: Request, region_name: str, node_name: str, *args: Any, **kwargs: Any) -> Response:
         taints = request.data.get("taints", [])
         res, body = region_api.update_node_taints(region_name, node_name, taints)
-        result = general_message(200, "success", "操作成功", list=body["list"])
+        result = general_message(200, "success", "操作成功", list=body["list"])  # type: ignore[index]
         return Response(result, status=status.HTTP_200_OK)
 
 
 class RainbondComponents(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         component_list = enterprise_services.get_rbdcomponents(region_name)
         result = general_message(200, "success", "获取成功", list=component_list)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class ContainerDisk(EnterpriseAdminView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         container_runtime = request.GET.get("container_runtime", "")
         container = container_runtime.split(":")[0]
         res, body = region_api.get_container_disk(region_name, container)
-        container_disk = body["bean"]
+        container_disk = body["bean"]  # type: ignore[index]
         res = {
             "path": container_disk["path"],
             "total": container_disk["total"] / 1024 / 1024 / 1024,
@@ -982,12 +1010,12 @@ class ContainerDisk(EnterpriseAdminView):
 
 
 class EnterpriseMenuManage(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         menus_res = enterprise_services.get_enterprise_menus(enterprise_id)
         result = general_message(200, "success", "获取成功", list=menus_res)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         title = request.data.get("title", "")
         path = request.data.get("path", "")
         parent_id = request.data.get("parent_id", 0)
@@ -1007,7 +1035,7 @@ class EnterpriseMenuManage(JWTAuthApiView):
         result = general_message(200, "success", "添加成功")
         return Response(result, status=status.HTTP_200_OK)
 
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         id = request.data.get("id", "")
         title = request.data.get("title", "")
         path = request.data.get("path", "")
@@ -1023,7 +1051,7 @@ class EnterpriseMenuManage(JWTAuthApiView):
         result = general_message(200, "success", "更新成功")
         return Response(result, status=status.HTTP_200_OK)
 
-    def delete(self, request, enterprise_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         id = request.data.get("id", "")
         enterprise_services.delete_enterprise_menu(enterprise_id, id)
         result = general_message(200, "success", "删除成功")
@@ -1031,21 +1059,21 @@ class EnterpriseMenuManage(JWTAuthApiView):
 
 
 class EnterpriseInfoFileView(AlowAnyApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Any:
         data = enterprise_services.get_enterprise_by_enterprise_id(enterprise_id)
         ent = {
-            "enterprise_id": data.enterprise_id,
-            "enterprise_name": data.enterprise_name,
-            "enterprise_alias": data.enterprise_alias,
+            "enterprise_id": data.enterprise_id,  # type: ignore[union-attr]
+            "enterprise_name": data.enterprise_name,  # type: ignore[union-attr]
+            "enterprise_alias": data.enterprise_alias,  # type: ignore[union-attr]
         }
-        json_dir = "{0}/{1}.json".format(DATA_DIR, data.enterprise_alias)
+        json_dir = "{0}/{1}.json".format(DATA_DIR, data.enterprise_alias)  # type: ignore[union-attr]
         file = os.path.exists(json_dir)
         if file:
             os.remove(json_dir)
         with open(json_dir, "w") as f:
             json.dump(ent, f)
 
-        def file_iterator(fn, chunk_size=512):
+        def file_iterator(fn: Any, chunk_size: int = 512) -> Any:
             while True:
                 c = fn.read(chunk_size)
                 if c:
@@ -1056,11 +1084,11 @@ class EnterpriseInfoFileView(AlowAnyApiView):
         fn = open(json_dir, 'rb')
         response = FileResponse(file_iterator(fn))
         response['Content-Type'] = 'application/octet-stream'
-        response['Content-Disposition'] = 'attachment;filename={}.json'.format(data.enterprise_alias)
+        response['Content-Disposition'] = 'attachment;filename={}.json'.format(data.enterprise_alias)  # type: ignore[union-attr]
         return response
 
 
-class EnterpriseRegionLangVersion(JWTAuthApiView):
+class EnterpriseRegionLangVersion(JWTAuthApiView):  # type: ignore[no-redef]  # NOTE: class redefined (pre-existing duplicate)
     """
         企业区域语言版本视图。
 
@@ -1076,14 +1104,14 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
         Returns:
             Response: 包含企业区域语言版本信息的 HTTP 响应。
         """
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.GET.get(LANGUAGE, "")
         build_strategy = request.GET.get("build_strategy", "")
         data = region_lang_version.show_long_version(enterprise_id, region_id, language, build_strategy)
         result = general_message(200, "success", "获取成功", list=data["list"])
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, region_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get(LANGUAGE, "")
         version = request.data.get(VERSION, "")
         event_id = request.data.get(EVENT_ID, "")
@@ -1112,7 +1140,7 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
             data = general_message(400,"package format mistake","文件上传格式不正确，支持jar, tar.gz")
             return Response(data, status=400)
 
-    def put(self, request, enterprise_id, region_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get(LANGUAGE, "")
         version = request.data.get(VERSION, "")
         first_choice = request.data.get("first_choice", True)
@@ -1124,7 +1152,7 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, enterprise_id, region_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         language = request.data.get(LANGUAGE, "")
         version = request.data.get(VERSION, "")
         build_strategy = request.data.get("build_strategy", None)
@@ -1136,7 +1164,7 @@ class EnterpriseRegionLangVersion(JWTAuthApiView):
         return Response(result, status=result.get("code", 200))
 
 class EnterpriseRegionCNBFrameworks(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             lang = request.GET.get("lang", "nodejs")
             data = region_cnb_config.show_cnb_frameworks(enterprise_id, region_id, lang)

--- a/console/views/enterprise_active.py
+++ b/console/views/enterprise_active.py
@@ -5,9 +5,11 @@
 import logging
 import os
 import base64
+from typing import Any
 
 from django.conf import settings
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.enterprise_services import enterprise_services
@@ -22,7 +24,7 @@ logger = logging.getLogger("default")
 
 class BindMarketEnterpriseAccessTokenView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         云市绑定企业账号
         ---
@@ -78,7 +80,7 @@ class BindMarketEnterpriseAccessTokenView(RegionTenantHeaderView):
 
 class BindMarketEnterpriseOptimizAccessTokenView(JWTAuthApiView):
     @never_cache
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         优化云市绑定企业账号
         ---
@@ -102,7 +104,8 @@ class BindMarketEnterpriseOptimizAccessTokenView(JWTAuthApiView):
         """
         logger.debug("bind market access token")
         ret = request.data.get('market_info')
-        market_info = eval(base64.decodestring(ret))
+        # NOTE: base64.decodestring was removed in Python 3.9; this is a latent runtime bug (backlog).
+        market_info = eval(base64.decodestring(ret))  # type: ignore[attr-defined]
         market_client_id = market_info.get('eid')
         market_client_token = market_info.get('token')
         if not enterprise_id or not market_client_id or not market_client_token:

--- a/console/views/enterprise_config.py
+++ b/console/views/enterprise_config.py
@@ -3,9 +3,11 @@
   Created on 18/3/15.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.enum.system_config import ConfigKeyEnum
@@ -23,7 +25,7 @@ logger = logging.getLogger("default")
 
 class EnterpriseConfigView(EnterpriseAdminView):
     @never_cache
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         title = parse_item(request, "title")
         logo = parse_item(request, "logo")
         favicon = parse_item(request, "favicon")
@@ -44,7 +46,8 @@ class EnterpriseConfigView(EnterpriseAdminView):
         security_restrictions = parse_item(request, "security_restrictions", default=False)
 
         config_service = ConfigService()
-        ent_config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        # NOTE: user_id is an int AutoField but service expects str (systemic int-as-str backlog).
+        ent_config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
 
         if title:
             config_service.update_config_value(ConfigKeyEnum.TITLE.name, title)
@@ -188,7 +191,7 @@ class EnterpriseConfigView(EnterpriseAdminView):
 
 class EnterpriseObjectStorageView(EnterpriseAdminView):
     @never_cache
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         enable = bool_argument(parse_item(request, "enable", required=True))
         provider = parse_item(request, "provider", required=True)
         endpoint = parse_item(request, "endpoint", required=True)
@@ -199,7 +202,7 @@ class EnterpriseObjectStorageView(EnterpriseAdminView):
         if provider not in ("alioss", "s3"):
             raise AbortRequest("provider {} not in (\"alioss\", \"s3\")".format(provider))
 
-        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         ent_cfg_svc.update_config_enable_status(key="OBJECT_STORAGE", enable=enable)
         ent_cfg_svc.update_config_value(
             key="OBJECT_STORAGE",
@@ -218,14 +221,14 @@ class EnterpriseObjectStorageView(EnterpriseAdminView):
 
 class EnterpriseAppStoreImageHubView(EnterpriseAdminView):
     @never_cache
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         enable = bool_argument(parse_item(request, "enable", required=True))
         hub_url = parse_item(request, "hub_url", required=True)
         namespace = parse_item(request, "namespace")
         hub_user = parse_item(request, "hub_user")
         hub_password = parse_item(request, "hub_password")
 
-        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         ent_cfg_svc.update_config_enable_status(key="APPSTORE_IMAGE_HUB", enable=enable)
         ent_cfg_svc.update_config_value(
             key="APPSTORE_IMAGE_HUB",
@@ -243,7 +246,7 @@ class EnterpriseAppStoreImageHubView(EnterpriseAdminView):
 
 class EnterpriseVisualMonitorView(EnterpriseAdminView):
     @never_cache
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         enable = bool_argument(parse_item(request, "enable", required=True))
         home_url = parse_item(request, "home_url", required=True)
         cluster_monitor_suffix = request.data.get("cluster_monitor_suffix", "/d/cluster/ji-qun-jian-kong-ke-shi-hua")
@@ -251,7 +254,7 @@ class EnterpriseVisualMonitorView(EnterpriseAdminView):
         component_monitor_suffix = request.data.get("component_monitor_suffix", "/d/component/zu-jian-jian-kong-ke-shi-hua")
         slo_monitor_suffix = request.data.get("slo_monitor_suffix", "/d/service/fu-wu-jian-kong-ke-shi-hua")
 
-        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)
+        ent_cfg_svc = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         ent_cfg_svc.update_config_enable_status(key="VISUAL_MONITOR", enable=enable)
         ent_cfg_svc.update_config_value(
             key="VISUAL_MONITOR",
@@ -267,6 +270,6 @@ class EnterpriseVisualMonitorView(EnterpriseAdminView):
 
 class EnterpriseAlertsView(JWTAuthApiView):
     @never_cache
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         alerts = enterprise_services.get_enterprise_alerts(enterprise_id)
         return Response(general_message(200, "success", "查询成功", list=alerts), status=status.HTTP_200_OK)

--- a/console/views/errlog.py
+++ b/console/views/errlog.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.errlog_service import errlog_service
@@ -11,12 +13,13 @@ logger = logging.getLogger("default")
 
 
 class ErrLogView(JWTAuthApiView):
-    def post(self, req, *args, **kwargslf):
+    def post(self, req: Request, *args: Any, **kwargslf: Any) -> Response:
         msg = req.data.get("msg")
         username = req.data.get("username")
         enterprise_id = req.data.get("enterprise_id")
         address = req.data.get("address")
         if msg:
             logger.error("error from frontend: {}".format(msg))
-            errlog_service.create(msg, username, enterprise_id, address)
+            # NOTE: request.data.get returns Optional; service expects str (legacy mismatch, backlog).
+            errlog_service.create(msg, username, enterprise_id, address)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "ok"), status=200)

--- a/console/views/file_upload.py
+++ b/console/views/file_upload.py
@@ -4,7 +4,9 @@
 """
 import logging
 import os
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.git_service import GitCodeService
@@ -17,7 +19,7 @@ git_service = GitCodeService()
 
 
 class ConsoleUploadFileView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         上传文件
         ---

--- a/console/views/group.py
+++ b/console/views/group.py
@@ -4,6 +4,7 @@
 """
 import json
 import logging
+from typing import Any
 
 from console.enum.app import GovernanceModeEnum
 from console.exception.main import AbortRequest, ServiceHandleException
@@ -22,6 +23,7 @@ from console.utils.reqparse import parse_item
 from console.utils.validation import is_qualified_name
 from console.views.base import (ApplicationView, RegionTenantHeaderCloudEnterpriseCenterView, RegionTenantHeaderView,
                                 ApplicationViewCloudEnterpriseCenterView)
+from rest_framework.request import Request
 from rest_framework.response import Response
 from urllib3.exceptions import MaxRetryError
 from www.apiclient.regionapi import RegionInvokeApi
@@ -32,7 +34,7 @@ region_api = RegionInvokeApi()
 
 
 class TenantGroupView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询租户在指定数据中心下的应用
         ---
@@ -44,7 +46,7 @@ class TenantGroupView(RegionTenantHeaderView):
         result = general_message(200, "success", "查询成功", list=data)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加应用信息
         ---
@@ -81,39 +83,42 @@ class TenantGroupView(RegionTenantHeaderView):
             k8s_app = app_template_name
         if not is_qualified_name(k8s_app):
             raise ErrQualifiedName(msg_show="应用英文名称只能由小写字母、数字或“-”组成，并且必须以字母开始、以数字或字母结尾")
+        # NOTE: request.data.get / nullable model fields yield Any|None|str|None where
+        # service expects str (systemic arg-type backlog).
         data = group_service.create_app(
             self.tenant,
             region_name,
-            app_name,
+            app_name,  # type: ignore[arg-type]
             note,
             self.user.get_username(),
-            app_store_name,
-            app_store_url,
-            app_template_name,
-            version,
-            self.user.enterprise_id,
+            app_store_name,  # type: ignore[arg-type]
+            app_store_url,  # type: ignore[arg-type]
+            app_template_name,  # type: ignore[arg-type]
+            version,  # type: ignore[arg-type]
+            self.user.enterprise_id,  # type: ignore[arg-type]
             logo,
             k8s_app=k8s_app)
-        new_information = group_service.json_app(app_name=app_name, k8s_app=k8s_app, logo=logo, note=note)
+        new_information = group_service.json_app(
+            app_name=app_name, k8s_app=k8s_app, logo=logo, note=note)  # type: ignore[arg-type]
         result = general_message(200, "success", "创建成功", bean=data)
         app_name = operation_log_service.process_app_name(app_name, region_name, self.tenant.tenant_name, data["app_id"])
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=region_name,
             team_name=self.tenant.tenant_name,
             suffix=" 中创建了应用 {}".format(app_name))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             new_information=new_information)
         return Response(result, status=result["code"])
 
 
 class TenantGroupOperationView(ApplicationView):
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
             修改组信息
             ---
@@ -148,14 +153,18 @@ class TenantGroupOperationView(ApplicationView):
         version = request.data.get("version", "")
         revision = request.data.get("revision", 0)
         old_app = group_repo.get_tenant_group_on_region(app_id)
+        # NOTE: nullable model fields / request.data.get yield str|None|Any|None where
+        # service expects str (systemic arg-type backlog).
         old_information = group_service.json_app(
-            app_name=self.app.app_name, k8s_app=k8s_app, logo=old_app.logo, note=old_app.note)
-        new_information = group_service.json_app(app_name=app_name, k8s_app=k8s_app, logo=logo, note=note)
+            app_name=self.app.app_name, k8s_app=k8s_app,
+            logo=old_app.logo, note=old_app.note)  # type: ignore[arg-type]
+        new_information = group_service.json_app(
+            app_name=app_name, k8s_app=k8s_app, logo=logo, note=note)  # type: ignore[arg-type]
         group_service.update_group(
             self.tenant,
             self.response_region,
             app_id,
-            app_name,
+            app_name,  # type: ignore[arg-type]
             note,
             username,
             overrides=overrides,
@@ -175,7 +184,7 @@ class TenantGroupOperationView(ApplicationView):
             self, comment, format_app=False, old_information=old_information, new_information=new_information)
         return Response(result, status=result["code"])
 
-    def delete(self, request, app_id, *args, **kwargs):
+    def delete(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
             删除应用
             ---
@@ -193,15 +202,17 @@ class TenantGroupOperationView(ApplicationView):
 
         """
         old_app = group_repo.get_tenant_group_on_region(app_id)
+        # NOTE: nullable model fields where service expects str (arg-type backlog).
         old_information = group_service.json_app(
-            app_name=self.app.app_name, k8s_app=old_app.k8s_app, logo=old_app.logo, note=old_app.note)
+            app_name=self.app.app_name, k8s_app=old_app.k8s_app,
+            logo=old_app.logo, note=old_app.note)  # type: ignore[arg-type]
         group_service.delete_app(self.tenant, self.region_name, self.app)
         result = general_message(200, "success", "删除成功")
         operation_log_service.create_app_log(
             self, "删除了应用 {app}".format(app=self.app.group_name), format_app=False, old_information=old_information)
         return Response(result, status=result["code"])
 
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询组信息
         ---
@@ -223,7 +234,7 @@ class TenantGroupOperationView(ApplicationView):
 
 
 class TenantGroupHandleView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         '''
         获取应用下资源信息
         '''
@@ -231,7 +242,7 @@ class TenantGroupHandleView(ApplicationView):
         result = general_message(200, "success", "success", bean=res)
         return Response(result, status=result["code"])
 
-    def delete(self, request, app_id, *args, **kwargs):
+    def delete(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除应用及所有资源
         """
@@ -248,10 +259,11 @@ class TenantGroupHandleView(ApplicationView):
                     component_names.append(svc.service_cname)
                     old_information.append({"组件名": svc.service_cname, "操作": "删除"})
                 if len(component_names) > 2:
-                    component_names = ",".join(component_names[0:2]) + "等"
+                    component_names_text = ",".join(component_names[0:2]) + "等"
                 else:
-                    component_names = ",".join(component_names)
-                comment = "删除了应用 {app}, 以及应用下的组件 {component_names}".format(app=app_name, component_names=component_names)
+                    component_names_text = ",".join(component_names)
+                comment = "删除了应用 {app}, 以及应用下的组件 {component_names}".format(
+                    app=app_name, component_names=component_names_text)
 
         old_information = json.dumps(old_information, ensure_ascii=False)
         operation_log_service.create_app_log(ctx=self, comment=comment, format_app=False, old_information=old_information)
@@ -261,7 +273,7 @@ class TenantGroupHandleView(ApplicationView):
 
 
 class TenantAppUpgradableNumView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         data = dict()
         data['upgradable_num'] = 0
         try:
@@ -279,7 +291,7 @@ class TenantAppUpgradableNumView(ApplicationView):
 
 # 应用（组）常见操作【停止，重启， 启动， 重新构建】
 class TenantGroupCommonOperationView(ApplicationViewCloudEnterpriseCenterView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         ---
         parameters:
@@ -301,8 +313,9 @@ class TenantGroupCommonOperationView(ApplicationViewCloudEnterpriseCenterView):
 
         """
         action = request.data.get("action", None)
-        group_id = int(kwargs.get("group_id", None))
-        services = group_service_relation_repo.list_service_groups(group_id)
+        # NOTE: kwargs.get may be None for int(); repo expects str group_id (arg-type backlog).
+        group_id = int(kwargs.get("group_id", None))  # type: ignore[arg-type]
+        services = group_service_relation_repo.list_service_groups(group_id)  # type: ignore[arg-type]
         if not services:
             result = general_message(400, "not service", "当前组内无组件，无法操作")
             return Response(result)
@@ -332,7 +345,7 @@ class TenantGroupCommonOperationView(ApplicationViewCloudEnterpriseCenterView):
 
 # 应用（组）状态
 class GroupStatusView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         group_id = request.GET.get("group_id", None)
         region_name = request.GET.get("region_name", None)
         if not group_id or not region_name:
@@ -356,12 +369,12 @@ class GroupStatusView(RegionTenantHeaderView):
 
 
 class AppGovernanceModeView(ApplicationView):
-    def get(self, *args, **kwargs):
+    def get(self, *args: Any, **kwargs: Any) -> Response:
         data = region_api.list_governance_mode(self.response_region, self.tenant_name)
         result = general_message(200, "success", "获取成功", list=data)
         return Response(result, status=result["code"])
 
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         governance_mode = parse_item(request, "governance_mode", required=True)
         action = parse_item(request, "action")
         bean = {"governance_mode": governance_mode}
@@ -377,25 +390,25 @@ class AppGovernanceModeView(ApplicationView):
 
 
 class AppGovernanceModeCRView(ApplicationView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         governance_cr = request.data.get("governance_cr", {})
         k8s_resource_service.create_governance_resource(self.app, governance_cr)
         return Response(general_message(200, "success", "创建成功", bean=governance_cr))
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         governance_cr = request.data.get("governance_cr", {})
         k8s_resource_service.update_governance_resource(self.app, governance_cr)
         result = general_message(200, "success", "更新成功", bean=governance_cr)
         return Response(result)
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         k8s_resource_service.delete_governance_resource(self.app)
         result = general_message(200, "success", "删除成功")
         return Response(result)
 
 
 class AppGovernanceModeCheckView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         governance_mode = request.GET.get("governance_mode", "")
         if governance_mode not in GovernanceModeEnum.names():
             raise AbortRequest("governance_mode not in ({})".format(GovernanceModeEnum.names()))
@@ -406,11 +419,12 @@ class AppGovernanceModeCheckView(ApplicationView):
 
 
 class AppComponentNameView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         service_ids = group_service_relation_repo.list_serivce_ids_by_app_id(self.tenant.tenant_id, self.region_name, app_id)
-        services = list()
+        services: list = list()
         if service_ids:
-            services = service_repo.list_by_ids(service_ids)
+            # NOTE: list_by_ids returns a QuerySet; reused list var (assignment backlog).
+            services = service_repo.list_by_ids(service_ids)  # type: ignore[assignment]
         component_names = [service.k8s_component_name for service in services]
         data = {"component_names": component_names}
         result = general_message(200, "success", "查询成功", bean=data)
@@ -418,13 +432,14 @@ class AppComponentNameView(ApplicationView):
 
 
 class AppKubernetesServiceView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         res = group_service.list_kubernetes_services(self.tenant.tenant_id, self.region_name, app_id)
         result = general_message(200, "success", "查询成功", list=res)
         return Response(result)
 
-    def put(self, request, app_id, *args, **kwargs):
-        k8s_services = request.data
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: request.data is a polymorphic body; treated as a list of dicts here (legacy).
+        k8s_services: Any = request.data
         port_aliases = {}
         # data validation
         for k8s_service in k8s_services:
@@ -444,21 +459,21 @@ class AppKubernetesServiceView(ApplicationView):
 
 
 class ApplicationStatusView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         status = group_service.get_app_status(self.tenant, self.region_name, app_id)
         result = general_message(200, "success", "查询成功", list=status)
         return Response(result)
 
 
 class ApplicationDetectPrecessView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         processes = group_service.get_detect_process(self.tenant, self.region_name, app_id)
         result = general_message(200, "success", "查询成功", list=processes)
         return Response(result)
 
 
 class ApplicationInstallView(ApplicationView):
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         overrides = request.data.get("overrides")
         group_service.install_app(self.tenant, self.region_name, app_id, overrides)
         result = general_message(200, "success", "安装成功")
@@ -466,39 +481,42 @@ class ApplicationInstallView(ApplicationView):
 
 
 class ApplicationPodView(ApplicationView):
-    def get(self, request, app_id, pod_name, *args, **kwargs):
+    def get(self, request: Request, app_id: str, pod_name: str, *args: Any, **kwargs: Any) -> Response:
         pod = group_service.get_pod(self.tenant, self.region_name, pod_name)
         result = general_message(200, "success", "安装成功", bean=pod)
         return Response(result)
 
 
 class ApplicationHelmAppComponentView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         components, err = helm_app_service.list_components(self.tenant, self.region_name, self.user, self.app)
         return Response(general_message(err.get("code", 200), err.get("msg", "success"), "查询成功", list=components))
 
 
 class ApplicationParseServicesView(ApplicationView):
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         values = parse_item(request, "values", required=True)
-        services = application_service.parse_services(self.region_name, self.tenant, app_id, values)
+        # NOTE: service signature expects (tenant_name: str, app_id: int) but callers pass a
+        # Tenants model and str app_id (systemic arg-type backlog).
+        services = application_service.parse_services(
+            self.region_name, self.tenant, app_id, values)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=services))
 
 
 class ApplicationReleasesView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
-        releases = application_service.list_releases(self.region_name, self.tenant, app_id)
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
+        releases = application_service.list_releases(self.region_name, self.tenant, app_id)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=releases))
 
 
 class ApplicationIngressesView(ApplicationView):
-    def get(self, request, app_id, *args, **kwargs):
-        result = application_service.list_access_info(self.tenant, app_id)
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
+        result = application_service.list_access_info(self.tenant, app_id)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=result))
 
 
 class ApplicationVolumesView(ApplicationView):
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         region_app_id = region_app_repo.get_region_app_id(self.region_name, app_id)
         region_api.change_application_volumes(self.tenant.tenant_name, self.region_name, region_app_id)
         result = general_message(200, "success", "存储路径修改成功")

--- a/console/views/helm_app.py
+++ b/console/views/helm_app.py
@@ -1,6 +1,8 @@
 import json
+from typing import Any
 
 from rest_framework import status
+from rest_framework.request import Request
 
 from console.repositories.helm import helm_repo
 from console.repositories.market_app_repo import rainbond_app_repo
@@ -14,7 +16,7 @@ from rest_framework.response import Response
 
 
 class HelmAppView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         检查helm应用
         """
@@ -22,13 +24,14 @@ class HelmAppView(RegionTenantHeaderView):
         repo_name = request.GET.get("repo_name")
         chart_name = request.GET.get("chart_name")
         version = request.GET.get("version")
-        overrides = []
-        _, data = helm_app_service.check_helm_app(name, repo_name, chart_name, version, overrides, self.region_name,
-                                                  self.tenant_name, self.tenant)
+        overrides: list = []
+        # NOTE: GET params are Optional[str] but service expects str (systemic mismatch; backlog).
+        _, data = helm_app_service.check_helm_app(name, repo_name, chart_name, version, overrides,  # type: ignore[arg-type]
+                                                  self.region_name, self.tenant_name, self.tenant)
         result = general_message(200, "success", "获取成功", bean=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         生成helm应用模型
         """
@@ -42,19 +45,23 @@ class HelmAppView(RegionTenantHeaderView):
         overrides_list = list()
         for key, value in overrides.items():
             overrides_list.append(key + "=" + value)
-        cvdata = helm_app_service.yaml_conversion(name, repo_name, chart_name, version, overrides_list, self.region_name,
+        # NOTE: request.data fields are Any|None but services expect str (systemic mismatch; backlog).
+        cvdata = helm_app_service.yaml_conversion(name, repo_name, chart_name, version,  # type: ignore[arg-type]
+                                                  overrides_list, self.region_name,
                                                   self.tenant_name, self.tenant, self.enterprise.enterprise_id,
                                                   self.region.region_id)
-        helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)
-        chart = repo_name + "/" + chart_name
-        helm_app_service.generate_template(cvdata, helm_center_app, version, self.tenant, chart, self.region_name,
-                                           self.enterprise.enterprise_id, self.user.user_id, overrides_list, app_id)
+        helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)  # type: ignore[arg-type]
+        chart = repo_name + "/" + chart_name  # type: ignore[operator]
+        helm_app_service.generate_template(cvdata, helm_center_app, version,  # type: ignore[arg-type]
+                                           self.tenant, chart, self.region_name,
+                                           self.enterprise.enterprise_id, self.user.user_id,
+                                           overrides_list, app_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "安装成功", bean="")
         return Response(result, status=status.HTTP_200_OK)
 
 
 class HelmCenterApp(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         生成helm应用模版
         """
@@ -63,7 +70,8 @@ class HelmCenterApp(RegionTenantHeaderView):
         pic = request.data.get("pic", "")
         describe = request.data.get("describe", "")
         details = request.data.get("details", "This is a helm application from {}".format(repo_name))
-        app_id = make_uuid3(repo_name + "/" + chart_name)
+        # NOTE: request.data fields are Any|None; string ops/args expect str (systemic mismatch; backlog).
+        app_id = make_uuid3(repo_name + "/" + chart_name)  # type: ignore[operator]
         helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_id)
         data = {"exist": True, "app_model_id": app_id}
         if not helm_center_app:
@@ -71,7 +79,7 @@ class HelmCenterApp(RegionTenantHeaderView):
                 "app_id": app_id,
                 "app_name": chart_name,
                 "create_team": "",
-                "source": "helm:" + repo_name,
+                "source": "helm:" + repo_name,  # type: ignore[operator]
                 "scope": "enterprise",
                 "pic": pic,
                 "describe": describe,
@@ -88,7 +96,7 @@ class HelmCenterApp(RegionTenantHeaderView):
 
 
 class HelmChart(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取chart包的一些信息
         """
@@ -97,16 +105,19 @@ class HelmChart(RegionTenantHeaderView):
         # highest 默认获取全部版本，传值获取最高版本
         highest = request.GET.get("highest", "")
         app_id = request.GET.get("app_id", "")
-        data = helm_repo.get_helm_repo_by_name(repo_name)
+        # NOTE: GET params are Optional[str] but repo/service expect str (systemic mismatch; backlog).
+        data = helm_repo.get_helm_repo_by_name(repo_name)  # type: ignore[arg-type]
         if not data:
-            ret = dict()
+            ret: dict = dict()
             ret["repo_exist"] = False
             result = general_message(200, "success", "查询成功", bean=ret)
             return Response(result, status=status.HTTP_200_OK)
-        chart_information = helm_app_service.get_helm_chart_information(self.region_name, self.tenant_name, data["repo_url"],
-                                                                        chart_name, data["username"], data["password"])
-        app = rainbond_app_repo.get_app_helm_overrides(app_id, make_uuid3(repo_name + "/" + chart_name)).last()
-        overrides_dict = dict()
+        chart_information = helm_app_service.get_helm_chart_information(
+            self.region_name, self.tenant_name, data["repo_url"],
+            chart_name, data["username"], data["password"])  # type: ignore[arg-type]
+        app = rainbond_app_repo.get_app_helm_overrides(
+            app_id, make_uuid3(repo_name + "/" + chart_name)).last()  # type: ignore[operator]
+        overrides_dict: Any = dict()
         if app:
             overrides = json.loads(app.overrides)
             overrides_dict = [{override.split('=')[0]: override.split('=')[1]} for override in overrides]
@@ -124,19 +135,20 @@ class HelmChart(RegionTenantHeaderView):
 
 
 class CommandInstallHelm(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         命令安装helm应用
         """
         command = request.data.get("command")
-        data = helm_app_service.parse_helm_command(command, self.region_name, self.tenant)
+        # NOTE: request.data fields are Any|None but service expects str (systemic mismatch; backlog).
+        data = helm_app_service.parse_helm_command(command, self.region_name, self.tenant)  # type: ignore[arg-type]
         data['eid'] = self.enterprise.enterprise_id
         result = general_message(200, "success", "执行成功", bean=data)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class HelmList(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询本地已经有的helm商店
         """
@@ -146,13 +158,13 @@ class HelmList(RegionTenantHeaderView):
 
 
 class HelmRepoAdd(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         根据cmd 命令行 增加helm仓库
         """
         command = request.data.get("command")
 
-        repo_name, repo_url, username, password, success = helm_app_service.parse_cmd_add_repo(command)
+        repo_name, repo_url, username, password, success = helm_app_service.parse_cmd_add_repo(command)  # type: ignore[arg-type]
         data = {"status": success, "repo_name": repo_name, "repo_url": repo_url, "username": username, "password": password}
         result = general_message(200, "success", "添加成功", bean=data)
 
@@ -160,7 +172,7 @@ class HelmRepoAdd(RegionTenantHeaderView):
 
 
 class HelmRepo(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加helm仓库
         """
@@ -168,75 +180,82 @@ class HelmRepo(JWTAuthApiView):
         repo_url = request.data.get("repo_url")
         username = request.data.get("username", "")
         password = request.data.get("password", "")
-        if helm_repo.get_helm_repo_by_name(repo_name):
+        # NOTE: request.data fields are Any|None but repo/service expect str (systemic mismatch; backlog).
+        if helm_repo.get_helm_repo_by_name(repo_name):  # type: ignore[arg-type]
             result = general_message(200, "success", "仓库已存在", "")
             return Response(result, status=status.HTTP_200_OK)
-        helm_app_service.add_helm_repo(repo_name, repo_url, username, password)
+        helm_app_service.add_helm_repo(repo_name, repo_url, username, password)  # type: ignore[arg-type]
         result = general_message(200, "success", "添加成功", "")
         return Response(result, status=status.HTTP_200_OK)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         更新helm仓库
         """
         repo_name = request.data.get("repo_name")
         repo_url = request.data.get("repo_url")
-        helm_repo.update_helm_repo(repo_name, repo_url)
+        helm_repo.update_helm_repo(repo_name, repo_url)  # type: ignore[arg-type]
         result = general_message(200, "success", "更新成功", "")
         return Response(result, status=status.HTTP_200_OK)
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除helm仓库
         """
         repo_name = request.data.get("repo_name")
-        rainbond_app_repo.delete_helm_shared_apps("helm:" + repo_name)
-        helm_repo.delete_helm_repo(repo_name)
+        rainbond_app_repo.delete_helm_shared_apps("helm:" + repo_name)  # type: ignore[operator]
+        helm_repo.delete_helm_repo(repo_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功", "")
         return Response(result, status=status.HTTP_200_OK)
 
 
 class UploadHelmChart(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.GET.get("event_id")
-        data = helm_app_service.get_upload_chart_information(self.region_name, self.tenant_name, event_id)
+        # NOTE: GET event_id is Optional[str] but service expects str (systemic mismatch; backlog).
+        data = helm_app_service.get_upload_chart_information(
+            self.region_name, self.tenant_name, event_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "获取成功", data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.data.get("event_id")
         name = request.data.get("name")
         version = request.data.get("version")
-        data = helm_app_service.check_upload_chart(self.region_name, self.tenant, event_id, name, version)
+        data = helm_app_service.check_upload_chart(
+            self.region_name, self.tenant, event_id, name, version)  # type: ignore[arg-type]
         result = general_message(200, "success", "检测完成", data)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class UploadHelmChartValue(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.GET.get("event_id")
-        data = helm_app_service.get_upload_chart_value(self.region_name, self.tenant_name, event_id)
+        data = helm_app_service.get_upload_chart_value(
+            self.region_name, self.tenant_name, event_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "获取成功", data)
         return Response(result, status=status.HTTP_200_OK)
 
 
 class UploadHelmChartValueResource(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.GET.get("event_id")
         name = request.GET.get("name")
         version = request.GET.get("version")
-        overrides = request.GET.get("overrides", {})
-        overrides_list = list()
+        overrides: Any = request.GET.get("overrides", {})
+        overrides_list: list = list()
         for key, value in overrides.items():
             overrides_list.append(key + "=" + value)
-        data = helm_app_service.get_upload_chart_resource(self.region_name, self.tenant, event_id, name, version,
-                                                          overrides_list)
+        data = helm_app_service.get_upload_chart_resource(
+            self.region_name, self.tenant, event_id, name, version,  # type: ignore[arg-type]
+            overrides_list)
         result = general_message(200, "success", "获取成功", bean=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         resource = request.data.get("resource")
         app_id = request.data.get("app_id")
-        helm_app_service.import_upload_chart_resource(self.region_name, self.tenant, app_id, resource, self.user)
+        helm_app_service.import_upload_chart_resource(
+            self.region_name, self.tenant, app_id, resource, self.user)  # type: ignore[arg-type]
         result = general_message(200, "success", "安装成功", "")
         return Response(result, status=status.HTTP_200_OK)

--- a/console/views/index.py
+++ b/console/views/index.py
@@ -3,15 +3,16 @@
   Created on 18/2/6.
 """
 import os
+from typing import Any
 
-from django.http import FileResponse, Http404
+from django.http import FileResponse, Http404, HttpRequest
 from django.template.response import TemplateResponse
 from django.views.generic import View
 from goodrain_web.sentry_config import get_frontend_posthog_config_json, get_frontend_sentry_config_json
 
 
 class IndexTemplateView(View):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> TemplateResponse:
         return TemplateResponse(self.request, "index.html", {
             "sentry_config_json": get_frontend_sentry_config_json(),
             "posthog_config_json": get_frontend_posthog_config_json(),
@@ -19,12 +20,12 @@ class IndexTemplateView(View):
 
 
 class GithubCallBackView(View):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> TemplateResponse:
         return TemplateResponse(self.request, "githubcallback.html")
 
 
 class RKE2Install(View):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> FileResponse:
         # 文件的路径（需要根据实际情况进行修改）
         file_path = './script/install-cluster.sh'
         # 检查文件是否存在

--- a/console/views/jwt_token_view.py
+++ b/console/views/jwt_token_view.py
@@ -1,6 +1,7 @@
 # coding:utf-8
 import logging
 import datetime
+from typing import Any
 
 from console.login.login_event import LoginEvent
 from console.repositories.login_event import login_event_repo
@@ -8,6 +9,7 @@ from console.services.operation_log import operation_log_service, Operation, Ope
 from console.utils.cache import cache
 from rest_framework import status
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -23,10 +25,10 @@ class JWTTokenView(APIView):
     authentication_classes = ()
     serializer_class = CustomJWTSerializer
 
-    def get_serializer(self, *args, **kwargs):
+    def get_serializer(self, *args: Any, **kwargs: Any) -> CustomJWTSerializer:
         return self.serializer_class(*args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         用户登录接口
         ---
@@ -48,13 +50,14 @@ class JWTTokenView(APIView):
         real_captcha_code = request.session.get("captcha_code")
         is_validate = request.POST.get("is_validate", False)
         times = cache.get(nick_name)
-        pass_error_times = cache.get(nick_name + "pass_error_times")
+        # NOTE: nick_name from POST.get is str|None; legacy concat assumes str (operator backlog).
+        pass_error_times = cache.get(nick_name + "pass_error_times")  # type: ignore[operator]
         if pass_error_times and int(pass_error_times) >= 4:
-            ten_min = cache.get(nick_name + "freeze")
+            ten_min = cache.get(nick_name + "freeze")  # type: ignore[operator]
             if not ten_min:
                 ten_min = (datetime.datetime.now() + datetime.timedelta(minutes=10)).strftime('%H:%M:%S')
-                cache.set(nick_name + "freeze", ten_min, 600)
-                cache.set(nick_name + "pass_error_times", pass_error_times, 600)
+                cache.set(nick_name + "freeze", ten_min, 600)  # type: ignore[operator]
+                cache.set(nick_name + "pass_error_times", pass_error_times, 600)  # type: ignore[operator]
                 freeze_time = ten_min
             elif type(ten_min) == bytes:
                 freeze_time = str(ten_min, encoding='utf-8')
@@ -102,13 +105,15 @@ class JWTTokenView(APIView):
                     expiration = (datetime.datetime.now() + datetime.timedelta(days=3650))
                     response.set_cookie(jwt_issuer.JWT_AUTH_COOKIE, token, expires=expiration)
                 jwt_manager = JwtManager()
-                jwt_manager.set(response_data["token"], user.user_id)
+                # NOTE: user resolves to Any|User|AnonymousUser; user_id/enterprise_id are on
+                # the concrete Users model (union-attr backlog).
+                jwt_manager.set(response_data["token"], user.user_id)  # type: ignore[union-attr]
                 login_event = LoginEvent(user, login_event_repo, request=request)
                 login_event.login()
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.FINISH, module=OperationModule.LOGIN, module_name="")
                 operation_log_service.create_enterprise_log(user=user, comment=comment,
-                                                            enterprise_id=user.enterprise_id)
+                                                            enterprise_id=user.enterprise_id)  # type: ignore[union-attr]
                 return response
             result = general_message(400, "login failed", "{}".format(list(dict(serializer.errors).values())[0][0]))
             return Response(result, status=status.HTTP_400_BAD_REQUEST)

--- a/console/views/k8s_attribute.py
+++ b/console/views/k8s_attribute.py
@@ -1,5 +1,8 @@
 # -*- coding: utf8 -*-
 
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import AbortRequest
@@ -9,11 +12,11 @@ from www.utils.return_message import general_message
 
 
 class ComponentK8sAttributeView(AppBaseView):
-    def get(self, request, name, *args, **kwargs):
+    def get(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         attributes = k8s_attribute_service.get_by_component_ids_and_name(self.service.service_id, name)
         return Response(general_message(200, "success", "查询成功", list=attributes))
 
-    def put(self, request, name, *args, **kwargs):
+    def put(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         attribute = request.data.get("attribute", {})
         if name != attribute.get("name", ""):
             raise AbortRequest(400, "参数错误")
@@ -21,17 +24,20 @@ class ComponentK8sAttributeView(AppBaseView):
         k8s_attribute_service.update_k8s_attribute(self.tenant, self.service, self.region_name, attribute)
         return Response(general_message(200, "success", "修改成功"))
 
-    def delete(self, request, name, *args, **kwargs):
-        k8s_attribute_service.delete_k8s_attribute(self.tenant, self.service, self.region_name, name, self.user.nick_name)
+    def delete(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: nick_name is Optional; service expects str (legacy mismatch, backlog).
+        k8s_attribute_service.delete_k8s_attribute(
+            self.tenant, self.service, self.region_name, name, self.user.nick_name)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "删除成功"))
 
 
 class ComponentK8sAttributeListView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         attributes = k8s_attribute_service.list_by_component_ids([self.service.service_id])
         return Response(general_message(200, "success", "查询成功", list=attributes))
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         attribute = request.data.get("attribute", {})
-        k8s_attribute_service.create_k8s_attribute(self.tenant, self.service, self.region_name, attribute, self.user.nick_name)
+        k8s_attribute_service.create_k8s_attribute(
+            self.tenant, self.service, self.region_name, attribute, self.user.nick_name)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "创建成功"))

--- a/console/views/k8s_resource.py
+++ b/console/views/k8s_resource.py
@@ -1,5 +1,8 @@
 # -*- coding: utf8 -*-
 
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.k8s_resource import k8s_resource_service
@@ -8,42 +11,44 @@ from www.utils.return_message import general_message
 
 
 class AppK8ResourceView(ApplicationView):
-    def get(self, request, name, *args, **kwargs):
+    def get(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         resource_id = request.GET.get("id")
+        # NOTE: resource_id from request params is Optional; service expects str (legacy mismatch, backlog).
         state = k8s_resource_service.get_k8s_resource(self.enterprise.enterprise_id, self.tenant_name, str(self.app_id),
-                                                      self.region_name, name, resource_id)
+                                                      self.region_name, name, resource_id)  # type: ignore[arg-type]
 
         return Response(general_message(200, "success", "查询成功", list=state))
 
-    def put(self, request, name, *args, **kwargs):
+    def put(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         resource_yaml = request.data.get("resource_yaml", {})
         resource_id = request.data.get("id")
         state = k8s_resource_service.update_k8s_resource(self.enterprise.enterprise_id, self.tenant_name, str(self.app_id),
-                                                         resource_yaml, self.region_name, name, resource_id)
+                                                         resource_yaml, self.region_name, name,
+                                                         resource_id)  # type: ignore[arg-type]
         if state == 2:
             return Response(general_message(200, "success", "修改成功"))
         return Response(general_message(400, "failed", "修改失败"))
 
-    def delete(self, request, name, *args, **kwargs):
+    def delete(self, request: Request, name: str, *args: Any, **kwargs: Any) -> Response:
         resource_id = request.data.get("id")
         k8s_resource_service.delete_k8s_resource(self.enterprise.enterprise_id, self.tenant_name, str(self.app_id),
-                                                 self.region_name, name, resource_id)
+                                                 self.region_name, name, resource_id)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "删除成功"))
 
 
 class AppK8sResourceListView(ApplicationView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         k8s_resource = k8s_resource_service.list_by_app_id(self.app_id)
         k8s_dict = k8s_resource.values()
         return Response(general_message(200, "success", "查询成功", list=k8s_dict))
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         resource_yaml = request.data.get("resource_yaml", {})
         k8s_resource_service.create_k8s_resource(self.enterprise.enterprise_id, self.tenant_name, self.app_id, resource_yaml,
                                                  self.region_name)
         return Response(general_message(200, "success", "创建成功"))
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         resource_ids = request.data.get("ids")
         k8s_resource_service.batch_delete_k8s_resource(self.enterprise.enterprise_id, self.tenant_name, str(self.app_id),
                                                        self.region_name, resource_ids)

--- a/console/views/kubeblocks.py
+++ b/console/views/kubeblocks.py
@@ -1,7 +1,10 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
+
 from django.db import IntegrityError
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.bcode import ErrK8sComponentNameExists
@@ -16,7 +19,7 @@ region_api = RegionInvokeApi()
 
 
 class KubeBlocksAddonsView(RegionTenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取指定区域下 KubeBlocks 支持的数据库类型列表
         """
@@ -30,7 +33,7 @@ class KubeBlocksAddonsView(RegionTenantHeaderView):
 
 
 class KubeBlocksStorageClassesView(RegionTenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取指定区域下 KubeBlocks StorageClass 列表
         """
@@ -42,7 +45,7 @@ class KubeBlocksStorageClassesView(RegionTenantHeaderView):
             return Response(general_message(500, "request error", f"请求异常: {str(e)}"), status=500)
 
 class KubeBlocksBackupReposView(RegionTenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取当前团队下 KubeBlocks BackupRepo 列表
         """
@@ -53,7 +56,7 @@ class KubeBlocksBackupReposView(RegionTenantHeaderView):
             logger.exception(e)
             return Response(general_message(500, "request error", f"请求异常: {str(e)}"), status=500)
 
-    def post(self, request, team_name, region_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         创建当前团队下 KubeBlocks BackupRepo
         """
@@ -72,7 +75,7 @@ class KubeBlocksBackupReposView(RegionTenantHeaderView):
             logger.exception(e)
             return Response(general_message(500, "request error", f"请求异常: {str(e)}"), status=500)
 
-    def put(self, request, team_name, region_name, repo_name, *args, **kwargs):
+    def put(self, request: Request, team_name: str, region_name: str, repo_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         更新当前团队下 KubeBlocks BackupRepo
         """
@@ -91,7 +94,7 @@ class KubeBlocksBackupReposView(RegionTenantHeaderView):
             logger.exception(e)
             return Response(general_message(500, "request error", f"请求异常: {str(e)}"), status=500)
 
-    def delete(self, request, team_name, region_name, repo_name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, region_name: str, repo_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除当前团队下 KubeBlocks BackupRepo
         """
@@ -108,7 +111,7 @@ class KubeBlocksBackupReposView(RegionTenantHeaderView):
 
 
 class KubeBlocksClusterDetailView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取 Cluster detail
         """
@@ -130,7 +133,7 @@ class KubeBlocksClusterDetailView(AppBaseView):
             logger.exception(f"查询集群详情异常: {str(e)}")
             return Response(general_message(500, "后端服务异常", f"后端服务异常: {str(e)}"))
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         伸缩 KubeBlocks 集群
         """
@@ -156,7 +159,7 @@ class KubeBlocksClusterDetailView(AppBaseView):
 
 
 class KubeBlocksClusterBackupView(AppBaseView):
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         更新 KubeBlocks 集群的备份配置
         """
@@ -182,7 +185,7 @@ class KubeBlocksClusterBackupView(AppBaseView):
             return Response(general_message(500, 'request error', f'请求异常: {str(e)}'))
 
 class KubeBlocksClusterBackupListView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取备份列表
         自动获得: self.service, self.app, self.tenant, self.response_region
@@ -215,7 +218,7 @@ class KubeBlocksClusterBackupListView(AppBaseView):
             logger.exception(f"获取KubeBlocks集群备份异常: {str(e)}")
             return Response(general_message(500, "后端服务异常", f"后端服务异常: {str(e)}"))
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         创建手动备份
         """
@@ -237,7 +240,7 @@ class KubeBlocksClusterBackupListView(AppBaseView):
             logger.exception(e)
             return Response(general_message(500, 'request error', f'请求异常: {str(e)}'))
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除备份
         """
@@ -264,7 +267,7 @@ class KubeBlocksClusterBackupListView(AppBaseView):
             return Response(general_message(500, 'request error', f'请求异常: {str(e)}'))
 
 class KubeBlocksClusterParametersView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取 KubeBlocks 数据库参数列表（分页/搜索）
         """
@@ -299,7 +302,7 @@ class KubeBlocksClusterParametersView(AppBaseView):
             logger.exception(f"获取KubeBlocks集群参数异常: {str(e)}")
             return Response(general_message(500, "后端服务异常", f"后端服务异常: {str(e)}"))
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         批量更新 KubeBlocks 数据库参数
         """
@@ -324,7 +327,7 @@ class KubeBlocksClusterParametersView(AppBaseView):
             return Response(general_message(500, "后端服务异常", f"后端服务异常: {str(e)}"))
 
 class KubeBlocksClusterRestoreView(AppBaseView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """从备份恢复 KubeBlocks 集群：新建组件"""
         try:
             body = request.data or {}

--- a/console/views/license.py
+++ b/console/views/license.py
@@ -1,6 +1,8 @@
 # coding:utf-8
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.views.base import JWTAuthApiView
@@ -12,7 +14,7 @@ logger = logging.getLogger("default")
 
 
 class LicenseLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         authz_code, license = license_service.get_licenses(enterprise_id)
         if not authz_code or not license:
             result = general_message(400, "invalid authz code", "无效授权码", bean={"authz_code": authz_code})
@@ -20,10 +22,11 @@ class LicenseLView(JWTAuthApiView):
         result = general_message(200, "success", "查询成功", bean=license)
         return Response(result, status=result["code"])
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         authz_code = request.data.get("authz_code")
         try:
-            config = license_service.update_license(enterprise_id, authz_code)
+            # NOTE: authz_code is Optional; service expects str (legacy mismatch, backlog).
+            config = license_service.update_license(enterprise_id, authz_code)  # type: ignore[arg-type]
         except ServiceHandleException as e:
             result = general_message(e.status_code, "error", e.msg_show)
             return Response(result, status=e.status_code)
@@ -32,7 +35,7 @@ class LicenseLView(JWTAuthApiView):
 
 
 class LicenseClusterIDView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             body = license_service.get_cluster_id(enterprise_id, region_name)
             bean = body.get("bean", {}) if body else {}
@@ -45,7 +48,7 @@ class LicenseClusterIDView(JWTAuthApiView):
 
 
 class LicenseActivateView(JWTAuthApiView):
-    def post(self, request, enterprise_id, region_name, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             license_code = request.data.get("license_code")
             if not license_code:
@@ -62,7 +65,7 @@ class LicenseActivateView(JWTAuthApiView):
 
 
 class LicenseStatusView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             body = license_service.get_license_status(enterprise_id, region_name)
             bean = body.get("bean", {}) if body else {}

--- a/console/views/log_proxy.py
+++ b/console/views/log_proxy.py
@@ -2,9 +2,11 @@
 import logging
 import requests
 import os
+from typing import Optional
 from urllib.parse import urljoin, urlparse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
 from console.views.base import JWTAuthApiView
@@ -20,7 +22,7 @@ class LogProxyView(JWTAuthApiView):
     前端传递接口地址和请求参数，后端代理请求并返回结果
     """
     
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             # 获取前端传递的参数
             target_url = request.data.get('url')
@@ -121,7 +123,7 @@ class LogProxyView(JWTAuthApiView):
             result = general_message(500, "System Error", f"Unknown exception: {str(e)}")
             return Response(result, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    def _get_log_plugin_backend(self):
+    def _get_log_plugin_backend(self) -> Optional[str]:
         """
         Get log plugin backend address from plugin configuration
         """
@@ -153,7 +155,8 @@ class LogProxyView(JWTAuthApiView):
             if enterprise_id and region_name:
                 region_api = RegionInvokeApi()
                 _, body = region_api.list_plugins(enterprise_id, region_name, official=True)
-                plugins = body.get("list", [])
+                # NOTE: region_api may return None; union-attr backlog.
+                plugins = body.get("list", [])  # type: ignore[union-attr]
 
                 # Find log plugin
                 for plugin in plugins:

--- a/console/views/login_event.py
+++ b/console/views/login_event.py
@@ -1,13 +1,16 @@
 # coding=utf-8
+from typing import Any
+
 from console.services.login_event import log_event_service
 from console.views.base import EnterpriseHeaderView
 from console.views.operation_log import extend_user_info
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.return_message import general_message
 
 
 class LoginEventView(EnterpriseHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         start_time = request.GET.get("start_time", None)
         end_time = request.GET.get("end_time", None)
         username = request.GET.get("username", None)

--- a/console/views/logos.py
+++ b/console/views/logos.py
@@ -4,8 +4,10 @@ import logging
 import os
 import subprocess
 from datetime import datetime
+from typing import Any, Optional
 
 from django.db import transaction
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import ServiceHandleException
@@ -27,14 +29,15 @@ logger = logging.getLogger("default")
 
 class ConfigOSSView(JWTTokenView):
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         oss_config = ConsoleSysConfig.objects.filter(key='OSS_CONFIG').first()
         if oss_config:
-            data = json.loads(oss_config.value)
+            # NOTE: model TextField value typed str|None by stubs (arg-type backlog).
+            data = json.loads(oss_config.value)  # type: ignore[arg-type]
             return Response(data=data, status=200)
         return Response(data={}, status=200)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         oss_config = ConsoleSysConfig.objects.filter(key='OSS_CONFIG').first()
 
         # 如果已存在，则更新；如果不存在，则创建
@@ -43,7 +46,7 @@ class ConfigOSSView(JWTTokenView):
             oss_config.desc = 'OSS 配置'
             oss_config.create_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             oss_config.save()
-            data = {'message': '配置更新成功'}
+            data: dict = {'message': '配置更新成功'}
         else:
             new_config = ConsoleSysConfig.objects.create(
                 key='OSS_CONFIG',
@@ -64,7 +67,7 @@ class ConfigRUDView(AlowAnyApiView):
     ---
     """
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         code = 200
         user = request.user
         status = perms_repo.initialize_permission_settings()
@@ -94,7 +97,7 @@ class ConfigRUDView(AlowAnyApiView):
         result = general_message(code, "query success", "Logo获取成功", bean=data, initialize_info=status)
         return Response(result, status=code)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         key = request.GET.get("key")
         if not key:
             result = general_message(404, "no found config key", "更新失败")
@@ -115,7 +118,7 @@ class ConfigRUDView(AlowAnyApiView):
             result = general_message(404, "no found config key", "更新失败")
         return Response(result, status=result.get("code", 200))
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         key = request.GET.get("key")
         if not key:
             result = general_message(404, "no found config key", "重置失败")
@@ -138,7 +141,7 @@ class ConfigRUDView(AlowAnyApiView):
 
 
 class LogoView(BaseApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取云帮Logo
         ---
@@ -148,17 +151,19 @@ class LogoView(BaseApiView):
             data = dict()
             logo = platform_config_service.get_config_by_key("LOGO")
             host_name = request.get_host()
-            data["logo"] = str(host_name) + str(logo.value)
+            # NOTE: get_config_by_key may return None (union-attr backlog).
+            data["logo"] = str(host_name) + str(logo.value)  # type: ignore[union-attr]
             result = general_message(code, "query success", "Logo获取成功", bean=data)
             return Response(result, status=code)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2-style Exception.message attribute (attr-defined backlog).
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result)
 
 
 class PhpConfigView(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """获取php的环境配置"""
 
         versions = ["5.6.11", "5.6.30", "5.6.35", "7.0.16", "7.0.29", "7.1.2", "7.1.16"]
@@ -287,7 +292,7 @@ class PhpConfigView(AlowAnyApiView):
 
 class InitPerms(AlowAnyApiView):
     @transaction.atomic()
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Optional[Response]:
         enterprise_id = request.data.get("enterprise_id")
         tenant_id = request.data.get("tenant_id")
         if tenant_id and enterprise_id:
@@ -300,10 +305,12 @@ class InitPerms(AlowAnyApiView):
             teams = Tenants.objects.all()
         if not teams:
             print("未发现团队, 初始化结束")
-            return
+            # NOTE: @transaction.atomic wrapper masks Optional[Response]; bare return ok.
+            return  # type: ignore[return-value]
         for team in teams:
             role_kind_services.init_default_roles(kind="team", kind_id=team.tenant_id)
-            users = team_repo.get_tenant_users_by_tenant_ID(team.ID)
+            # NOTE: ID is an int AutoField but repo expects str (systemic int-as-str backlog).
+            users = team_repo.get_tenant_users_by_tenant_ID(team.ID)  # type: ignore[arg-type]
             admin = role_kind_services.get_role_by_name(kind="team", kind_id=team.tenant_id, name="管理员")
             developer = role_kind_services.get_role_by_name(kind="team", kind_id=team.tenant_id, name="开发者")
             if not admin or not developer:
@@ -326,7 +333,7 @@ class UserSourceView(AlowAnyApiView):
     ---
     """
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         使用curl发送飞书消息
         ---

--- a/console/views/mcp_query.py
+++ b/console/views/mcp_query.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from queue import Empty, Queue
 from threading import Lock
+from typing import Any, Optional
 
 from django.core import signing
 from django.http import HttpResponse, StreamingHttpResponse
@@ -20,6 +21,7 @@ from rest_framework import exceptions
 from rest_framework.authentication import get_authorization_header
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import BaseRenderer, JSONRenderer
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from console.utils import jwt_issuer
@@ -34,7 +36,7 @@ _MCP_HTTP_SESSION_SALT = "console.mcp.http.session"
 _MCP_HTTP_SESSION_MAX_AGE_SECONDS = 1800
 
 
-def _request_has_mcp_auth_input(request):
+def _request_has_mcp_auth_input(request: Any) -> bool:
     if get_authorization_header(request):
         return True
     if jwt_issuer.JWT_AUTH_COOKIE and request.COOKIES.get(jwt_issuer.JWT_AUTH_COOKIE):
@@ -47,7 +49,7 @@ def _request_has_mcp_auth_input(request):
     return False
 
 
-def _build_mcp_auth_expired_response():
+def _build_mcp_auth_expired_response() -> Response:
     return Response({
         "code": "AUTH_TOKEN_EXPIRED",
         "status_code": 401,
@@ -63,7 +65,7 @@ class MCPSSEEventStreamRenderer(BaseRenderer):
     charset = "utf-8"
     render_style = "binary"
 
-    def render(self, data, accepted_media_type=None, renderer_context=None):
+    def render(self, data: Any, accepted_media_type: Optional[str] = None, renderer_context: Any = None) -> bytes:
         if data is None:
             return b""
         if isinstance(data, bytes):
@@ -75,38 +77,38 @@ class MCPSSEEventStreamRenderer(BaseRenderer):
 
 class MCPSSESession(object):
 
-    def __init__(self, user, protocol_version="2024-11-05"):
+    def __init__(self, user: Any, protocol_version: str = "2024-11-05") -> None:
         self.session_id = uuid.uuid4().hex
         self.user = user
         self.protocol_version = protocol_version
-        self.queue = Queue()
+        self.queue: Queue = Queue()
 
-    def send(self, message):
+    def send(self, message: Any) -> None:
         self.queue.put(message)
 
 
-def _register_mcp_sse_session(user, protocol_version="2024-11-05"):
+def _register_mcp_sse_session(user: Any, protocol_version: str = "2024-11-05") -> MCPSSESession:
     session = MCPSSESession(user, protocol_version=protocol_version)
     with _MCP_SESSION_LOCK:
         _MCP_SSE_SESSIONS[session.session_id] = session
     return session
 
 
-def _get_mcp_sse_session(session_id):
+def _get_mcp_sse_session(session_id: Optional[str]) -> Optional[MCPSSESession]:
     if not session_id:
         return None
     with _MCP_SESSION_LOCK:
         return _MCP_SSE_SESSIONS.get(session_id)
 
 
-def _remove_mcp_sse_session(session_id):
+def _remove_mcp_sse_session(session_id: Optional[str]) -> None:
     if not session_id:
         return
     with _MCP_SESSION_LOCK:
         _MCP_SSE_SESSIONS.pop(session_id, None)
 
 
-def _build_mcp_http_session_token(user, protocol_version):
+def _build_mcp_http_session_token(user: Any, protocol_version: str) -> str:
     payload = {"protocol_version": protocol_version}
     user_id = getattr(user, "user_id", None)
     if user_id is not None:
@@ -114,7 +116,7 @@ def _build_mcp_http_session_token(user, protocol_version):
     return signing.dumps(payload, salt=_MCP_HTTP_SESSION_SALT, compress=True)
 
 
-def _load_mcp_http_session(session_id):
+def _load_mcp_http_session(session_id: Optional[str]) -> Optional[dict]:
     if not session_id:
         return None
     try:
@@ -139,7 +141,7 @@ class MCPJSONWebTokenAuthentication(JSONWebTokenAuthentication):
     - token in query/body (token/access_token/jwt)
     """
 
-    def get_jwt_value(self, request):
+    def get_jwt_value(self, request: Any) -> Any:
         auth = get_authorization_header(request).split()
         auth_header_prefix = jwt_issuer.JWT_AUTH_HEADER_PREFIX.lower()
         valid_prefixes = [auth_header_prefix, "jwt", "bearer"]
@@ -183,7 +185,7 @@ class MCPJSONWebTokenAuthenticationSafe(MCPJSONWebTokenAuthentication):
     return None instead of raising auth errors.
     """
 
-    def authenticate(self, request):
+    def authenticate(self, request: Any) -> Any:
         try:
             return super(MCPJSONWebTokenAuthenticationSafe, self).authenticate(request=request)
         except AuthenticationInfoHasExpiredError as exc:
@@ -203,7 +205,7 @@ class MCPQueryRPCMixin(object):
     authentication_classes = (InternalTokenAuthentication, MCPJSONWebTokenAuthenticationSafe)
     renderer_classes = (MCPSSEEventStreamRenderer, JSONRenderer)
 
-    def _parse_request_payload(self, request):
+    def _parse_request_payload(self, request: Any) -> Any:
         if isinstance(request.data, dict):
             return request.data
         if not request.body:
@@ -213,7 +215,7 @@ class MCPQueryRPCMixin(object):
         except Exception:
             return {}
 
-    def _dispatch_rpc(self, payload, user, protocol_version="2024-11-05"):
+    def _dispatch_rpc(self, payload: Any, user: Any, protocol_version: str = "2024-11-05") -> dict:
         if not isinstance(payload, dict):
             return self._jsonrpc_error(None, -32600, "Invalid Request")
 
@@ -310,7 +312,7 @@ class MCPQueryRPCMixin(object):
         return self._jsonrpc_error(request_id, -32601, "Method not found: {}".format(method))
 
     @staticmethod
-    def _jsonrpc_result(request_id, result):
+    def _jsonrpc_result(request_id: Any, result: Any) -> dict:
         return {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -318,7 +320,7 @@ class MCPQueryRPCMixin(object):
         }
 
     @staticmethod
-    def _jsonrpc_error(request_id, code, message):
+    def _jsonrpc_error(request_id: Any, code: int, message: str) -> dict:
         return {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -329,7 +331,7 @@ class MCPQueryRPCMixin(object):
         }
 
     @staticmethod
-    def _format_sse_message(event, data, serialize_json=True):
+    def _format_sse_message(event: str, data: Any, serialize_json: bool = True) -> str:
         if serialize_json:
             payload = json.dumps(data, ensure_ascii=False, default=str)
         else:
@@ -337,7 +339,7 @@ class MCPQueryRPCMixin(object):
         return "event: {event}\ndata: {data}\n\n".format(event=event, data=payload)
 
     @staticmethod
-    def _format_sse_data(data, serialize_json=True):
+    def _format_sse_data(data: Any, serialize_json: bool = True) -> str:
         if serialize_json:
             payload = json.dumps(data, ensure_ascii=False, default=str)
         else:
@@ -345,15 +347,16 @@ class MCPQueryRPCMixin(object):
         return "data: {data}\n\n".format(data=payload)
 
     @staticmethod
-    def _is_authenticated_user(user):
+    def _is_authenticated_user(user: Any) -> bool:
         return user is not None and hasattr(user, "user_id") and getattr(user, "is_authenticated", True)
 
     @staticmethod
-    def _describe_tool_exception(exc):
+    def _describe_tool_exception(exc: Exception) -> Any:
         """Map an arbitrary tool exception to (http_status, human readable reason)."""
         status_raw = getattr(exc, "status", None)
         try:
-            status_code = int(status_raw)
+            # NOTE: status_raw may be None; TypeError caught below (legacy, backlog).
+            status_code = int(status_raw)  # type: ignore[arg-type]
         except (TypeError, ValueError):
             status_code = 500
         if not (100 <= status_code <= 599):
@@ -361,7 +364,7 @@ class MCPQueryRPCMixin(object):
         return status_code, MCPQueryRPCMixin._extract_tool_error_reason(exc)
 
     @staticmethod
-    def _extract_tool_error_reason(exc):
+    def _extract_tool_error_reason(exc: Exception) -> str:
         """Pull a concise, non-sensitive failure reason out of an exception.
 
         Region CallApiError carries a dict `message` whose `body` usually holds the
@@ -386,37 +389,39 @@ class MCPQueryRPCMixin(object):
         return exc.__class__.__name__
 
 
-class MCPQuerySSEView(MCPQueryRPCMixin, APIView):
+# NOTE: mixin declares permission/renderer/authentication_classes incompatibly with APIView (pre-existing).
+class MCPQuerySSEView(MCPQueryRPCMixin, APIView):  # type: ignore[misc]
     """Legacy MCP HTTP+SSE endpoint for backwards-compatible clients."""
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         if getattr(request, "_mcp_auth_error", None) is not None:
             return _build_mcp_auth_expired_response()
         session = _register_mcp_sse_session(request.user if self._is_authenticated_user(request.user) else None)
         return self._build_sse_response(request, session)
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return Response(
             {"detail": "Use the endpoint event URI for POST requests."},
             status=405,
         )
 
     @never_cache
-    def options(self, request, *args, **kwargs):
+    # NOTE: APIView.options returns Response/takes HttpRequest; CORS preflight needs raw HttpResponse (legacy, backlog).
+    def options(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
         response = HttpResponse(status=204)
         response["Access-Control-Allow-Origin"] = "*"
         response["Access-Control-Allow-Headers"] = "Cache-Control, Content-Type, Authorization"
         response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
         return response
 
-    def _build_sse_response(self, request, session):
+    def _build_sse_response(self, request: Any, session: MCPSSESession) -> StreamingHttpResponse:
         message_endpoint = request.build_absolute_uri(
             "/console/mcp/query/message?session_id={}".format(session.session_id)
         )
 
-        def event_stream():
+        def event_stream() -> Any:
             yield self._format_sse_message("endpoint", message_endpoint, serialize_json=False)
 
             try:
@@ -441,10 +446,10 @@ class MCPQuerySSEView(MCPQueryRPCMixin, APIView):
         return response
 
 
-class MCPQueryMessageView(MCPQueryRPCMixin, APIView):
+class MCPQueryMessageView(MCPQueryRPCMixin, APIView):  # type: ignore[misc]
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         if getattr(request, "_mcp_auth_error", None) is not None:
             return _build_mcp_auth_expired_response()
         session_id = request.GET.get("session_id")
@@ -465,7 +470,7 @@ class MCPQueryMessageView(MCPQueryRPCMixin, APIView):
         return HttpResponse(status=202)
 
     @never_cache
-    def options(self, request, *args, **kwargs):
+    def options(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
         response = HttpResponse(status=204)
         response["Access-Control-Allow-Origin"] = "*"
         response["Access-Control-Allow-Headers"] = "Cache-Control, Content-Type, Authorization"
@@ -473,13 +478,13 @@ class MCPQueryMessageView(MCPQueryRPCMixin, APIView):
         return response
 
 
-class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
+class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):  # type: ignore[misc]
     """Streamable HTTP MCP endpoint."""
 
     _EXPOSE_HEADERS = "Mcp-Session-Id, MCP-Protocol-Version"
 
     @staticmethod
-    def _get_http_session_user(session_payload):
+    def _get_http_session_user(session_payload: Optional[dict]) -> Any:
         user_id = (session_payload or {}).get("user_id")
         if not user_id:
             return None
@@ -490,7 +495,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
             return None
 
     @classmethod
-    def _apply_http_headers(cls, response, protocol_version, session_id=None):
+    def _apply_http_headers(cls, response: Any, protocol_version: str, session_id: Optional[str] = None) -> Any:
         if session_id:
             response["Mcp-Session-Id"] = session_id
         response["MCP-Protocol-Version"] = protocol_version
@@ -503,7 +508,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
         return response
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         if getattr(request, "_mcp_auth_error", None) is not None:
             return _build_mcp_auth_expired_response()
         payload = self._parse_request_payload(request)
@@ -537,7 +542,8 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
             response = HttpResponse(status=202)
         else:
             if self._request_accepts_sse(request):
-                response = StreamingHttpResponse(
+                # NOTE: response var reused across HttpResponse/StreamingHttpResponse/Response (legacy, backlog).
+                response = StreamingHttpResponse(  # type: ignore[assignment]
                     self._single_rpc_sse_stream(rpc_response),
                     content_type="text/event-stream",
                 )
@@ -548,7 +554,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
         return self._apply_http_headers(response, protocol_version, session_id=session_id)
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         if getattr(request, "_mcp_auth_error", None) is not None:
             return _build_mcp_auth_expired_response()
         session_id = request.META.get("HTTP_MCP_SESSION_ID", "")
@@ -559,7 +565,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
             return Response({"detail": "MCP HTTP session not found."}, status=404)
         protocol_version = session_payload.get("protocol_version") or self._resolve_http_protocol_version(request)
 
-        def event_stream():
+        def event_stream() -> Any:
             try:
                 while True:
                     yield ": keepalive {}\n\n".format(int(time.time()))
@@ -573,7 +579,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
         return self._apply_http_headers(response, protocol_version, session_id=session_id)
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         if getattr(request, "_mcp_auth_error", None) is not None:
             return _build_mcp_auth_expired_response()
         session_id = request.META.get("HTTP_MCP_SESSION_ID", "")
@@ -587,7 +593,7 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
         return self._apply_http_headers(response, protocol_version, session_id=session_id)
 
     @never_cache
-    def options(self, request, *args, **kwargs):
+    def options(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
         response = HttpResponse(status=204)
         response["Access-Control-Allow-Origin"] = "*"
         response["Access-Control-Allow-Headers"] = "Cache-Control, Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id"
@@ -596,15 +602,15 @@ class MCPQueryHTTPView(MCPQueryRPCMixin, APIView):
         return response
 
     @staticmethod
-    def _request_accepts_sse(request):
+    def _request_accepts_sse(request: Any) -> bool:
         accept = smart_str(request.META.get("HTTP_ACCEPT", "")).lower()
         return "text/event-stream" in accept
 
     @staticmethod
-    def _single_rpc_sse_stream(rpc_response):
+    def _single_rpc_sse_stream(rpc_response: Any) -> Any:
         yield "event: message\n" + MCPQueryRPCMixin._format_sse_data(rpc_response)
 
-    def _resolve_http_protocol_version(self, request):
+    def _resolve_http_protocol_version(self, request: Any) -> str:
         version = request.META.get("HTTP_MCP_PROTOCOL_VERSION", "") or _MCP_HTTP_DEFAULT_PROTOCOL_VERSION
         if version not in _MCP_HTTP_PROTOCOL_VERSIONS:
             raise exceptions.ParseError("Unsupported MCP-Protocol-Version: {}".format(version))

--- a/console/views/message.py
+++ b/console/views/message.py
@@ -3,8 +3,10 @@
   Created on 18/5/5.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.message_service import msg_service
@@ -16,7 +18,7 @@ logger = logging.getLogger('default')
 
 class UserMessageView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询用户的站内信息
         ---
@@ -51,7 +53,7 @@ class UserMessageView(RegionTenantHeaderView):
         msg_type = request.GET.get("msg_type", None)
         page_num = int(request.GET.get("page_num", 1))
         page_size = int(request.GET.get("page_size", 5))
-        is_read = request.GET.get("is_read", None)
+        is_read: Any = request.GET.get("is_read", None)
         if is_read:
             is_read = bool(int(is_read))
         # 先同步数据
@@ -62,7 +64,7 @@ class UserMessageView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         将站内信息标记为已读或未读
         ---
@@ -103,7 +105,7 @@ class UserMessageView(RegionTenantHeaderView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除站内信
         ---

--- a/console/views/oauth.py
+++ b/console/views/oauth.py
@@ -2,6 +2,7 @@
 import os
 import json
 import logging
+from typing import Any
 from urllib.parse import urlsplit
 
 from console.exception.main import ServiceHandleException, AbortRequest
@@ -14,6 +15,7 @@ from console.views.base import (AlowAnyApiView, EnterpriseAdminView, JWTAuthApiV
 from console.models.main import OAuthServices
 from django.http import HttpResponseRedirect
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import Tenants
@@ -26,7 +28,7 @@ logger = logging.getLogger("default")
 
 
 class OauthType(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             data = list(support_oauth_type.keys())
         except Exception as e:
@@ -37,27 +39,32 @@ class OauthType(JWTAuthApiView):
 
 
 class OauthConfig(EnterpriseAdminView):
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = request.data.get("oauth_services")
-        enable = data.get("enable")
-        EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).update_config_enable_status(key="OAUTH_SERVICES", enable=enable)
+        # NOTE: request.data.get may return None; legacy assumes present (backlog).
+        enable = data.get("enable")  # type: ignore[union-attr]
+        # NOTE: user_id int AutoField (systemic str); request.user is User|AnonymousUser, auth guarantees user (backlog).
+        EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).update_config_enable_status(key="OAUTH_SERVICES", enable=enable)  # type: ignore[arg-type, union-attr]
         rst = {"data": {"bean": {"oauth_services": data}}}
         op = Operation.ENABLE if enable else Operation.DISABLE
         comment = operation_log_service.generate_generic_comment(
             operation=op, module=OperationModule.OAUTHCONNECT, module_name="")
+        # NOTE: enterprise_id nullable; create_enterprise_log takes str (systemic, backlog).
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(rst, status=status.HTTP_200_OK)
 
 
 class OauthService(EnterpriseAdminView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         all_services_list = []
-        eid = request.user.enterprise_id
-        service = oauth_repo.get_conosle_oauth_service(eid, self.user.user_id)
-        all_services = oauth_repo.get_all_oauth_services(eid, self.user.user_id)
+        # NOTE: request.user is User|AnonymousUser; auth guarantees authenticated user (backlog).
+        eid = request.user.enterprise_id  # type: ignore[union-attr]
+        # NOTE: user_id is int AutoField; repo signatures take str (systemic int-as-str, backlog).
+        service = oauth_repo.get_conosle_oauth_service(eid, self.user.user_id)  # type: ignore[arg-type]
+        all_services = oauth_repo.get_all_oauth_services(eid, self.user.user_id)  # type: ignore[arg-type]
         svc_ids = [svc.ID for svc in all_services]
-        user_oauth_list = oauth_user_repo.get_by_oauths_user_id(svc_ids, self.user.user_id)
+        user_oauth_list = oauth_user_repo.get_by_oauths_user_id(svc_ids, self.user.user_id)  # type: ignore[arg-type]
         user_oauth_dict = {uol.service_id: uol for uol in user_oauth_list}
         if all_services is not None:
             for l_service in all_services:
@@ -80,26 +87,30 @@ class OauthService(EnterpriseAdminView):
                     "is_git": l_service.is_git,
                     "authorize_url": authorize_url,
                     "enterprise_id": l_service.eid,
-                    "is_authenticated": user_oauth_dict.get(l_service.ID).is_authenticated if user_oauth_dict.get(l_service.ID) else False,
-                    "is_expired": user_oauth_dict.get(l_service.ID).is_expired if user_oauth_dict.get(l_service.ID) else False,
+                    # NOTE: dict.get may return None; ternary guards it but mypy can't narrow (backlog).
+                    "is_authenticated": user_oauth_dict.get(l_service.ID).is_authenticated if user_oauth_dict.get(l_service.ID) else False,  # type: ignore[union-attr]
+                    "is_expired": user_oauth_dict.get(l_service.ID).is_expired if user_oauth_dict.get(l_service.ID) else False,  # type: ignore[union-attr]
                 })
         rst = {"data": {"list": all_services_list}}
         return Response(rst, status=status.HTTP_200_OK)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         values = request.data.get("oauth_services")
         system = request.data.get("system")
-        eid = request.user.enterprise_id
+        eid = request.user.enterprise_id  # type: ignore[union-attr]
         try:
-            services = oauth_repo.create_or_update_console_oauth_services(values, eid, self.user.user_id, system)
+            services = oauth_repo.create_or_update_console_oauth_services(values, eid, self.user.user_id, system)  # type: ignore[arg-type]
         except Exception as e:
             logger.exception(e)
-            return Response({"msg": e.message}, status=status.HTTP_400_BAD_REQUEST)
-        service = oauth_repo.get_conosle_oauth_service(eid, self.user.user_id)
-        api = get_oauth_instance(service.oauth_type, service, None)
+            # NOTE: py2-era Exception.message; preserved for behavior compat (backlog).
+            return Response({"msg": e.message}, status=status.HTTP_400_BAD_REQUEST)  # type: ignore[attr-defined]
+        # NOTE: get_conosle_oauth_service may return None; legacy assumes present (backlog).
+        service = oauth_repo.get_conosle_oauth_service(eid, self.user.user_id)  # type: ignore[arg-type]
+        api = get_oauth_instance(service.oauth_type, service, None)  # type: ignore[union-attr]
         authorize_url = api.get_authorize_url()
         data = []
-        for service in services:
+        # NOTE: services may be None; legacy assumes iterable result (backlog).
+        for service in services:  # type: ignore[union-attr]
             data.append({
                 "service_id": service.ID,
                 "name": service.name,
@@ -121,12 +132,12 @@ class OauthService(EnterpriseAdminView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.UPDATE, module=OperationModule.OAUTHCONFIG, module_name="")
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(rst, status=status.HTTP_200_OK)
 
 
 class EnterpriseOauthService(EnterpriseAdminView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         all_services_list = []
         public_only = request.GET.get('system', 'false').lower() == 'true'
         if public_only:
@@ -135,13 +146,13 @@ class EnterpriseOauthService(EnterpriseAdminView):
         else:
             # Get both public services and user's private services
             public_services = oauth_repo.get_all_oauth_services_by_system(enterprise_id, True)
-            private_services = oauth_repo.get_all_oauth_services(enterprise_id, self.user.user_id)
+            private_services = oauth_repo.get_all_oauth_services(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
             # Combine both querysets
             all_services = public_services | private_services
         
         if all_services is not None:
             svc_ids = [svc.ID for svc in all_services]
-            user_oauth_list = [] if public_only else oauth_user_repo.get_by_oauths_user_id(svc_ids, self.user.user_id)
+            user_oauth_list = [] if public_only else oauth_user_repo.get_by_oauths_user_id(svc_ids, self.user.user_id)  # type: ignore[arg-type]
             user_oauth_dict = {uol.service_id: uol for uol in user_oauth_list}
             
             for l_service in all_services:
@@ -150,8 +161,9 @@ class EnterpriseOauthService(EnterpriseAdminView):
                 is_authenticated = False
                 is_expired = False
                 if not public_only and user_oauth_dict.get(l_service.ID):
-                    is_authenticated = user_oauth_dict.get(l_service.ID).is_authenticated
-                    is_expired = user_oauth_dict.get(l_service.ID).is_expired
+                    # NOTE: dict.get may return None; guard above, mypy can't narrow (backlog).
+                    is_authenticated = user_oauth_dict.get(l_service.ID).is_authenticated  # type: ignore[union-attr, assignment]
+                    is_expired = user_oauth_dict.get(l_service.ID).is_expired  # type: ignore[union-attr, assignment]
                 
                 all_services_list.append({
                     "service_id": l_service.ID,
@@ -177,9 +189,9 @@ class EnterpriseOauthService(EnterpriseAdminView):
         rst = {"data": {"list": all_services_list}}
         return Response(rst, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         values = request.data.get("oauth_services")
-        services = oauth_repo.create_or_update_oauth_services(values, enterprise_id, self.user.user_id)
+        services = oauth_repo.create_or_update_oauth_services(values, enterprise_id, self.user.user_id)  # type: ignore[arg-type]
 
         data = []
         for service in services:
@@ -206,12 +218,12 @@ class EnterpriseOauthService(EnterpriseAdminView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.UPDATE, module=OperationModule.OAUTHCONFIG, module_name="")
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(rst, status=status.HTTP_200_OK)
 
 
 class OauthServiceInfo(EnterpriseAdminView):
-    def delete(self, request, service_id, *args, **kwargs):
+    def delete(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             oauth_repo.delete_oauth_service(service_id)
             oauth_user_repo.delete_users_by_services_id(service_id)
@@ -224,7 +236,7 @@ class OauthServiceInfo(EnterpriseAdminView):
 
 
 class OAuthServiceRedirect(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         code = request.GET.get("code")
         state = request.GET.get("state")
         service_id = request.GET.get("service_id")
@@ -248,7 +260,8 @@ class OAuthServiceRedirect(AlowAnyApiView):
             return HttpResponseRedirect("/")
 
         try:
-            service = OAuthServices.objects.get(ID=service_id)
+            # NOTE: service_id from query params is str|None; ORM lookup expects str|int (backlog).
+            service = OAuthServices.objects.get(ID=service_id)  # type: ignore[misc]
         except OAuthServices.DoesNotExist:
             logger.error(f"OAuth service not found: {service_id}")
             return HttpResponseRedirect("/")
@@ -271,7 +284,7 @@ class OAuthServiceRedirect(AlowAnyApiView):
 
 
 class OAuthServerAuthorize(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         code = request.GET.get("code")
         service_id = request.GET.get("service_id")
         domain = request.GET.get("domain")
@@ -297,12 +310,13 @@ class OAuthServerAuthorize(AlowAnyApiView):
 
         home_split_url = None
         try:
-            oauth_service = OAuthServices.objects.get(ID=service_id)
+            oauth_service = OAuthServices.objects.get(ID=service_id)  # type: ignore[misc]
             if not oauth_service.enable:
                  raise ServiceHandleException(msg="OAuth service disabled", msg_show="该 OAuth 服务已被禁用")
             if oauth_service.oauth_type == "enterprisecenter" and domain:
                 home_split_url = urlsplit(oauth_service.home_url)
-                oauth_service.proxy_home_url = home_split_url.scheme + "://" + domain + home_split_url.path
+                # NOTE: proxy_home_url is a dynamic attr; urlsplit may yield bytes (legacy, backlog).
+                oauth_service.proxy_home_url = home_split_url.scheme + "://" + domain + home_split_url.path  # type: ignore[attr-defined, operator]
         except OAuthServices.DoesNotExist:
             logger.debug(f"OAuth service with ID {service_id} not found.")
             rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务, 请检查该服务是否存在且属于开启状态"}
@@ -329,17 +343,20 @@ class OAuthServerAuthorize(AlowAnyApiView):
             return Response(rst, status=status.HTTP_200_OK)
         if api.is_communication_oauth():
             logger.debug(oauth_user.enterprise_domain)
-            logger.debug(domain.split(".")[0])
-            logger.debug(home_split_url.netloc.split("."))
-            if oauth_user.enterprise_domain != domain.split(".")[0] and \
-                    domain.split(".")[0] != home_split_url.netloc.split(".")[0]:
+            # NOTE: domain from query params may be None; legacy assumes str (backlog).
+            logger.debug(domain.split(".")[0])  # type: ignore[union-attr]
+            # NOTE: home_split_url may be None / netloc may be bytes; legacy assumes str (backlog).
+            logger.debug(home_split_url.netloc.split("."))  # type: ignore[union-attr, arg-type]
+            if (oauth_user.enterprise_domain != domain.split(".")[0]  # type: ignore[union-attr]
+                    and domain.split(".")[0] != home_split_url.netloc.split(".")[0]):  # type: ignore[union-attr, arg-type]
                 raise ServiceHandleException(msg="Domain Inconsistent", msg_show="登录失败", status_code=401, error_code=10405)
             oauth_sev_user_service.get_or_create_user_and_enterprise(oauth_user)
-        return oauth_sev_user_service.set_oauth_user_relation(api, oauth_service, oauth_user, access_token, refresh_token, code)
+        # NOTE: code from query params may be None; set_oauth_user_relation takes str (backlog).
+        return oauth_sev_user_service.set_oauth_user_relation(api, oauth_service, oauth_user, access_token, refresh_token, code)  # type: ignore[arg-type]
 
 
 class OauthUserLogoutView(AlowAnyApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         client_id = parse_item(request, "client_id", required=True)
         client_secret = parse_item(request, "client_secret", required=True)
         user_id = parse_item(request, "user_id", required=True)
@@ -350,7 +367,8 @@ class OauthUserLogoutView(AlowAnyApiView):
         if oauth_service.client_secret != client_secret:
             raise AbortRequest("the requested client key does not match")
 
-        oauth_user = oauth_user_repo.get_by_oauth_user_id(oauth_service.ID, user_id)
+        # NOTE: ID is int AutoField; get_by_oauth_user_id takes str (systemic int-as-str, backlog).
+        oauth_user = oauth_user_repo.get_by_oauth_user_id(oauth_service.ID, user_id)  # type: ignore[arg-type]
 
         # Go to Oauth2 Server to check if the user has logged out
         api = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
@@ -362,14 +380,15 @@ class OauthUserLogoutView(AlowAnyApiView):
 
 
 class OAuthUserInfo(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         id = request.GET.get("id")
         code = request.GET.get("code")
         service_id = request.GET.get("service_id")
         if code is not None:
-            user_info = oauth_user_repo.get_user_oauth_by_code(code=code, service_id=service_id)
+            # NOTE: service_id from query params is str|None; repo expects str (backlog).
+            user_info = oauth_user_repo.get_user_oauth_by_code(code=code, service_id=service_id)  # type: ignore[arg-type]
         elif id is not None:
-            user_info = oauth_user_repo.get_user_oauth_by_id(id=id, service_id=service_id)
+            user_info = oauth_user_repo.get_user_oauth_by_id(id=id, service_id=service_id)  # type: ignore[arg-type]
         else:
             user_info = None
         if user_info:
@@ -388,12 +407,13 @@ class OAuthUserInfo(AlowAnyApiView):
             }
             rst = {"data": {"bean": {"user_info": data}}}
             return Response(rst, status=status.HTTP_200_OK)
-        rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务"}
+        # NOTE: rst reused with a differently-shaped dict literal; legacy value-type inference (backlog).
+        rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务"}  # type: ignore[dict-item]
         return Response(rst, status=status.HTTP_404_NOT_FOUND)
 
 
 class OAuthServerUserAuthorize(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         login_user = request.user
         code = request.data.get("code")
         service_id = request.data.get("service_id")
@@ -421,27 +441,30 @@ class OAuthServerUserAuthorize(JWTAuthApiView):
             rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务, 请检查该服务是否存在且属于开启状态"}
             return Response(rst, status=status.HTTP_200_OK)
         try:
-            api = get_oauth_instance(oauth_service.oauth_type, oauth_service, None)
+            # NOTE: get_oauth_services_by_service_id may return None; legacy assumes present (backlog).
+            api = get_oauth_instance(oauth_service.oauth_type, oauth_service, None)  # type: ignore[union-attr]
         except NoSupportOAuthType as e:
             logger.debug(e)
             rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务"}
             return Response(rst, status=status.HTTP_200_OK)
         try:
             # 只有 Gitea 需要 PKCE 的 code_verifier 参数
-            if oauth_service.oauth_type == 'gitea':
+            if oauth_service.oauth_type == 'gitea':  # type: ignore[union-attr]
                 user, access_token, refresh_token = api.get_user_info(code=code, code_verifier=code_verifier)
             else:
                 user, access_token, refresh_token = api.get_user_info(code=code)
         except Exception as e:
             logger.exception(e)
-            rst = {"data": {"bean": None}, "status": 404, "msg_show": e.message}
+            # NOTE: py2-era Exception.message; preserved for behavior compat (backlog).
+            rst = {"data": {"bean": None}, "status": 404, "msg_show": e.message}  # type: ignore[attr-defined]
             return Response(rst, status=status.HTTP_200_OK)
 
         user_name = user.name
         user_id = str(user.id)
         user_email = user.email
-        authenticated_user = oauth_user_repo.user_oauth_exists(service_id=service_id, oauth_user_id=user_id)
-        link_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=login_user.user_id)
+        # NOTE: service_id is str|None & login_user is User|AnonymousUser; legacy assumes str/user (backlog).
+        authenticated_user = oauth_user_repo.user_oauth_exists(service_id=service_id, oauth_user_id=user_id)  # type: ignore[arg-type]
+        link_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=login_user.user_id)  # type: ignore[arg-type, union-attr]
         if link_user is not None and link_user.oauth_user_id != user_id:
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "该用户已绑定其他账号"}
             return Response(rst, status=status.HTTP_200_OK)
@@ -455,7 +478,7 @@ class OAuthServerUserAuthorize(JWTAuthApiView):
             authenticated_user.code = code
             authenticated_user.is_authenticated = True
             authenticated_user.is_expired = True
-            authenticated_user.user_id = login_user.user_id
+            authenticated_user.user_id = login_user.user_id  # type: ignore[union-attr]
             authenticated_user.save()
             return Response(None, status=status.HTTP_200_OK)
         else:
@@ -463,7 +486,7 @@ class OAuthServerUserAuthorize(JWTAuthApiView):
                 oauth_user_id=user_id,
                 oauth_user_name=user_name,
                 oauth_user_email=user_email,
-                user_id=login_user.user_id,
+                user_id=login_user.user_id,  # type: ignore[union-attr]
                 code=code,
                 service_id=service_id,
                 access_token=access_token,
@@ -476,7 +499,7 @@ class OAuthServerUserAuthorize(JWTAuthApiView):
 
 
 class UserOAuthLink(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         oauth_user_id = str(request.data.get("oauth_user_id"))
         service_id = request.data.get("service_id")
         try:
@@ -485,9 +508,11 @@ class UserOAuthLink(JWTAuthApiView):
             logger.debug(e)
             rst = {"data": {"bean": None}, "status": 404, "msg_show": "未找到oauth服务, 请检查该服务是否存在且属于开启状态"}
             return Response(rst, status=status.HTTP_200_OK)
-        user_id = request.user.user_id
-        oauth_user = oauth_user_repo.user_oauth_exists(service_id=service_id, oauth_user_id=oauth_user_id)
-        link_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=user_id)
+        # NOTE: request.user is User|AnonymousUser; auth guarantees authenticated user (backlog).
+        user_id = request.user.user_id  # type: ignore[union-attr]
+        # NOTE: service_id is str|None; repo expects str (backlog).
+        oauth_user = oauth_user_repo.user_oauth_exists(service_id=service_id, oauth_user_id=oauth_user_id)  # type: ignore[arg-type]
+        link_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=user_id)  # type: ignore[arg-type]
         if link_user is not None and link_user.oauth_user_id != oauth_user_id:
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "绑定失败， 该用户已绑定其他账号"}
             return Response(rst, status=status.HTTP_200_OK)
@@ -502,7 +527,8 @@ class UserOAuthLink(JWTAuthApiView):
                 "is_expired": oauth_user.is_expired,
                 "is_link": True,
                 "service_id": service_id,
-                "oauth_type": oauth_service.oauth_type,
+                # NOTE: oauth_service may be None; legacy assumes present (backlog).
+                "oauth_type": oauth_service.oauth_type,  # type: ignore[union-attr]
             }
             rst = {"data": {"bean": data}, "status": 200, "msg_show": "绑定成功"}
             return Response(rst, status=status.HTTP_200_OK)
@@ -512,8 +538,8 @@ class UserOAuthLink(JWTAuthApiView):
 
 
 class OAuthGitUserRepositories(JWTAuthApiView):
-    def get(self, request, service_id, *args, **kwargs):
-        user_id = request.user.user_id
+    def get(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
+        user_id = request.user.user_id  # type: ignore[union-attr]
         page = request.GET.get("page", 1)
         search = request.GET.get("search", '')
         try:
@@ -526,13 +552,15 @@ class OAuthGitUserRepositories(JWTAuthApiView):
         if oauth_user is None:
             rst = {"data": {"bean": {"repositories": []}}, "status": 400, "msg_show": "未成功获取第三方用户信息"}
             return Response(rst, status=status.HTTP_200_OK)
-        service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+        # NOTE: oauth_service may be None; legacy assumes present (backlog).
+        service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
         if not service.is_git_oauth():
             rst = {"data": {"bean": {"repositories": []}}, "status": 400, "msg_show": "该OAuth服务不是代码仓库类型"}
             return Response(rst, status=status.HTTP_200_OK)
         try:
             if len(search) > 0 and search is not None:
-                true_search = oauth_user.oauth_user_name + '/' + search.split("/")[-1]
+                # NOTE: oauth_user_name may be None; legacy assumes str (backlog).
+                true_search = oauth_user.oauth_user_name + '/' + search.split("/")[-1]  # type: ignore[operator]
                 data, total = service.search_repos(true_search, page=page)
             else:
                 data, total = service.get_repos(page=page)
@@ -542,8 +570,8 @@ class OAuthGitUserRepositories(JWTAuthApiView):
                         "repositories": data,
                         "user_id": user_id,
                         "service_id": service_id,
-                        "service_type": oauth_service.oauth_type,
-                        "service_name": oauth_service.name,
+                        "service_type": oauth_service.oauth_type,  # type: ignore[union-attr]
+                        "service_name": oauth_service.name,  # type: ignore[union-attr]
                         "total": total
                     }
                 }
@@ -556,9 +584,9 @@ class OAuthGitUserRepositories(JWTAuthApiView):
 
 
 class OAuthGitUserRepository(JWTAuthApiView):
-    def get(self, request, service_id, path, name, *args, **kwargs):
+    def get(self, request: Request, service_id: str, path: str, name: str, *args: Any, **kwargs: Any) -> Response:
         full_name = '/'.join([path, name])
-        user_id = request.user.user_id
+        user_id = request.user.user_id  # type: ignore[union-attr]
         try:
             oauth_service = oauth_repo.get_oauth_services_by_service_id(service_id=service_id)
             oauth_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=user_id)
@@ -570,7 +598,8 @@ class OAuthGitUserRepository(JWTAuthApiView):
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未成功获取第三方用户信息"}
             return Response(rst, status=status.HTTP_200_OK)
         try:
-            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+            # NOTE: oauth_service may be None; legacy assumes present (backlog).
+            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
         except Exception as e:
             logger.debug(e)
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务"}
@@ -590,8 +619,8 @@ class OAuthGitUserRepository(JWTAuthApiView):
                         "repositories": repo_list,
                         "user_id": user_id,
                         "service_id": service_id,
-                        "service_type": oauth_service.oauth_type,
-                        "service_name": oauth_service.name,
+                        "service_type": oauth_service.oauth_type,  # type: ignore[union-attr]
+                        "service_name": oauth_service.name,  # type: ignore[union-attr]
                         "total": 10
                     }
                 }
@@ -604,8 +633,8 @@ class OAuthGitUserRepository(JWTAuthApiView):
 
 
 class OAuthGitUserRepositoryBranches(JWTAuthApiView):
-    def get(self, request, service_id, *args, **kwargs):
-        user_id = request.user.user_id
+    def get(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
+        user_id = request.user.user_id  # type: ignore[union-attr]
         type = request.GET.get("type")
         full_name = request.GET.get("full_name")
         try:
@@ -619,7 +648,8 @@ class OAuthGitUserRepositoryBranches(JWTAuthApiView):
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未成功获取第三方用户信息"}
             return Response(rst, status=status.HTTP_200_OK)
         try:
-            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+            # NOTE: oauth_service may be None; legacy assumes present (backlog).
+            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
         except Exception as e:
             logger.debug(e)
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务"}
@@ -638,12 +668,12 @@ class OAuthGitUserRepositoryBranches(JWTAuthApiView):
 
 
 class OAuthGitCodeDetection(JWTAuthApiView):
-    def post(self, request, service_id, *args, **kwargs):
+    def post(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         region = request.data.get("region_name")
         tenant_name = request.data.get("tenant_name", None)
         git_url = request.data.get("project_url")
         version = request.data.get("version")
-        user_id = request.user.user_id
+        user_id = request.user.user_id  # type: ignore[union-attr]
         try:
             oauth_service = oauth_repo.get_oauth_services_by_service_id(service_id)
             oauth_user = oauth_user_repo.get_user_oauth_by_user_id(service_id=service_id, user_id=user_id)
@@ -656,7 +686,8 @@ class OAuthGitCodeDetection(JWTAuthApiView):
             return Response(rst, status=status.HTTP_200_OK)
 
         try:
-            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)
+            # NOTE: oauth_service may be None; legacy assumes present (backlog).
+            service = get_oauth_instance(oauth_service.oauth_type, oauth_service, oauth_user)  # type: ignore[union-attr]
         except Exception as e:
             logger.debug(e)
             rst = {"data": {"bean": None}, "status": 400, "msg_show": "未找到OAuth服务"}
@@ -680,7 +711,7 @@ class OAuthGitCodeDetection(JWTAuthApiView):
         }
 
         source_body = json.dumps(sb)
-        body = dict()
+        body: dict = dict()
         body["tenant_id"] = tenant.tenant_id
         body["source_type"] = "sourcecode"
         body["namespace"] = tenant.namespace
@@ -688,18 +719,20 @@ class OAuthGitCodeDetection(JWTAuthApiView):
         body["password"] = None
         body["source_body"] = source_body
         try:
-            res, body = region_api.service_source_check(region, tenant.tenant_name, body)
+            # NOTE: region from request.data may be None & region result may be None; legacy assumes present (backlog).
+            res, body = region_api.service_source_check(region, tenant.tenant_name, body)  # type: ignore[arg-type, assignment]
             return Response({"data": {"data": body}}, status=status.HTTP_200_OK)
         except (region_api.CallApiError, ServiceHandleException) as e:
             logger.debug(e)
             raise ServiceHandleException(msg="region error", msg_show="访问数据中心失败")
 
-    def get(self, request, service_id):
+    def get(self, request: Request, service_id: str) -> Response:
         region = request.GET.get("region")
         tenant_name = request.GET.get("tenant_name")
         check_uuid = request.GET.get("check_uuid")
         try:
-            res, body = region_api.get_service_check_info(region, tenant_name, check_uuid)
+            # NOTE: query params are str|None; region client expects str (backlog).
+            res, body = region_api.get_service_check_info(region, tenant_name, check_uuid)  # type: ignore[arg-type]
             return Response({"data": body}, status=status.HTTP_200_OK)
         except (region_api.CallApiError, ServiceHandleException) as e:
             logger.debug(e)
@@ -707,15 +740,16 @@ class OAuthGitCodeDetection(JWTAuthApiView):
 
 
 class OverScore(EnterpriseAdminView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # 获取超分比例配置
-        ss_config = EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).get_config_by_key(
+        # NOTE: user_id int AutoField; EnterpriseConfigService takes str (systemic int-as-str, backlog).
+        ss_config = EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).get_config_by_key(  # type: ignore[arg-type, union-attr]
             key="OVER_SCORE")
         over_score_rate = {"CPU": 1.0, "MEMORY": 1.0}
 
         # 如果配置不存在，则初始化
         if not ss_config:
-            EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).add_config(
+            EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).add_config(  # type: ignore[arg-type, union-attr]
                 key="OVER_SCORE",
                 default_value=json.dumps({"CPU": 1.0, "MEMORY": 1.0}),
                 type="json",
@@ -724,7 +758,8 @@ class OverScore(EnterpriseAdminView):
             )
             region_api.set_over_score_rate({"over_score_rate": json.dumps(over_score_rate)})
         else:
-            over_score_rate = json.loads(ss_config.value)
+            # NOTE: ss_config.value may be None; legacy assumes str (backlog).
+            over_score_rate = json.loads(ss_config.value)  # type: ignore[arg-type]
 
         # 返回规范化结构
         rst = {
@@ -739,12 +774,12 @@ class OverScore(EnterpriseAdminView):
         }
         return Response(rst, status=status.HTTP_200_OK)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # 获取用户提交的新超分比例
         over_score_rate = request.data.get("over_score_rate")
 
         # 更新超分比例配置
-        EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).update_config_value(
+        EnterpriseConfigService(request.user.enterprise_id, self.user.user_id).update_config_value(  # type: ignore[arg-type, union-attr]
             key="OVER_SCORE",
             value=over_score_rate
         )
@@ -756,7 +791,7 @@ class OverScore(EnterpriseAdminView):
             "msg_show": "更新超分比例成功",
             "data": {
                 "bean": {
-                    "over_score_rate": json.loads(over_score_rate)
+                    "over_score_rate": json.loads(over_score_rate)  # type: ignore[arg-type]
                 }
             }
         }

--- a/console/views/operation_log.py
+++ b/console/views/operation_log.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from www.utils.return_message import general_message
@@ -15,7 +17,7 @@ logger = logging.getLogger("default")
 
 
 class OperationLogView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         params = get_query_params(request)
         logs, total = operation_log_service.list(enterprise_id, params)
         logs = extend_user_info(enterprise_id, logs)
@@ -24,24 +26,27 @@ class OperationLogView(JWTAuthApiView):
 
 
 class TeamOperationLogView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         params = get_query_params(request)
-        logs, total = operation_log_service.list_team_logs(self.user.enterprise_id, self.tenant, params)
-        logs = extend_user_info(self.user.enterprise_id, logs)
+        # NOTE: enterprise_id is nullable but callees expect str (arg-type backlog).
+        logs, total = operation_log_service.list_team_logs(
+            self.user.enterprise_id, self.tenant, params)  # type: ignore[arg-type]
+        logs = extend_user_info(self.user.enterprise_id, logs)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", list=logs, total=total)
         return Response(result, status=result["code"])
 
 
 class AppOperationLogView(ApplicationView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         params = get_query_params(request)
-        logs, total = operation_log_service.list_app_logs(self.user.enterprise_id, self.tenant, self.app, params)
-        logs = extend_user_info(self.user.enterprise_id, logs)
+        logs, total = operation_log_service.list_app_logs(
+            self.user.enterprise_id, self.tenant, self.app, params)  # type: ignore[arg-type]
+        logs = extend_user_info(self.user.enterprise_id, logs)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", list=logs, total=total)
         return Response(result, status=result["code"])
 
 
-def get_query_params(request):
+def get_query_params(request: Request) -> dict:
     params = {
         "start_time": request.GET.get("start_time", None),
         "end_time": request.GET.get("end_time", None),
@@ -56,7 +61,7 @@ def get_query_params(request):
     return params
 
 
-def extend_user_info(enterprise_id, logs):
+def extend_user_info(enterprise_id: str, logs: Any) -> Any:
     if not logs:
         return
     for log in logs:

--- a/console/views/perms.py
+++ b/console/views/perms.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.models.main import EnterpriseUserPerm
@@ -20,79 +22,87 @@ logger = logging.getLogger("default")
 
 
 class PermsInfoLView(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         tenant_id = request.GET.get("tenant_id", None)
-        perms = perm_services.get_all_perms(tenant_id)
+        # NOTE: GET param is Optional; service expects str (legacy mismatch, backlog).
+        perms = perm_services.get_all_perms(tenant_id)  # type: ignore[arg-type]
         result = general_message(200, None, None, bean=perms)
         return Response(result, status=200)
 
 
 class TeamRolesLCView(TenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         roles = role_kind_services.get_roles("team", self.tenant.tenant_id, with_default=True)
         result = general_message(200, "success", None, list=roles.values("name", "ID"))
         return Response(result, status=200)
 
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
         tenant = team_services.get_tenant(team_name)
         regions = region_repo.get_region_by_tenant_name(team_name)
-        role = role_kind_services.create_role("team", self.tenant.tenant_id, name)
+        # NOTE: request.data.get returns Optional; service expects str (legacy mismatch, backlog).
+        role = role_kind_services.create_role("team", self.tenant.tenant_id, name)  # type: ignore[arg-type]
         result = general_message(200, "success", "创建角色成功", bean=role.to_dict())
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=tenant.tenant_alias,
+            # NOTE: model alias/name fields are nullable; service expects str (systemic, backlog).
+            module_name=tenant.tenant_alias,  # type: ignore[arg-type]
             region=regions[0].region_name if regions else "",
             team_name=tenant.tenant_name,
             suffix=" 中创建了角色 {}".format(name))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=tenant.tenant_name)
+            # NOTE: enterprise_id is nullable; service expects str (systemic, backlog).
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=tenant.tenant_name)
         return Response(result, status=200)
 
 
 class TeamRolesRUDView(RegionTenantHeaderView):
-    def get(self, request, team_name, role_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, role_id: str, *args: Any, **kwargs: Any) -> Response:
         role = role_kind_services.get_role_by_id("team", self.tenant.tenant_id, role_id, with_default=True)
-        data = role.to_dict()
+        # NOTE: get_role_by_id may return None; legacy code calls attrs directly (backlog).
+        data = role.to_dict()  # type: ignore[union-attr]
         del data["kind"]
         del data["kind_id"]
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
-    def put(self, request, team_name, role_id, *args, **kwargs):
+    def put(self, request: Request, team_name: str, role_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
-        role = role_kind_services.update_role("team", self.tenant.tenant_id, role_id, name)
+        role = role_kind_services.update_role("team", self.tenant.tenant_id, role_id, name)  # type: ignore[arg-type]
         data = role.to_dict()
         del data["kind"]
         del data["kind_id"]
         result = general_message(200, "success", "更新角色成功", bean=data)
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中编辑了角色 {}".format(role.name))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=200)
 
-    def delete(self, request, team_name, role_id, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, role_id: str, *args: Any, **kwargs: Any) -> Response:
         role = role_kind_services.get_role_by_id("team", self.tenant.tenant_id, role_id)
         role_kind_services.delete_role("team", self.tenant.tenant_id, role_id)
         result = general_message(200, "success", "删除角色成功")
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
-            suffix=" 中删除了角色 {}".format(role.name))
+            suffix=" 中删除了角色 {}".format(role.name))  # type: ignore[union-attr]
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=200)
 
 
 class TeamRolesPermsLView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         roles = role_kind_services.get_roles("team", self.tenant.tenant_id, with_default=True)
         data = role_perm_service.get_roles_perms(roles, kind="team")
         result = general_message(200, "success", None, list=data)
@@ -100,23 +110,24 @@ class TeamRolesPermsLView(RegionTenantHeaderView):
 
 
 class TeamRolePermsRUDView(RegionTenantHeaderView):
-    def get(self, request, team_name, role_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, role_id: str, *args: Any, **kwargs: Any) -> Response:
         role = role_kind_services.get_role_by_id("team", self.tenant.tenant_id, role_id, with_default=True)
         data = role_perm_service.get_role_perms(role, kind="team", tenant_id=self.tenant.tenant_id)
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
-    def put(self, request, team_name, role_id, *args, **kwargs):
+    def put(self, request: Request, team_name: str, role_id: str, *args: Any, **kwargs: Any) -> Response:
         perms_model = request.data.get("permissions")
         role = role_kind_services.get_role_by_id("team", self.tenant.tenant_id, role_id, with_default=True)
-        role_perm_service.update_role_perms(role.ID, perms_model, kind="team")
+        # NOTE: role may be None and ID is int AutoField; service expects str (systemic, backlog).
+        role_perm_service.update_role_perms(role.ID, perms_model, kind="team")  # type: ignore[union-attr,arg-type]
         data = role_perm_service.get_role_perms(role, kind="team", tenant_id=self.tenant.tenant_id)
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
 
 class TeamUsersRolesLView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         # 获取团队所有用户
         team_users = team_services.get_team_users(self.tenant)
         
@@ -140,30 +151,33 @@ class TeamUsersRolesLView(RegionTenantHeaderView):
 
 
 class TeamUserRolesRUDView(TenantHeaderView):
-    def get(self, request, team_name, user_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         team_users = team_services.get_team_users(self.tenant)
         user = team_users.filter(user_id=user_id).first()
         data = user_kind_role_service.get_user_roles(kind="team", kind_id=self.tenant.tenant_id, user=user)
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
-    def put(self, request, team_name, user_id, *args, **kwargs):
+    def put(self, request: Request, team_name: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         roles = request.data.get("roles")
         team_users = team_services.get_team_users(self.tenant)
         user = team_users.filter(user_id=user_id).first()
-        user_kind_role_service.update_user_roles(kind="team", kind_id=self.tenant.tenant_id, user=user, role_ids=roles)
+        # NOTE: roles is Optional; service expects list[int] (legacy mismatch, backlog).
+        user_kind_role_service.update_user_roles(kind="team", kind_id=self.tenant.tenant_id, user=user,
+                                                 role_ids=roles)  # type: ignore[arg-type]
         data = user_kind_role_service.get_user_roles(kind="team", kind_id=self.tenant.tenant_id, user=user)
         result = general_message(200, "success", None, bean=data)
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             suffix=" 中修改了用户 {} 的角色".format(user.get_name()))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=200)
 
-    def delete(self, request, team_name, user_id, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         team_users = team_services.get_team_users(self.tenant)
         user = team_users.filter(user_id=user_id).first()
         user_kind_role_service.delete_user_roles(kind="team", kind_id=self.tenant.tenant_id, user=user)
@@ -173,7 +187,7 @@ class TeamUserRolesRUDView(TenantHeaderView):
 
 
 class TeamUserPermsLView(RegionTenantHeaderView):
-    def get(self, request, team_name, user_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         team_users = team_services.get_team_users(self.tenant)
         user = team_users.filter(user_id=user_id).first()
         data = user_kind_perm_service.get_user_perms(

--- a/console/views/platform_plugin.py
+++ b/console/views/platform_plugin.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import ServiceHandleException
@@ -12,7 +14,7 @@ logger = logging.getLogger("default")
 
 
 class PlatformPluginLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             plugins = platform_plugin_service.list_platform_plugins(enterprise_id, region_name)
             result = general_message(200, "success", "查询成功", list=plugins)
@@ -24,7 +26,8 @@ class PlatformPluginLView(JWTAuthApiView):
 
 
 class PlatformPluginInstallView(JWTAuthApiView):
-    def post(self, request, enterprise_id, region_name, plugin_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_name: str, plugin_id: str, *args: Any,
+             **kwargs: Any) -> Response:
         try:
             data = platform_plugin_service.install_platform_plugin(
                 enterprise_id, region_name, plugin_id, self.user)

--- a/console/views/platform_resources/cluster.py
+++ b/console/views/platform_resources/cluster.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
+from typing import Any, Optional
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.models.main import ConsoleSysConfig
@@ -14,68 +16,68 @@ _STORAGE_CONFIG_KEY = "default_storage_class_{region}"
 
 
 class PlatformResourceTypesView(EnterpriseAdminView):
-    def get(self, request, eid, region, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.get_cluster_resource(region, "platform-resources/types")
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class PlatformResourcesView(EnterpriseAdminView):
-    def get(self, request, eid, region, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_cluster_resource(region, "platform-resources", params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def post(self, request, eid, region, *args, **kwargs):
+    def post(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.post_cluster_resource(region, "platform-resources", request.body, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class PlatformResourceDetailView(EnterpriseAdminView):
-    def get(self, request, eid, region, name, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_cluster_resource(region, "platform-resources/{}".format(name), params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def put(self, request, eid, region, name, *args, **kwargs):
+    def put(self, request: Request, eid: str, region: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.put_cluster_resource(region, "platform-resources/{}".format(name), request.body, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def delete(self, request, eid, region, name, *args, **kwargs):
+    def delete(self, request: Request, eid: str, region: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         region_api.delete_cluster_resource(region, "platform-resources/{}".format(name), params=params)
         return Response(general_message(200, "success", "删除成功"))
 
 
 class StorageClassesView(EnterpriseAdminView):
-    def get(self, request, eid, region, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.get_cluster_resource(region, "storageclasses")
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def post(self, request, eid, region, *args, **kwargs):
+    def post(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.post_cluster_resource(region, "storageclasses", request.body)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class StorageClassDetailView(EnterpriseAdminView):
-    def delete(self, request, eid, region, name, *args, **kwargs):
+    def delete(self, request: Request, eid: str, region: str, name: str, *args: Any, **kwargs: Any) -> Response:
         region_api.delete_cluster_resource(region, "storageclasses/{}".format(name))
         return Response(general_message(200, "success", "删除成功"))
 
 
 class PersistentVolumesView(EnterpriseAdminView):
-    def get(self, request, eid, region, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.get_cluster_resource(region, "persistentvolumes")
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def post(self, request, eid, region, *args, **kwargs):
+    def post(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.post_cluster_resource(region, "persistentvolumes", request.body)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class PersistentVolumeDetailView(EnterpriseAdminView):
-    def delete(self, request, eid, region, name, *args, **kwargs):
+    def delete(self, request: Request, eid: str, region: str, name: str, *args: Any, **kwargs: Any) -> Response:
         region_api.delete_cluster_resource(region, "persistentvolumes/{}".format(name))
         return Response(general_message(200, "success", "删除成功"))
 
@@ -86,14 +88,14 @@ class StorageConfigView(EnterpriseAdminView):
     PUT  — 更新默认存储类，持久化到 ConsoleSysConfig
     """
 
-    def _config_key(self, region):
+    def _config_key(self, region: str) -> str:
         return _STORAGE_CONFIG_KEY.format(region=region)
 
-    def _get_sc_detail(self, region, sc_name):
+    def _get_sc_detail(self, region: str, sc_name: str) -> Optional[dict]:
         """从 K8s 实时获取指定 StorageClass 的详情，失败时返回 None"""
         try:
             res, data = region_api.get_cluster_resource(region, "storageclasses")
-            sc_list = (data.get("bean") or {}).get("list", [])
+            sc_list = (data.get("bean") or {}).get("list", [])  # type: ignore[union-attr]
             for sc in sc_list:
                 if sc.get("name") == sc_name:
                     return sc
@@ -101,7 +103,7 @@ class StorageConfigView(EnterpriseAdminView):
             pass
         return None
 
-    def get(self, request, eid, region, *args, **kwargs):
+    def get(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         key = self._config_key(region)
         cfg = ConsoleSysConfig.objects.filter(key=key, enterprise_id=eid).first()
         default_sc = cfg.value if cfg else None
@@ -114,7 +116,7 @@ class StorageConfigView(EnterpriseAdminView):
         }
         return Response(general_message(200, "success", "OK", bean=bean))
 
-    def put(self, request, eid, region, *args, **kwargs):
+    def put(self, request: Request, eid: str, region: str, *args: Any, **kwargs: Any) -> Response:
         try:
             body = json.loads(request.body)
         except (ValueError, TypeError):

--- a/console/views/platform_settings.py
+++ b/console/views/platform_settings.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from typing import Any
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.views.base import EnterpriseAdminView, JWTAuthApiView
@@ -7,7 +9,7 @@ from www.models.main import TenantEnterprise
 
 
 class PlatformSettingsView(JWTAuthApiView):
-    def get(self, request, eid, *args, **kwargs):
+    def get(self, request: Request, eid: str, *args: Any, **kwargs: Any) -> Response:
         try:
             enterprise = TenantEnterprise.objects.get(enterprise_id=eid)
         except TenantEnterprise.DoesNotExist:
@@ -19,7 +21,7 @@ class PlatformSettingsView(JWTAuthApiView):
 
 
 class PlatformSettingsUpdateView(EnterpriseAdminView):
-    def put(self, request, eid, *args, **kwargs):
+    def put(self, request: Request, eid: str, *args: Any, **kwargs: Any) -> Response:
         try:
             enterprise = TenantEnterprise.objects.get(enterprise_id=eid)
         except TenantEnterprise.DoesNotExist:

--- a/console/views/plugin/base.py
+++ b/console/views/plugin/base.py
@@ -2,6 +2,9 @@
 """
   Created on 18/3/4.
 """
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import BusinessException
@@ -14,12 +17,15 @@ from www.utils.return_message import general_message
 
 
 class PluginBaseView(RegionTenantHeaderView):
-    def __init__(self, *args, **kwargs):
-        super(PluginBaseView, self).__init__(*args, **kwargs)
-        self.plugin = None
-        self.plugin_version = None
+    plugin: TenantPlugin
+    plugin_version: PluginBuildVersion
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super(PluginBaseView, self).__init__(*args, **kwargs)
+        self.plugin = None  # type: ignore[assignment]
+        self.plugin_version = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(PluginBaseView, self).initial(request, *args, **kwargs)
         plugin_id = kwargs.get("plugin_id", None)
         if not plugin_id:
@@ -29,7 +35,8 @@ class PluginBaseView(RegionTenantHeaderView):
         except TenantPlugin.DoesNotExist:
             raise BusinessException(Response(general_message(404, "plugin not found", "插件不存在"), status=404))
 
-        self.plugin = tenant_plugin
+        # NOTE: plugin_repo.get_by_plugin_id may return None; backlog
+        self.plugin = tenant_plugin  # type: ignore[assignment]
         if self.plugin.tenant_id != self.tenant.tenant_id:
             team_info = Tenants.objects.filter(tenant_id=self.plugin.tenant_id)
             if team_info:
@@ -47,7 +54,8 @@ class PluginBaseView(RegionTenantHeaderView):
 
         build_version = kwargs.get("build_version", None)
         if build_version:
-            plugin_build_version = PluginBuildVersion.objects.filter(
+            # NOTE: model lacks objects stub
+            plugin_build_version = PluginBuildVersion.objects.filter(  # type: ignore[attr-defined]
                 tenant_id=self.tenant.tenant_id, plugin_id=plugin_id, build_version=build_version)
             if plugin_build_version:
                 self.plugin_version = plugin_build_version[0]
@@ -58,5 +66,5 @@ class PluginBaseView(RegionTenantHeaderView):
                                         "当前版本插件不存在"),
                         status=404))
 
-    def initial_header_info(self, request):
+    def initial_header_info(self, request: Request) -> None:
         pass

--- a/console/views/plugin/plugin_config.py
+++ b/console/views/plugin/plugin_config.py
@@ -3,8 +3,10 @@
   Created on 18/3/5.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
@@ -19,7 +21,7 @@ logger = logging.getLogger("default")
 
 class ConfigPluginManageView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取某个插件的配置信息
         ---
@@ -50,7 +52,7 @@ class ConfigPluginManageView(PluginBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改插件配置信息
         ---
@@ -83,50 +85,57 @@ class ConfigPluginManageView(PluginBaseView):
         config_name = config.get("config_name")
         config_group_pk = config.get("ID")
         modify_type = config.get("modify_type", False)
-        old_config = plugin_config_service.get_config_group_by_pk(config_group_pk)
-        old_information = plugin_config_service.json_config_group(old_config)
+        old_config = plugin_config_service.get_config_group_by_pk(config_group_pk)  # type: ignore[arg-type]
+        old_information = plugin_config_service.json_config_group(old_config)  # type: ignore[arg-type]
         config_groups = plugin_config_service.get_config_group(self.plugin_version.plugin_id,
                                                                self.plugin_version.build_version).exclude(pk=config_group_pk)
-        is_pass, msg = plugin_config_service.check_group_config(service_meta_type, injection, config_groups)
+        is_pass, msg = plugin_config_service.check_group_config(
+            service_meta_type, injection, config_groups)  # type: ignore[arg-type]
 
         if not is_pass:
             return Response(general_message(400, "param error", msg), status=400)
-        config_group = plugin_config_service.get_config_group_by_pk(config_group_pk)
-        old_meta_type = config_group.service_meta_type
-        plugin_config_service.update_config_group_by_pk(config_group_pk, config_name, service_meta_type, injection)
+        config_group = plugin_config_service.get_config_group_by_pk(config_group_pk)  # type: ignore[arg-type]
+        # NOTE: config.get / get_config_group_by_pk may yield None; backlog
+        old_meta_type = config_group.service_meta_type  # type: ignore[union-attr]
+        plugin_config_service.update_config_group_by_pk(
+            config_group_pk, config_name, service_meta_type, injection)  # type: ignore[arg-type]
 
         # 删除原有配置项
         plugin_config_service.delet_config_items(self.plugin_version.plugin_id, self.plugin_version.build_version,
                                                  old_meta_type)
         options = config.get("options")
         if modify_type and injection == "plugin_storage":
-            plugin_config_service.delete_config_group_by_meta_type(config_group.plugin_id, config_group.build_version,
-                                                                   config_group.service_meta_type)
+            plugin_config_service.delete_config_group_by_meta_type(
+                config_group.plugin_id,  # type: ignore[union-attr]
+                config_group.build_version,  # type: ignore[union-attr]
+                config_group.service_meta_type)  # type: ignore[union-attr]
         else:
-            plugin_config_service.create_config_items(self.plugin_version.plugin_id, self.plugin_version.build_version,
-                                                      service_meta_type, *options)
+            plugin_config_service.create_config_items(
+                self.plugin_version.plugin_id, self.plugin_version.build_version,
+                service_meta_type,  # type: ignore[arg-type]
+                *options)  # type: ignore[misc]
         result = general_message(200, "success", "修改成功")
         plugin_name = operation_log_service.process_plugin_name(self.plugin.plugin_alias, self.response_region,
                                                                 self.tenant.tenant_name, self.plugin.plugin_id)
-        new_config = plugin_config_service.get_config_group_by_pk(config_group_pk)
-        new_information = plugin_config_service.json_config_group(new_config)
+        new_config = plugin_config_service.get_config_group_by_pk(config_group_pk)  # type: ignore[arg-type]
+        new_information = plugin_config_service.json_config_group(new_config)  # type: ignore[arg-type]
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中编辑了插件 {} 的配置组 {}".format(plugin_name, config.get("config_name", "")))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             old_information=old_information,
             new_information=new_information)
         return Response(result, status=result["code"])
 
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         添加插件配置信息
         ---
@@ -157,15 +166,17 @@ class ConfigPluginManageView(PluginBaseView):
         injection = config.get("injection")
         service_meta_type = config.get("service_meta_type")
         config_groups = plugin_config_service.get_config_group(self.plugin_version.plugin_id, self.plugin_version.build_version)
-        is_pass, msg = plugin_config_service.check_group_config(service_meta_type, injection, config_groups)
+        is_pass, msg = plugin_config_service.check_group_config(
+            service_meta_type, injection, config_groups)  # type: ignore[arg-type]
 
         if not is_pass:
             return Response(general_message(400, "param error", msg), status=400)
         create_data = [config]
         new_information = ""
         if modify_type and injection == "plugin_storage":
-            plugin_config_service.create_config_items(self.plugin_version.plugin_id, self.plugin_version.build_version,
-                                                      service_meta_type, config["options"][0])
+            plugin_config_service.create_config_items(
+                self.plugin_version.plugin_id, self.plugin_version.build_version,
+                service_meta_type, config["options"][0])  # type: ignore[arg-type]
         else:
             new_config = plugin_config_service.create_config_groups(self.plugin_version.plugin_id, self.plugin_version.build_version,
                                                        create_data)
@@ -176,20 +187,20 @@ class ConfigPluginManageView(PluginBaseView):
                                                                 self.tenant.tenant_name, self.plugin.plugin_id)
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中添加了插件 {} 的配置组 {}".format(plugin_name, config.get("config_name", "")))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             new_information=new_information)
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除插件配置信息
         ---
@@ -224,9 +235,11 @@ class ConfigPluginManageView(PluginBaseView):
             return Response(general_message(404, "config group not exist", "配置组不存在"), status=404)
         plugin_config_service.delete_config_group_by_meta_type(config_group.plugin_id, config_group.build_version,
                                                                config_group.service_meta_type)
-        old_config = plugin_config_service.delete_config_group_by_meta_type(config_group.plugin_id, config_group.build_version,
-                                                                            config_group.service_meta_type)
-        old_information = plugin_config_service.json_config_group(old_config)
+        # NOTE: delete_config_group_by_meta_type returns None; old_config is always None (latent bug)
+        old_config = plugin_config_service.delete_config_group_by_meta_type(
+            config_group.plugin_id, config_group.build_version,
+            config_group.service_meta_type)  # type: ignore[func-returns-value]
+        old_information = plugin_config_service.json_config_group(old_config)  # type: ignore[arg-type]
 
         result = general_message(200, "success", "删除成功")
 
@@ -234,14 +247,14 @@ class ConfigPluginManageView(PluginBaseView):
                                                                 self.tenant.tenant_name, self.plugin.plugin_id)
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中删除了插件 {} 的配置组 {}".format(plugin_name, config_group.config_name))
         operation_log_service.create_team_log(
             user=self.user,
             comment=comment,
-            enterprise_id=self.user.enterprise_id,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
             team_name=self.tenant.tenant_name,
             old_information=old_information)
         return Response(result, status=result["code"])
@@ -249,7 +262,7 @@ class ConfigPluginManageView(PluginBaseView):
 
 class ConfigPreviewView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取某个插件某个版本的预览信息
         ---
@@ -278,7 +291,7 @@ class ConfigPreviewView(PluginBaseView):
         mysql_id = "mysql_service_id"
 
         config_groups = plugin_config_service.get_config_group(self.plugin_version.plugin_id, self.plugin_version.build_version)
-        all_config_group = []
+        all_config_group: list = []
         base_ports = []
         base_services = []
         base_normal = {}
@@ -293,7 +306,7 @@ class ConfigPreviewView(PluginBaseView):
 
             if config_group.service_meta_type == PluginMetaType.UPSTREAM_PORT:
                 for port in wp_ports:
-                    base_port = {}
+                    base_port: dict = {}
                     base_port["service_alias"] = wordpress_alias
                     base_port["service_id"] = wp_id
                     base_port["port"] = port
@@ -302,7 +315,7 @@ class ConfigPreviewView(PluginBaseView):
                     base_ports.append(base_port)
             if config_group.service_meta_type == PluginMetaType.DOWNSTREAM_PORT:
                 for port in mysql_port:
-                    base_service = {}
+                    base_service: dict = {}
                     base_service["service_alias"] = wordpress_alias
                     base_service["service_id"] = wp_id
                     base_service["port"] = port

--- a/console/views/plugin/plugin_create.py
+++ b/console/views/plugin/plugin_create.py
@@ -3,8 +3,10 @@
   Created on 18/3/5.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
@@ -20,7 +22,7 @@ logger = logging.getLogger("default")
 
 class PluginCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         插件创建
         ---
@@ -138,25 +140,29 @@ class PluginCreateView(RegionTenantHeaderView):
             # 创建插件版本信息
             plugin_build_version = plugin_version_service.create_build_version(
                 self.response_region,
-                tenant_plugin.plugin_id,
+                tenant_plugin.plugin_id,  # type: ignore[union-attr]
                 self.tenant.tenant_id,
-                self.user.user_id,
+                self.user.user_id,  # type: ignore[arg-type] # NOTE: systemic int-as-str user_id
                 "",
                 "unbuild",
                 min_memory,
-                build_cmd,
+                build_cmd,  # type: ignore[arg-type]
                 image_tag,
-                code_version,
+                code_version,  # type: ignore[arg-type]
                 min_cpu=min_cpu)
             # 数据中心创建插件
-            code, msg = plugin_service.create_region_plugin(self.response_region, self.tenant, tenant_plugin, image_tag)
+            # NOTE: create_tenant_plugin may return None tenant_plugin; backlog
+            code, msg = plugin_service.create_region_plugin(
+                self.response_region, self.tenant, tenant_plugin, image_tag)  # type: ignore[arg-type]
             if code != 200:
-                plugin_service.delete_console_tenant_plugin(self.tenant.tenant_id, tenant_plugin.plugin_id)
-                plugin_version_service.delete_build_version_by_id_and_version(self.tenant.tenant_id, tenant_plugin.plugin_id,
-                                                                              plugin_build_version.build_version, True)
+                plugin_service.delete_console_tenant_plugin(
+                    self.tenant.tenant_id, tenant_plugin.plugin_id)  # type: ignore[union-attr]
+                plugin_version_service.delete_build_version_by_id_and_version(
+                    self.tenant.tenant_id, tenant_plugin.plugin_id,  # type: ignore[union-attr]
+                    plugin_build_version.build_version, True)
                 return Response(general_message(code, "create plugin error", msg), status=code)
 
-            bean = tenant_plugin.to_dict()
+            bean = tenant_plugin.to_dict()  # type: ignore[union-attr]
             bean["build_version"] = plugin_build_version.build_version
             bean["code_version"] = plugin_build_version.code_version
             bean["build_status"] = plugin_build_version.build_status
@@ -164,31 +170,34 @@ class PluginCreateView(RegionTenantHeaderView):
             bean["image_tag"] = plugin_build_version.image_tag
 
             result = general_message(200, "success", "创建成功", bean=bean)
-            plugin_name = operation_log_service.process_plugin_name(tenant_plugin.plugin_alias, self.response_region,
-                                                                    self.tenant.tenant_name, tenant_plugin.plugin_id)
+            plugin_name = operation_log_service.process_plugin_name(
+                tenant_plugin.plugin_alias, self.response_region,  # type: ignore[union-attr]
+                self.tenant.tenant_name, tenant_plugin.plugin_id)  # type: ignore[union-attr]
             comment = operation_log_service.generate_team_comment(
                 operation=Operation.IN,
-                module_name=self.tenant.tenant_alias,
+                module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                 region=self.response_region,
                 team_name=self.tenant.tenant_name,
                 suffix=" 中创建了插件 {}".format(plugin_name))
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,
+                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             if tenant_plugin:
                 plugin_service.delete_console_tenant_plugin(self.tenant.tenant_id, tenant_plugin.plugin_id)
             if plugin_build_version:
-                plugin_version_service.delete_build_version_by_id_and_version(self.tenant.tenant_id, tenant_plugin.plugin_id,
-                                                                              plugin_build_version.build_version, True)
+                # NOTE: tenant_plugin may be None here (not guarded); latent bug
+                plugin_version_service.delete_build_version_by_id_and_version(
+                    self.tenant.tenant_id, tenant_plugin.plugin_id,  # type: ignore[union-attr]
+                    plugin_build_version.build_version, True)
         return Response(result, status=result["code"])
 
 
 class DefaultPluginCreateView(RegionTenantHeaderView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         插件创建
         ---
@@ -211,19 +220,23 @@ class DefaultPluginCreateView(RegionTenantHeaderView):
             return Response(general_message(400, "plugin type not support", "插件类型不支持"), status=400)
         plugin = plugin_service.add_default_plugin(self.user, self.team, self.response_region, plugin_type)
         result = general_message(200, "success", "创建成功")
-        plugin_name = operation_log_service.process_plugin_name(plugin.plugin_alias, self.response_region,
-                                                                self.tenant.tenant_name, plugin.plugin_id)
+        # NOTE: add_default_plugin may return None; backlog
+        plugin_name = operation_log_service.process_plugin_name(
+            plugin.plugin_alias, self.response_region,  # type: ignore[union-attr]
+            self.tenant.tenant_name, plugin.plugin_id)  # type: ignore[union-attr]
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中安装了插件 {}".format(plugin_name))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=200)
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询安装的默认插件
         ---

--- a/console/views/plugin/plugin_info.py
+++ b/console/views/plugin/plugin_info.py
@@ -4,6 +4,9 @@
 """
 import logging
 import threading
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.repositories.plugin import (app_plugin_relation_repo, plugin_version_repo)
 from console.services.operation_log import operation_log_service, Operation
@@ -23,7 +26,7 @@ region_api = RegionInvokeApi()
 
 class PluginBaseInfoView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件基础信息
         ---
@@ -47,7 +50,7 @@ class PluginBaseInfoView(PluginBaseView):
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除插件
         ---
@@ -69,18 +72,20 @@ class PluginBaseInfoView(PluginBaseView):
         result = general_message(200, "success", "删除成功")
         comment = operation_log_service.generate_team_comment(
             operation=Operation.IN,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 中删除了插件 {}".format(self.plugin.plugin_alias))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=result["code"])
 
 
 class PluginEventLogView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取event事件
         ---
@@ -108,14 +113,15 @@ class PluginEventLogView(PluginBaseView):
         """
         level = request.GET.get("level", "info")
         event_id = self.plugin_version.event_id
-        logs = plugin_service.get_plugin_event_log(self.response_region, self.tenant, event_id, level)
+        logs = plugin_service.get_plugin_event_log(
+            self.response_region, self.tenant, event_id, level)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", list=logs)
         return Response(result, status=result["code"])
 
 
 class AllPluginVersionInfoView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         插件构建历史信息展示
         ---
@@ -160,7 +166,7 @@ class AllPluginVersionInfoView(PluginBaseView):
 
 class PluginVersionInfoView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件某个版本的信息
         ---
@@ -183,7 +189,8 @@ class PluginVersionInfoView(PluginBaseView):
         """
         base_info = self.plugin
         if base_info.image and base_info.build_source == "image":
-            base_info.image = base_info.image + ":" + self.plugin_version.image_tag
+            # NOTE: plugin_version.image_tag may be None; backlog
+            base_info.image = base_info.image + ":" + self.plugin_version.image_tag  # type: ignore[operator]
         data = base_info.to_dict()
         data.update(self.plugin_version.to_dict())
         update_status_thread = threading.Thread(
@@ -193,7 +200,7 @@ class PluginVersionInfoView(PluginBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         更新某个版本插件的信息
         ---
@@ -292,20 +299,21 @@ class PluginVersionInfoView(PluginBaseView):
                                                                     self.tenant.tenant_name, self.plugin.plugin_id)
             comment = operation_log_service.generate_team_comment(
                 operation=Operation.IN,
-                module_name=self.tenant.tenant_alias,
+                module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                 region=self.response_region,
                 team_name=self.tenant.tenant_name,
                 suffix=" 中编辑了插件 {} 的基础信息".format(plugin_name))
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,
+                user=self.user, comment=comment,
+                enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除插件某个版本
         ---
@@ -348,13 +356,13 @@ class PluginVersionInfoView(PluginBaseView):
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class AllPluginBaseInfoView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件基础信息
         ---
@@ -373,7 +381,7 @@ class AllPluginBaseInfoView(RegionTenantHeaderView):
 
 class PluginUsedServiceView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件被哪些当前团队哪些组件使用
         ---
@@ -401,7 +409,8 @@ class PluginUsedServiceView(PluginBaseView):
         """
         page = request.GET.get("page", 1)
         page_size = request.GET.get("page_size", 10)
-        data, total = app_plugin_service.get_plugin_used_services(self.plugin.plugin_id, self.tenant.tenant_id, page, page_size)
+        data, total = app_plugin_service.get_plugin_used_services(
+            self.plugin.plugin_id, self.tenant.tenant_id, page, page_size)  # type: ignore[arg-type]
 
         result = general_message(200, "success", "查询成功", list=data, total=total)
         return Response(result, status=result["code"])

--- a/console/views/plugin/plugin_manage.py
+++ b/console/views/plugin/plugin_manage.py
@@ -4,8 +4,10 @@
 """
 import datetime
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
@@ -23,7 +25,7 @@ region_api = RegionInvokeApi()
 
 class PluginBuildView(PluginBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         构建插件
         ---
@@ -76,12 +78,12 @@ class PluginBuildView(PluginBaseView):
                                                                     self.tenant.tenant_name, self.plugin.plugin_id)
             comment = operation_log_service.generate_team_comment(
                 operation=Operation.IN,
-                module_name=self.tenant.tenant_alias,
+                module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                 region=self.response_region,
                 team_name=self.tenant.tenant_name,
                 suffix=" 中构建了插件 {}".format(plugin_name))
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,
+                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name)
         except Exception as e:
             logger.exception(e)
@@ -91,7 +93,7 @@ class PluginBuildView(PluginBaseView):
 
 class CreatePluginVersionView(PluginBaseView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         创建插件新版本
         ---
@@ -131,7 +133,7 @@ class CreatePluginVersionView(PluginBaseView):
 
 class PluginBuildStatusView(PluginBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件构建状态
         ---
@@ -154,5 +156,7 @@ class PluginBuildStatusView(PluginBaseView):
         """
         pbv = plugin_version_service.get_plugin_build_status(self.response_region, self.tenant, self.plugin_version.plugin_id,
                                                              self.plugin_version.build_version)
-        result = general_message(200, "success", "查询成功", {"status": pbv.build_status, "event_id": pbv.event_id})
+        # NOTE: get_plugin_build_status may return None; backlog
+        result = general_message(200, "success", "查询成功",
+                                 {"status": pbv.build_status, "event_id": pbv.event_id})  # type: ignore[union-attr]
         return Response(result, status=result["code"])

--- a/console/views/plugin/plugin_market.py
+++ b/console/views/plugin/plugin_market.py
@@ -1,7 +1,9 @@
 # -*- coding:utf8 -*-
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.models.main import RainbondCenterPlugin
 from console.repositories.enterprise_repo import enterprise_repo
@@ -15,7 +17,7 @@ logger = logging.getLogger('default')
 
 class MarketPluginsView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取云市插件分页列表
         :param request:
@@ -30,13 +32,16 @@ class MarketPluginsView(RegionTenantHeaderView):
 
         # market_plugin_service.sync_market_plugins(self.tenant.tenant_id)
         total, plugins = market_plugin_service.get_paged_plugins(
-            plugin_name, page=page, limit=limit, order_by='is_complete', source='market', scope='goodrain', tenant=self.tenant)
+            plugin_name,  # type: ignore[arg-type]
+            page=page,  # type: ignore[arg-type]
+            limit=limit,  # type: ignore[arg-type]
+            order_by='is_complete', source='market', scope='goodrain', tenant=self.tenant)
         result = general_message(200, "success", "查询成功", list=plugins, total=total, next_page=int(page) + 1)
         return Response(data=result, status=200)
 
 
 class SyncMarketPluginsView(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         同步云市插件分享
         :param request:
@@ -57,13 +62,14 @@ class SyncMarketPluginsView(RegionTenantHeaderView):
         limit = request.GET.get('limit', 10)
         plugin_name = request.GET.get('plugin_name', '')
 
-        plugins, total = market_plugin_service.sync_market_plugins(self.tenant, page, limit, plugin_name)
+        plugins, total = market_plugin_service.sync_market_plugins(
+            self.tenant, page, limit, plugin_name)  # type: ignore[arg-type]
         result = general_message(200, "success", "同步成功", list=plugins, total=total)
         return Response(result, 200)
 
 
 class SyncMarketPluginTemplatesView(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         同步插件模板
         :param request:
@@ -89,7 +95,7 @@ class SyncMarketPluginTemplatesView(RegionTenantHeaderView):
 
 
 class InstallMarketPlugin(RegionTenantHeaderView):
-    def post(self, requset, *args, **kwargs):
+    def post(self, requset: Request, *args: Any, **kwargs: Any) -> Response:
         """
         安装插件
         :param requset:
@@ -100,7 +106,8 @@ class InstallMarketPlugin(RegionTenantHeaderView):
         plugin_id = requset.data.get('plugin_id')
 
         try:
-            plugin = RainbondCenterPlugin.objects.get(ID=plugin_id)
+            # NOTE: request.data.get returns Any|None for ID lookup
+            plugin = RainbondCenterPlugin.objects.get(ID=plugin_id)  # type: ignore[misc]
             status, msg = market_plugin_service.install_plugin(self.user, self.team, self.response_region, plugin)
             if status != 200:
                 return Response(general_message(500, 'install plugin failed', msg), 500)
@@ -110,7 +117,7 @@ class InstallMarketPlugin(RegionTenantHeaderView):
 
 
 class InternalMarketPluginsView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         内部插件市场接口
         :param request:
@@ -123,14 +130,20 @@ class InternalMarketPluginsView(RegionTenantHeaderView):
         limit = request.GET.get('limit', 10)
         scope = request.GET.get('scope')
 
+        # NOTE: request.GET.get yields str|None and str|int for typed params
         total, plugins = market_plugin_service.get_paged_plugins(
-            plugin_name, is_complete=True, scope=scope, tenant=self.tenant, page=page, limit=limit)
+            plugin_name,  # type: ignore[arg-type]
+            is_complete=True,
+            scope=scope,  # type: ignore[arg-type]
+            tenant=self.tenant,
+            page=page,  # type: ignore[arg-type]
+            limit=limit)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", list=plugins, total=total, next_page=int(page) + 1)
         return Response(data=result, status=200)
 
 
 class InstallableInteralPluginsView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取可安装的内部插件列表接口
         :param request:
@@ -143,7 +156,11 @@ class InstallableInteralPluginsView(RegionTenantHeaderView):
         limit = request.GET.get('limit', 10)
 
         total, plugins = market_plugin_service.get_paged_plugins(
-            plugin_name, is_complete=True, tenant=self.tenant, page=page, limit=limit)
+            plugin_name,  # type: ignore[arg-type]
+            is_complete=True,
+            tenant=self.tenant,
+            page=page,  # type: ignore[arg-type]
+            limit=limit)  # type: ignore[arg-type]
 
         installed = plugin_repo.get_tenant_plugins(self.tenant.tenant_id, self.response_region). \
             filter(origin__in=['local_market', 'market'])
@@ -160,7 +177,7 @@ class InstallableInteralPluginsView(RegionTenantHeaderView):
 
 
 class UninstallPluginTemplateView(RegionTenantHeaderView):
-    def post(self, requset, *args, **kwargs):
+    def post(self, requset: Request, *args: Any, **kwargs: Any) -> Response:
         """
         卸载插件模板
         :param requset:
@@ -174,7 +191,7 @@ class UninstallPluginTemplateView(RegionTenantHeaderView):
         plugin_id = requset.data.get('plugin_id')
 
         try:
-            plugin = RainbondCenterPlugin.objects.get(ID=plugin_id)
+            plugin = RainbondCenterPlugin.objects.get(ID=plugin_id)  # type: ignore[misc]
             plugin.delete()
             return Response(general_message(200, '', ''), 200)
         except RainbondCenterPlugin.DoesNotExist:

--- a/console/views/plugin/plugin_share.py
+++ b/console/views/plugin/plugin_share.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 
 from django.db.models import Q
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.models.main import PluginShareRecordEvent
@@ -18,7 +20,7 @@ logger = logging.getLogger('default')
 
 
 class PluginShareRecordView(RegionTenantHeaderView):
-    def get(self, request, team_name, plugin_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询插件分享记录
         :param request:
@@ -37,7 +39,7 @@ class PluginShareRecordView(RegionTenantHeaderView):
         result = general_message(200, "not found uncomplete share record", "无未完成分享流程")
         return Response(data=result, status=200)
 
-    def post(self, request, team_name, plugin_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         创建分享插件记录
         ---
@@ -87,7 +89,7 @@ class PluginShareRecordView(RegionTenantHeaderView):
 
 
 class PluginShareInfoView(RegionTenantHeaderView):
-    def get(self, request, team_name, share_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询分享的插件信息
         ---
@@ -164,7 +166,7 @@ class PluginShareInfoView(RegionTenantHeaderView):
 
         return Response(general_message(200, "", "", bean={'share_plugin_info': share_plugin_info}), 200)
 
-    def post(self, request, team_name, share_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         创建插件分享
         ---
@@ -201,7 +203,7 @@ class PluginShareInfoView(RegionTenantHeaderView):
         result = general_message(status, "create share info", msg, bean=plugin)
         return Response(result, status=status)
 
-    def delete(self, request, team_name, share_id, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         放弃插件分享
         ---
@@ -240,7 +242,7 @@ class PluginShareInfoView(RegionTenantHeaderView):
 
 
 class PluginShareEventsView(RegionTenantHeaderView):
-    def get(self, request, team_name, share_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件分享事件
         :param request:
@@ -264,7 +266,7 @@ class PluginShareEventsView(RegionTenantHeaderView):
             result = general_message(404, "not exist", "分享事件不存在")
             return Response(result, status=404)
 
-        data = {"event_list": []}
+        data: dict = {"event_list": []}
 
         for event in events:
             if event.event_status != "success":
@@ -276,7 +278,7 @@ class PluginShareEventsView(RegionTenantHeaderView):
 
 
 class PluginShareEventView(RegionTenantHeaderView):
-    def get(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取插件分享事件列表
         :param request:
@@ -311,7 +313,7 @@ class PluginShareEventView(RegionTenantHeaderView):
             result = general_message(404, "not exist", "分享事件不存在")
             return Response(result, status=404)
 
-    def post(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         创建分享事件
         :param request:
@@ -334,13 +336,15 @@ class PluginShareEventView(RegionTenantHeaderView):
         try:
             event = PluginShareRecordEvent.objects.get(record_id=share_id, ID=event_id)
 
-            status, msg, data = market_plugin_service.sync_event(self.user.nick_name, self.response_region, team_name, event)
+            status, msg, data = market_plugin_service.sync_event(
+                self.user.nick_name, self.response_region, team_name, event)  # type: ignore[arg-type]
 
             if status != 200:
                 result = general_message(status, "sync share event failed", msg)
                 return Response(result, status=status)
 
-            result = general_message(status, "sync share event", msg, bean=data.to_dict())
+            # NOTE: sync_event may return None data; backlog
+            result = general_message(status, "sync share event", msg, bean=data.to_dict())  # type: ignore[union-attr]
             return Response(result, status=status)
 
         except PluginShareRecordEvent.DoesNotExist:
@@ -349,7 +353,7 @@ class PluginShareEventView(RegionTenantHeaderView):
 
 
 class PluginShareCompletionView(RegionTenantHeaderView):
-    def post(self, request, team_name, share_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         创建分享完成接口
         :param request:
@@ -376,6 +380,7 @@ class PluginShareCompletionView(RegionTenantHeaderView):
             result = general_message(415, "share complete can not do", "插件同步未完成")
             return Response(result, status=415)
 
-        app_market_url = market_plugin_service.plugin_share_completion(self.tenant, share_record, self.user.nick_name)
+        app_market_url = market_plugin_service.plugin_share_completion(
+            self.tenant, share_record, self.user.nick_name)  # type: ignore[arg-type]
         result = general_message(200, "share complete", "插件分享完成", bean=share_record.to_dict(), app_market_url=app_market_url)
         return Response(result, status=200)

--- a/console/views/plugin/service_plugin.py
+++ b/console/views/plugin/service_plugin.py
@@ -4,6 +4,9 @@
 """
 import json
 import logging
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import app_plugin_service, plugin_version_service, plugin_service
@@ -18,7 +21,7 @@ logger = logging.getLogger("default")
 
 
 class ServicePluginsView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件可用的插件列表
         ---
@@ -52,7 +55,7 @@ class ServicePluginsView(AppBaseView):
 
 
 class ServicePluginInstallView(AppBaseView):
-    def post(self, request, plugin_id, *args, **kwargs):
+    def post(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件安装插件
         ---
@@ -88,8 +91,9 @@ class ServicePluginInstallView(AppBaseView):
 
         result = general_message(200, "success", "安装成功")
         plugin = plugin_service.get_plugin_by_plugin_id(self.tenant, plugin_id)
+        # NOTE: get_plugin_by_plugin_id may return None; backlog
         plugin_name = operation_log_service.process_plugin_name(
-            plugin.plugin_alias,
+            plugin.plugin_alias,  # type: ignore[union-attr]
             region=self.service.service_region,
             team_name=self.tenant.tenant_name,
             plugin_id=plugin_id,
@@ -110,7 +114,7 @@ class ServicePluginInstallView(AppBaseView):
             service_alias=self.service.service_alias)
         return Response(result, status=result["code"])
 
-    def delete(self, request, plugin_id, *args, **kwargs):
+    def delete(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件卸载插件
         ---
@@ -144,7 +148,7 @@ class ServicePluginInstallView(AppBaseView):
             region=self.service.service_region,
             team_name=self.tenant.tenant_name,
             service_alias=self.service.service_alias,
-            suffix=" 下的插件 {}".format(plugin.plugin_alias))
+            suffix=" 下的插件 {}".format(plugin.plugin_alias))  # type: ignore[union-attr]
         operation_log_service.create_component_log(
             user=self.user,
             comment=comment,
@@ -157,7 +161,7 @@ class ServicePluginInstallView(AppBaseView):
 
 
 class ServicePluginOperationView(AppBaseView):
-    def put(self, request, plugin_id, *args, **kwargs):
+    def put(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         启停用组件插件
         ---
@@ -200,7 +204,7 @@ class ServicePluginOperationView(AppBaseView):
         memory = request.data.get("min_memory")
         cpu = request.data.get("min_cpu")
 
-        data = dict()
+        data: dict = dict()
         data["plugin_id"] = plugin_id
         data["switch"] = is_active
         data["version_id"] = build_version
@@ -218,7 +222,7 @@ class ServicePluginOperationView(AppBaseView):
 
 
 class ServicePluginConfigView(AppBaseView):
-    def get(self, request, plugin_id, *args, **kwargs):
+    def get(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件插件查看配置
         ---
@@ -258,7 +262,7 @@ class ServicePluginConfigView(AppBaseView):
         return Response(result, result["code"])
 
     @transaction.atomic
-    def put(self, request, plugin_id, *args, **kwargs):
+    def put(self, request: Request, plugin_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         组件插件配置更新
         ---

--- a/console/views/pod.py
+++ b/console/views/pod.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.views.app_config.base import AppBaseView
@@ -14,13 +16,14 @@ region_api = RegionInvokeApi()
 
 
 class AppPodsView(AppBaseView):
-    def get(self, req, pod_name, *args, **kwargs):
+    def get(self, req: Request, pod_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             data = region_api.pod_detail(self.service.service_region, self.tenant.tenant_name, self.service.service_alias,
                                          pod_name)
             if self.service.extend_method == "kubeblocks_component":
                 data = region_api.kubeblocks_cluster_pod_detail(self.service.service_region, self.service.service_id, pod_name)
-            result = general_message(200, 'success', "查询成功", data.get("bean", None))
+            # NOTE: region_api may return None; union-attr backlog.
+            result = general_message(200, 'success', "查询成功", data.get("bean", None))  # type: ignore[union-attr]
         except RegionApiBaseHttpClient.CallApiError as e:
             logger.exception(e)
             result = error_message(e.message)

--- a/console/views/posthog_proxy.py
+++ b/console/views/posthog_proxy.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
@@ -38,7 +39,7 @@ class PostHogProxyRequestError(Exception):
     pass
 
 
-def _get_api_proxy_target():
+def _get_api_proxy_target() -> str:
     return (
         os.environ.get("RAINBOND_POSTHOG_PROXY_TARGET")
         or os.environ.get("POSTHOG_PROXY_TARGET")
@@ -46,7 +47,7 @@ def _get_api_proxy_target():
     ).rstrip("/")
 
 
-def _get_asset_proxy_target(api_target):
+def _get_asset_proxy_target(api_target: str) -> str:
     return (
         os.environ.get("RAINBOND_POSTHOG_ASSET_PROXY_TARGET")
         or os.environ.get("POSTHOG_ASSET_PROXY_TARGET")
@@ -55,7 +56,7 @@ def _get_asset_proxy_target(api_target):
     ).rstrip("/")
 
 
-def _get_replay_proxy_target(api_target):
+def _get_replay_proxy_target(api_target: str) -> str:
     return (
         os.environ.get("RAINBOND_POSTHOG_REPLAY_PROXY_TARGET")
         or os.environ.get("POSTHOG_REPLAY_PROXY_TARGET")
@@ -64,17 +65,17 @@ def _get_replay_proxy_target(api_target):
     ).rstrip("/")
 
 
-def _is_asset_path(path):
+def _is_asset_path(path: str) -> bool:
     request_path = (path or "").lstrip("/")
     return request_path.startswith("static/") or request_path.startswith("array/")
 
 
-def _is_replay_path(path):
+def _is_replay_path(path: str) -> bool:
     request_path = (path or "").lstrip("/")
     return request_path == "s" or request_path.startswith("s/")
 
 
-def _get_proxy_target(path):
+def _get_proxy_target(path: str) -> str:
     api_target = _get_api_proxy_target()
     if _is_asset_path(path):
         return _get_asset_proxy_target(api_target)
@@ -83,7 +84,7 @@ def _get_proxy_target(path):
     return api_target
 
 
-def _build_target_url(path, query_string):
+def _build_target_url(path: str, query_string: str) -> str:
     target = urlsplit(_get_proxy_target(path))
     if not target.scheme or not target.netloc:
         raise ValueError("invalid posthog proxy target")
@@ -94,7 +95,7 @@ def _build_target_url(path, query_string):
     return urlunsplit((target.scheme, target.netloc, target_path, query_string, ""))
 
 
-def _build_upstream_headers(request):
+def _build_upstream_headers(request: HttpRequest) -> dict:
     headers = {}
     for meta_key, header_name in REQUEST_HEADER_MAP.items():
         value = request.META.get(meta_key)
@@ -107,7 +108,7 @@ def _build_upstream_headers(request):
     return headers
 
 
-def _send_upstream_request(**kwargs):
+def _send_upstream_request(**kwargs: Any) -> Any:
     import requests
     try:
         return requests.request(**kwargs)
@@ -115,7 +116,7 @@ def _send_upstream_request(**kwargs):
         raise PostHogProxyRequestError(str(exc))
 
 
-def _add_cors_headers(response, request):
+def _add_cors_headers(response: HttpResponse, request: HttpRequest) -> HttpResponse:
     origin = request.META.get("HTTP_ORIGIN")
     response["Access-Control-Allow-Origin"] = origin or "*"
     response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
@@ -130,16 +131,16 @@ def _add_cors_headers(response, request):
 class PostHogProxyView(View):
     http_method_names = ["get", "post", "options", "head"]
 
-    def options(self, request, path=""):
+    def options(self, request: HttpRequest, path: str = "") -> HttpResponse:
         return _add_cors_headers(HttpResponse(status=204), request)
 
-    def get(self, request, path=""):
+    def get(self, request: HttpRequest, path: str = "") -> HttpResponse:
         return self._proxy(request, path)
 
-    def post(self, request, path=""):
+    def post(self, request: HttpRequest, path: str = "") -> HttpResponse:
         return self._proxy(request, path)
 
-    def _proxy(self, request, path):
+    def _proxy(self, request: HttpRequest, path: str) -> HttpResponse:
         try:
             target_url = _build_target_url(path, request.META.get("QUERY_STRING", ""))
         except ValueError:

--- a/console/views/protocols.py
+++ b/console/views/protocols.py
@@ -4,9 +4,11 @@
 """
 
 import logging
+from typing import Any
 
 from console.views.base import RegionTenantHeaderView
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 # -*- coding: utf8 -*-
 from www.apiclient.regionapi import RegionInvokeApi
@@ -18,7 +20,7 @@ region_api = RegionInvokeApi()
 
 class RegionProtocolView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取数据中心支持的协议
         ---
@@ -37,7 +39,8 @@ class RegionProtocolView(RegionTenantHeaderView):
         try:
             region_name = request.GET.get("region_name", self.response_region)
             protocols_info = region_api.get_protocols(region_name, self.team.tenant_name)
-            protocols = protocols_info["list"]
+            # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+            protocols = protocols_info["list"]  # type: ignore[index]
             p_list = []
             for p in protocols:
                 p_list.append(p["protocol_child"])

--- a/console/views/proxy.py
+++ b/console/views/proxy.py
@@ -1,9 +1,11 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
 from django.views import View
 from console.utils.cache_decorators import never_cache
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.region_app import region_app_repo
@@ -18,34 +20,37 @@ region_api = RegionInvokeApi()
 
 class ProxySSEView(View):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
         path = request.get_full_path().replace("/console/sse", "")
-        return region_api.sse_proxy(request.GET.get("region_name"), path)
+        # NOTE: GET params are Optional[str] but region API expects str (systemic mismatch; backlog).
+        return region_api.sse_proxy(request.GET.get("region_name"), path)  # type: ignore[arg-type]
 
 
 class ProxyPassView(JWTAuthApiView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         path = request.get_full_path().replace("/console", "")
         app_id = request.GET.get("appID")
         region_name = request.GET.get("region_name")
         if app_id and "routes/tcp?" in path:
-            region_app_id = region_app_repo.get_region_app_id(region_name, app_id)
+            region_app_id = region_app_repo.get_region_app_id(region_name, app_id)  # type: ignore[arg-type]
             path = path.replace("appID=" + str(app_id), "appID=" + region_app_id) + "&intID=" + str(app_id)
-        resp = region_api.post_proxy(request.GET.get("region_name"), path, request.data)
-        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])
+        resp = region_api.post_proxy(request.GET.get("region_name"), path, request.data)  # type: ignore[arg-type]
+        # NOTE: region API result may be None; indexing it is a latent risk (backlog).
+        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])  # type: ignore[index]
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         path = request.get_full_path().replace("/console", "")
-        resp = region_api.get_proxy(request.GET.get("region_name"), path, app_id=request.GET.get("appID"))
-        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])
+        resp = region_api.get_proxy(
+            request.GET.get("region_name"), path, app_id=request.GET.get("appID"))  # type: ignore[arg-type]
+        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])  # type: ignore[index]
         return Response(result, status=result["code"])
 
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         path = request.get_full_path().replace("/console", "")
-        resp = region_api.delete_proxy(request.GET.get("region_name"), path)
-        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])
+        resp = region_api.delete_proxy(request.GET.get("region_name"), path)  # type: ignore[arg-type]
+        result = general_message(200, "success", "请求成功", bean=resp['bean'], list=resp['list'])  # type: ignore[index]
         return Response(result, status=result["code"])

--- a/console/views/public_areas.py
+++ b/console/views/public_areas.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from functools import cmp_to_key
+from typing import Any
 
 from console.exception.exceptions import GroupNotExistError
 from console.repositories.app_config import volume_repo
@@ -19,6 +20,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import connection
 from console.utils.cache_decorators import never_cache
 from goodrain_web.tools import JuncheePaginator
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import RegionApp
@@ -33,7 +35,7 @@ logger = logging.getLogger('default')
 
 
 class AllServiceInfo(RegionTenantHeaderView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查看总览分页页面应用状态信息(弃)
         ---
@@ -57,20 +59,21 @@ class AllServiceInfo(RegionTenantHeaderView):
                 region=self.response_region,
                 tenant_name=self.team_name,
                 service_ids=service_ids,
-                enterprise_id=self.team.enterprise_id)
+                enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]  # NOTE: enterprise_id nullable; str expected (backlog).
         result = general_message(code, "success", "批量获取状态成功", list=status_list)
         return Response(result, status=code)
 
 
 class TeamArchView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         res, body = region_api.get_cluster_nodes_arch(self.region_name)
-        result = general_message(200, "success", "架构获取成功", list=list(set(body.get("list"))))
+        # NOTE: region_api may return None body / None list; legacy assumes present (backlog).
+        result = general_message(200, "success", "架构获取成功", list=list(set(body.get("list"))))  # type: ignore[union-attr,arg-type]
         return Response(result, status=200)
 
 
 class TeamOverView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         总览 团队信息
         ---
@@ -81,7 +84,7 @@ class TeamOverView(RegionTenantHeaderView):
               type: string
               paramType: path
         """
-        overview_detail = dict()
+        overview_detail: dict = dict()
         users = team_services.get_team_users(self.team)
         if users:
             user_nums = len(users)
@@ -89,8 +92,9 @@ class TeamOverView(RegionTenantHeaderView):
             team_service_num = service_repo.get_team_service_num_by_team_id(
                 team_id=self.team.tenant_id, region_name=self.response_region)
             source = common_services.get_current_region_used_resource(self.team, self.response_region)
-            team = team_services.get_team_by_team_id_and_eid(self.team.tenant_id, self.team.enterprise_id)
-            overview_detail["logo"] = team.logo
+            team = team_services.get_team_by_team_id_and_eid(self.team.tenant_id, self.team.enterprise_id)  # type: ignore[arg-type]
+            # NOTE: get_team_by_team_id_and_eid may return None; legacy assumes present (backlog).
+            overview_detail["logo"] = team.logo  # type: ignore[union-attr]
             region = region_repo.get_region_by_region_name(self.response_region)
             if not region:
                 overview_detail["region_health"] = False
@@ -108,8 +112,10 @@ class TeamOverView(RegionTenantHeaderView):
                     if app_id_rels.get(group.ID):
                         region_app_ids.append(app_id_rels[group.ID])
                         continue
-                    create_app_body = dict()
-                    group_services = base_service.get_group_services_list(self.team.tenant_id, region.region_name, group.ID)
+                    create_app_body: dict = dict()
+                    # NOTE: group.ID is int AutoField; service signature takes str (systemic int-as-str, backlog).
+                    group_services = base_service.get_group_services_list(self.team.tenant_id, region.region_name,
+                                                                          group.ID)  # type: ignore[arg-type]
                     service_ids = []
                     if group_services:
                         service_ids = [service["service_id"] for service in group_services]
@@ -127,9 +133,9 @@ class TeamOverView(RegionTenantHeaderView):
                     app_list = []
                     if applist:
                         for app in applist:
-                            data = RegionApp(
+                            region_app_obj = RegionApp(
                                 app_id=app["app_id"], region_app_id=app["region_app_id"], region_name=region.region_name)
-                            app_list.append(data)
+                            app_list.append(region_app_obj)
                             region_app_ids.append(app["region_app_id"])
                     RegionApp.objects.bulk_create(app_list)
                 except Exception as e:
@@ -139,7 +145,8 @@ class TeamOverView(RegionTenantHeaderView):
             try:
                 resp = region_api.list_app_statuses_by_app_ids(self.tenant_name, self.response_region,
                                                                {"app_ids": region_app_ids})
-                app_statuses = resp.get("list", [])
+                # NOTE: region_api result may be None; legacy assumes dict (backlog).
+                app_statuses = resp.get("list", [])  # type: ignore[union-attr]
                 if app_statuses is None:
                     app_statuses = []
                 for app_status in app_statuses:
@@ -193,7 +200,7 @@ class TeamOverView(RegionTenantHeaderView):
 
 
 class ServiceGroupView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用列表
         ---
@@ -217,7 +224,7 @@ class ServiceGroupView(RegionTenantHeaderView):
 
 
 class GroupOperatorManagedView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         纳管当前应用经用户Operator处理创建的资源
         """
@@ -226,14 +233,15 @@ class GroupOperatorManagedView(RegionTenantHeaderView):
         if group_id == '':
             group_id = None
         code = 200
-        operator_managed = group_service.get_watch_managed_data(self.tenant, self.region_name, group_id)
+        # NOTE: group_id may be None; get_watch_managed_data expects str (backlog).
+        operator_managed = group_service.get_watch_managed_data(self.tenant, self.region_name, group_id)  # type: ignore[arg-type]
         result = general_message(code, "success", "获取成功", list=operator_managed)
         return Response(result, status=code)
 
 
 class GroupServiceView(RegionTenantHeaderView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用组件列表、状态展示
         ---
@@ -279,16 +287,17 @@ class GroupServiceView(RegionTenantHeaderView):
                     team_name=self.team_name,
                     team_id=self.team.tenant_id,
                     region_name=self.response_region,
-                    enterprise_id=self.team.enterprise_id)
+                    enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]
                 if page_size == "-1" or page_size == "" or page_size == "0":
                     page_size = len(no_group_service_list) if len(no_group_service_list) > 0 else 10
                 paginator = Paginator(no_group_service_list, page_size)
                 try:
-                    no_group_service_list = paginator.page(page).object_list
+                    # NOTE: object_list is _SupportsPagination, not list; legacy reuse (backlog).
+                    no_group_service_list = paginator.page(page).object_list  # type: ignore[assignment]
                 except PageNotAnInteger:
-                    no_group_service_list = paginator.page(1).object_list
+                    no_group_service_list = paginator.page(1).object_list  # type: ignore[assignment]
                 except EmptyPage:
-                    no_group_service_list = paginator.page(paginator.num_pages).object_list
+                    no_group_service_list = paginator.page(paginator.num_pages).object_list  # type: ignore[assignment]
                 result = general_message(code, "query success", "应用查询成功", list=no_group_service_list, total=paginator.count)
                 return Response(result, status=code)
 
@@ -303,17 +312,17 @@ class GroupServiceView(RegionTenantHeaderView):
                 region_name=self.response_region,
                 team_id=self.team.tenant_id,
                 team_name=self.team_name,
-                enterprise_id=self.team.enterprise_id,
+                enterprise_id=self.team.enterprise_id,  # type: ignore[arg-type]
                 query=query)
             if page_size == "-1" or page_size == "" or page_size == "0":
                 page_size = len(group_service_list) if len(group_service_list) > 0 else 10
             paginator = Paginator(group_service_list, page_size)
             try:
-                group_service_list = paginator.page(page).object_list
+                group_service_list = paginator.page(page).object_list  # type: ignore[assignment]
             except PageNotAnInteger:
-                group_service_list = paginator.page(1).object_list
+                group_service_list = paginator.page(1).object_list  # type: ignore[assignment]
             except EmptyPage:
-                group_service_list = paginator.page(paginator.num_pages).object_list
+                group_service_list = paginator.page(paginator.num_pages).object_list  # type: ignore[assignment]
             result = general_message(code, "query success", "应用查询成功", list=group_service_list, total=paginator.count)
             if sort == 3:
                 if order == "ascend":
@@ -348,16 +357,17 @@ class GroupServiceView(RegionTenantHeaderView):
 
 
 class ServiceEventsView(RegionTenantHeaderView):
-    def __sort_events(self, event1, event2):
+    def __sort_events(self, event1: Any, event2: Any) -> int:
         event1_start_time = event1.get("start_time") if isinstance(event1, dict) else event1.start_time
         event2_start_time = event2.get("start_time") if isinstance(event2, dict) else event2.start_time
-        if event1_start_time < event2_start_time:
+        # NOTE: start_time may be None; legacy comparison assumes present (backlog).
+        if event1_start_time < event2_start_time:  # type: ignore[operator]
             return 1
-        if event1_start_time > event2_start_time:
+        if event1_start_time > event2_start_time:  # type: ignore[operator]
             return -1
         return 1
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         组件事件动态
         ---
@@ -382,7 +392,7 @@ class ServiceEventsView(RegionTenantHeaderView):
         page_size = request.GET.get("page_size", 3)
         total = 0
         region_list = region_repo.get_team_opened_region(self.tenant.tenant_name)
-        event_service_dynamic_list = []
+        event_service_dynamic_list: list = []
         if region_list:
             for region in region_list:
                 try:
@@ -420,7 +430,7 @@ class ServiceEventsView(RegionTenantHeaderView):
 
 
 class TeamServiceOverViewView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         总览 团队应用信息 + 分页 + 排序 + 模糊查询
         ---
@@ -480,7 +490,7 @@ class TeamServiceOverViewView(RegionTenantHeaderView):
                     region=self.response_region,
                     tenant_name=self.team_name,
                     service_ids=service_ids,
-                    enterprise_id=self.team.enterprise_id)
+                    enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]
                 status_cache = {}
                 statuscn_cache = {}
                 for status in status_list:
@@ -528,7 +538,7 @@ class TeamServiceOverViewView(RegionTenantHeaderView):
 
 
 class TeamAppNamesView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         groups = group_repo.get_tenant_region_groups(self.team.tenant_id, self.response_region, "")
         group_k8s_app_names = [app.k8s_app for app in groups]
         data = {"app_names": group_k8s_app_names}
@@ -536,7 +546,7 @@ class TeamAppNamesView(RegionTenantHeaderView):
 
 
 class TeamAppSortViewView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         总览 团队应用信息
         """
@@ -554,13 +564,14 @@ class TeamAppSortViewView(RegionTenantHeaderView):
             group_ids = [group.ID for group in groups]
             group_ids = group_ids[start:end]
             apps = group_service.get_multi_apps_all_info(sort, groups, group_ids, self.response_region, self.team_name,
-                                                         self.team.enterprise_id, self.team)
+                                                         self.team.enterprise_id, self.team)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=apps, bean=app_num_dict), status=200)
 
 
 # 团队下应用环境变量模糊查询
 class TenantServiceEnvsView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    # NOTE: falls through returning None when both attr_name and attr_value empty (latent bug, backlog).
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # type: ignore[return]
         attr_name = request.GET.get("attr_name", None)
         attr_value = request.GET.get("attr_value", None)
         if not attr_name and not attr_value:
@@ -605,11 +616,13 @@ class TenantServiceEnvsView(RegionTenantHeaderView):
 
 
 class AccessTokenView(JWTAuthApiView):
-    def get(self, request, team_name, token_note, **kwargs):
-        access_key = user_access_services.get_user_access_key_by_note(request.user.user_id, token_note).first()
+    def get(self, request: Request, team_name: str, token_note: str, **kwargs: Any) -> Response:
+        # NOTE: request.user is User|AnonymousUser; auth guarantees authenticated user (backlog).
+        access_key = user_access_services.get_user_access_key_by_note(request.user.user_id, token_note).first()  # type: ignore[union-attr]
         if not access_key:
             try:
-                access_key = user_access_services.create_user_access_key(token_note, request.user.user_id, "")
+                # NOTE: create_user_access_key expects int|None for 3rd arg; legacy passes "" (backlog).
+                access_key = user_access_services.create_user_access_key(token_note, request.user.user_id, "")  # type: ignore[arg-type, union-attr]
             except ValueError as e:
                 logger.exception(e)
                 raise e

--- a/console/views/rbd_ability.py
+++ b/console/views/rbd_ability.py
@@ -1,5 +1,8 @@
 # -*- coding: utf8 -*-
 
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.views.base import EnterpriseAdminView
@@ -9,13 +12,14 @@ from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient
 
 
 class RainbondAbilityLView(EnterpriseAdminView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         abilities = rbd_ability_service.list_abilities(enterprise_id, region_name)
         return Response(general_message(200, "success", "查询成功", list=abilities))
 
 
 class RainbondAbilityRUDView(EnterpriseAdminView):
-    def put(self, request, enterprise_id, region_name, ability_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, region_name: str, ability_id: str, *args: Any,
+            **kwargs: Any) -> Response:
         k8s_object = request.data["object"] if request.data.get("object") else {}
         try:
             ability = rbd_ability_service.update_ability(enterprise_id, region_name, ability_id, k8s_object)
@@ -24,7 +28,8 @@ class RainbondAbilityRUDView(EnterpriseAdminView):
             return Response(general_message(400, message, message), status=400)
         return Response(general_message(200, "success", "查询成功", bean=ability))
 
-    def get(self, request, enterprise_id, region_name, ability_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, ability_id: str, *args: Any,
+            **kwargs: Any) -> Response:
         try:
             ability = rbd_ability_service.get_ability(enterprise_id, region_name, ability_id)
         except RegionApiBaseHttpClient.CallApiError as exc:

--- a/console/views/rbd_plugin.py
+++ b/console/views/rbd_plugin.py
@@ -1,4 +1,7 @@
 # -*- coding: utf8 -*-
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 from django.http import HttpResponse
 
@@ -11,13 +14,13 @@ region_api = RegionInvokeApi()
 
 
 class RainbondPluginLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         plugins, _ = rbd_plugin_service.list_plugins(enterprise_id, region_name)
         return Response(general_message(200, "success", "查询成功", list=plugins))
 
 
 class RainbondPluginStaticView(AlowAnyApiView):
-    def get(self, request, region_name, plugin_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, plugin_name: str, *args: Any, **kwargs: Any) -> HttpResponse:
         path = "/v2/platform/static/plugins/" + plugin_name
         resp = region_api.get_proxy(region_name, path, check_status=False)
         return HttpResponse(resp, content_type="application/javascript")
@@ -25,7 +28,8 @@ class RainbondPluginStaticView(AlowAnyApiView):
 class RainbondPluginBackendView(JWTAuthApiView):
     # 流式代理插件后端 API：支持 SSE / 长响应，转发 body 与请求头（含 Cookie/JWT），
     # 不缓冲、不走 proxy() 的固定 20s 超时。
-    def get(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def get(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+            **kwargs: Any) -> HttpResponse:
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
         # 传递查询参数
         query_string = request.META.get('QUERY_STRING', '')
@@ -33,7 +37,8 @@ class RainbondPluginBackendView(JWTAuthApiView):
             path = path + "?" + query_string
         return region_api.stream_proxy(request, path, region_name)
 
-    def post(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def post(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+             **kwargs: Any) -> HttpResponse:
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
         # 传递查询参数
         query_string = request.META.get('QUERY_STRING', '')
@@ -41,7 +46,8 @@ class RainbondPluginBackendView(JWTAuthApiView):
             path = path + "?" + query_string
         return region_api.stream_proxy(request, path, region_name)
 
-    def put(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def put(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+            **kwargs: Any) -> HttpResponse:
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
         # 传递查询参数
         query_string = request.META.get('QUERY_STRING', '')
@@ -49,7 +55,8 @@ class RainbondPluginBackendView(JWTAuthApiView):
             path = path + "?" + query_string
         return region_api.stream_proxy(request, path, region_name)
 
-    def delete(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def delete(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+               **kwargs: Any) -> HttpResponse:
         path = "/v2/platform/backend/plugins/" + plugin_name + "/" + file_path
         # 传递查询参数
         query_string = request.META.get('QUERY_STRING', '')
@@ -58,29 +65,35 @@ class RainbondPluginBackendView(JWTAuthApiView):
         return region_api.stream_proxy(request, path, region_name)
 
 class RainbondPluginStatusView(EnterpriseAdminView):
-    def post(self, request, region_name, plugin_name, *args, **kwargs):
+    def post(self, request: Request, region_name: str, plugin_name: str, *args: Any, **kwargs: Any) -> Response:
         path = "/v2/platform/plugins/" + plugin_name + "/status"
         resp = region_api.post_proxy(region_name, path, request.data)
-        result = general_message(200, "success", "更新成功", bean=resp['bean'], list=resp['list'])
+        # NOTE: post_proxy may return None; legacy code indexes directly (backlog).
+        result = general_message(200, "success", "更新成功", bean=resp['bean'], list=resp['list'])  # type: ignore[index]
         return Response(result, status=result["code"])
 
 class RainbondOfficialPluginLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         plugins, need_authz = rbd_plugin_service.list_plugins(enterprise_id, region_name, official=True)
         return Response(general_message(200, "success", "查询成功", bean={"need_authz": need_authz}, list=plugins))
 
 
 class RainbondObservablePluginLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
-        regions = region_services.get_regions_by_enterprise_id(enterprise_id)
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: region_services is undefined in this module — latent NameError at runtime (real bug, backlog).
+        regions = region_services.get_regions_by_enterprise_id(enterprise_id)  # type: ignore[name-defined]
         res = []
         for region in regions:
             plugins = rbd_plugin_service.list_plugins(enterprise_id, region.region_name, official=True)
+            # NOTE: list_plugins returns (plugins, need_authz) tuple; loop iterates the tuple and
+            # indexes plugin as a dict — latent bug, items are list/bool not dict (real bug, backlog).
             for plugin in plugins:
-                if plugin["name"] == "observability":
-                    res.append({"region_name": region.region_name, "urls": plugin["urls"], "name": "observability"})
-                elif plugin["name"] == "rainbond-large-screen":
-                    res.append({"region_name": region.region_name, "urls": plugin["urls"], "name": "rainbond-large-screen"})
+                if plugin["name"] == "observability":  # type: ignore[index,call-overload]
+                    res.append({"region_name": region.region_name, "urls": plugin["urls"],  # type: ignore[index,call-overload]
+                                "name": "observability"})
+                elif plugin["name"] == "rainbond-large-screen":  # type: ignore[index,call-overload]
+                    res.append({"region_name": region.region_name, "urls": plugin["urls"],  # type: ignore[index,call-overload]
+                                "name": "rainbond-large-screen"})
         return Response(general_message(200, "success", "查询成功", list=res))
 
 
@@ -102,7 +115,7 @@ class RainbondPluginFullProxyView(JWTAuthApiView):
     前端 -> Console (此视图) -> Region API (Go 反向代理) -> 插件服务 (Grafana 等)
     """
 
-    def _handle_proxy(self, request, region_name, plugin_name, file_path):
+    def _handle_proxy(self, request: Request, region_name: str, plugin_name: str, file_path: str) -> HttpResponse:
         """
         统一的代理处理方法
         使用 region_api.proxy() 实现完整的 HTTP 代理
@@ -119,17 +132,22 @@ class RainbondPluginFullProxyView(JWTAuthApiView):
         # 该方法在 www/apiclient/regionapibaseclient.py:309-382 中实现
         return region_api.proxy(request, path, region_name)
 
-    def get(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def get(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+            **kwargs: Any) -> HttpResponse:
         return self._handle_proxy(request, region_name, plugin_name, file_path)
 
-    def post(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def post(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+             **kwargs: Any) -> HttpResponse:
         return self._handle_proxy(request, region_name, plugin_name, file_path)
 
-    def put(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def put(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+            **kwargs: Any) -> HttpResponse:
         return self._handle_proxy(request, region_name, plugin_name, file_path)
 
-    def delete(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def delete(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+               **kwargs: Any) -> HttpResponse:
         return self._handle_proxy(request, region_name, plugin_name, file_path)
 
-    def patch(self, request, region_name, plugin_name, file_path, *args, **kwargs):
+    def patch(self, request: Request, region_name: str, plugin_name: str, file_path: str, *args: Any,
+              **kwargs: Any) -> HttpResponse:
         return self._handle_proxy(request, region_name, plugin_name, file_path)

--- a/console/views/region.py
+++ b/console/views/region.py
@@ -1,6 +1,7 @@
 # -*- coding: utf8 -*-
 import json
 import logging
+from typing import Any
 
 import requests
 
@@ -9,6 +10,7 @@ from console.services.operation_log import operation_log_service, Operation
 from console.services.region_services import region_services
 from console.services.team_services import team_services
 from console.views.base import (JWTAuthApiView, RegionTenantHeaderView, TenantHeaderView, AlowAnyApiView)
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.marketclient import MarketOpenAPI
 from www.apiclient.regionapi import RegionInvokeApi
@@ -21,7 +23,7 @@ market_api = MarketOpenAPI()
 
 
 class RegQuyView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取团队数据中心(详细)
         ---
@@ -39,12 +41,13 @@ class RegQuyView(RegionTenantHeaderView):
         except Exception as e:
             code = 500
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2-style Exception.message; not present on py3 Exception (legacy; backlog).
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=code)
 
 
 class RegUnopenView(TenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取团队未开通的数据中心
         ---
@@ -60,13 +63,14 @@ class RegUnopenView(TenantHeaderView):
         if not team:
             result = general_message(404, "team no found", "团队不存在")
             return Response(result, status=code)
-        unopen_regions = region_services.get_team_unopen_region(team_name, team.enterprise_id)
+        # NOTE: enterprise_id is nullable but service expects str (systemic mismatch; backlog).
+        unopen_regions = region_services.get_team_unopen_region(team_name, team.enterprise_id)  # type: ignore[arg-type]
         result = general_message(code, "query the data center is successful.", "数据中心获取成功", list=unopen_regions)
         return Response(result, status=code)
 
 
 class OpenRegionView(TenantHeaderView):
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         为团队开通数据中心
         ---
@@ -90,13 +94,16 @@ class OpenRegionView(TenantHeaderView):
             return Response(general_message(404, "team is not found", "团队{0}不存在".format(team_name)), status=403)
         region_services.create_tenant_on_region(self.enterprise.enterprise_id, team_name, region_name, team.namespace)
         result = general_message(200, "success", "数据中心{0}开通成功".format(region_name))
+        # NOTE: tenant_alias/enterprise_id are nullable but log service expects str (systemic; backlog).
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.FOR, module_name=team.tenant_alias, team_name=team.tenant_name, suffix=" 开通了集群")
+            operation=Operation.FOR, module_name=team.tenant_alias,  # type: ignore[arg-type]
+            team_name=team.tenant_name, suffix=" 开通了集群")
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=team.tenant_name)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id, team_name=team.tenant_name)  # type: ignore[arg-type]
         return Response(result, result["code"])
 
-    def patch(self, request, team_name, *args, **kwargs):
+    def patch(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         为团队批量开通数据中心
         ---
@@ -125,12 +132,14 @@ class OpenRegionView(TenantHeaderView):
             region_services.create_tenant_on_region(self.enterprise.enterprise_id, team_name, region_name, team.namespace)
         result = general_message(200, "success", "批量开通数据中心成功")
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.FOR, module_name=team.tenant_alias, team_name=team.tenant_name, suffix=" 开通了集群")
+            operation=Operation.FOR, module_name=team.tenant_alias,  # type: ignore[arg-type]
+            team_name=team.tenant_name, suffix=" 开通了集群")
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=team.tenant_name)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id, team_name=team.tenant_name)  # type: ignore[arg-type]
         return Response(result, result["code"])
 
-    def delete(self, request, team_name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         为团队关闭数据中心
         ---
@@ -152,16 +161,19 @@ class OpenRegionView(TenantHeaderView):
         tenant = team_services.get_tenant_by_tenant_name(team_name)
         region_services.delete_tenant_on_region(self.enterprise.enterprise_id, team_name, region_name, self.user)
         result = general_message(200, "success", "团队关闭数据中心{0}成功".format(region_name))
+        # NOTE: tenant may be None and tenant_alias/enterprise_id nullable; service expects str (systemic; backlog).
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.UNINSTALL, module_name=tenant.tenant_alias, team_name=tenant.tenant_name,
-            suffix=" 下的集群")
+            operation=Operation.UNINSTALL, module_name=tenant.tenant_alias,  # type: ignore[union-attr,arg-type]
+            team_name=tenant.tenant_name, suffix=" 下的集群")  # type: ignore[union-attr]
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=tenant.tenant_name)
+            user=self.user, comment=comment,
+            enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=tenant.tenant_name)  # type: ignore[union-attr]
         return Response(result, result["code"])
 
 
 class RegionMonitor(AlowAnyApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         url = request.data.get("url", None)
         data = request.data.get("data", None)
         headers = {
@@ -170,7 +182,7 @@ class RegionMonitor(AlowAnyApiView):
         ret = requests.post(url, headers=headers, data=json.dumps(data).encode("utf-8"))
         ret_data = json.loads(ret.text)
         results = ret_data.get("results", {})
-        body = dict()
+        body: Any = dict()
         for k, result in results.items():
             frames = result.get("frames", [])
             for frame in frames:
@@ -190,7 +202,7 @@ class RegionMonitor(AlowAnyApiView):
 
 
 class QyeryRegionView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取当前可用全部数据中心
         ---
@@ -202,7 +214,7 @@ class QyeryRegionView(JWTAuthApiView):
 
 
 class GetRegionPublicKeyView(RegionTenantHeaderView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取指定数据中心的Key
         ---
@@ -214,7 +226,7 @@ class GetRegionPublicKeyView(RegionTenantHeaderView):
 
 
 class GetRegionFeature(RegionTenantHeaderView):
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取指定数据中心的授权功能列表
         ---
@@ -226,7 +238,7 @@ class GetRegionFeature(RegionTenantHeaderView):
 
 
 class PublicRegionListView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         团队管理员可以获取公有云的数据中心列表
         ---
@@ -246,9 +258,13 @@ class PublicRegionListView(JWTAuthApiView):
             team_name = request.GET.get("team_name", None)
             if not team_name:
                 return Response(general_message(400, "params error", "参数错误"), status=400)
-            perm_list = team_services.get_user_perm_identitys_in_permtenant(user_id=request.user.user_id, tenant_name=team_name)
+            # NOTE: request.user may be AnonymousUser lacking user_id (legacy; backlog).
+            perm_list = team_services.get_user_perm_identitys_in_permtenant(
+                user_id=request.user.user_id, tenant_name=team_name)  # type: ignore[union-attr]
 
-            role_name_list = team_services.get_user_perm_role_in_permtenant(user_id=request.user.user_id, tenant_name=team_name)
+            # NOTE: get_user_perm_role_in_permtenant does not exist on TeamService — latent AttributeError bug (backlog).
+            role_name_list = team_services.get_user_perm_role_in_permtenant(  # type: ignore[attr-defined]
+                user_id=request.user.user_id, tenant_name=team_name)  # type: ignore[union-attr]
             perm = "owner" not in perm_list and "admin" not in perm_list
             if perm and "owner" not in role_name_list and "admin" not in role_name_list:
                 code = 400
@@ -256,7 +272,9 @@ class PublicRegionListView(JWTAuthApiView):
                 return Response(result, status=code)
 
             team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)
-            res, data = market_api.get_public_regions_list(tenant_id=team.tenant_id, enterprise_id=team.enterprise_id)
+            # NOTE: get_tenant_by_tenant_name return is Optional; attribute access is a latent risk (backlog).
+            res, data = market_api.get_public_regions_list(
+                tenant_id=team.tenant_id, enterprise_id=team.enterprise_id)  # type: ignore[union-attr]
             if res["status"] == 200:
                 code = 200
                 result = general_message(code, "query the data center is successful.", "公有云数据中心获取成功", list=data)
@@ -266,12 +284,12 @@ class PublicRegionListView(JWTAuthApiView):
         except Exception as e:
             code = 500
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=code)
 
 
 class RegionResourceDetailView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         公有云数据中心资源详情
         ---
@@ -296,7 +314,8 @@ class RegionResourceDetailView(JWTAuthApiView):
             team_name = request.GET.get("team_name", None)
             region = request.GET.get("region", None)
 
-            team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)
+            # NOTE: GET team_name is Optional[str] but service expects str (systemic mismatch; backlog).
+            team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)  # type: ignore[arg-type]
             if not team:
                 return Response(general_message(404, "team not found", "指定团队不存在"), status=404)
 
@@ -308,17 +327,18 @@ class RegionResourceDetailView(JWTAuthApiView):
                 result = general_message(200, "success", "查询成功", bean=data)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class RegionResPrice(JWTAuthApiView):
-    def post(self, request, region_name):
+    def post(self, request: Request, region_name: str) -> Response:
         """资源费用计算"""
 
         team_name = request.data.get('team_name')
 
-        team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)
+        # NOTE: request.data team_name is Any|None but service expects str (systemic mismatch; backlog).
+        team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)  # type: ignore[arg-type]
         if not team:
             return Response(general_message(404, "team not found", "指定团队不存在"), status=404)
 
@@ -338,12 +358,13 @@ class RegionResPrice(JWTAuthApiView):
 
 
 class RegionResPurchage(JWTAuthApiView):
-    def post(self, request, region_name):
+    def post(self, request: Request, region_name: str) -> Response:
         """资源购买"""
 
         team_name = request.data.get('team_name')
 
-        team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)
+        # NOTE: request.data team_name is Any|None but service expects str (systemic mismatch; backlog).
+        team = team_services.get_tenant_by_tenant_name(tenant_name=team_name, exception=True)  # type: ignore[arg-type]
         if not team:
             return Response(general_message(404, "team not found", "指定团队不存在"), status=404)
 
@@ -364,10 +385,11 @@ class RegionResPurchage(JWTAuthApiView):
 
 
 class MavenSettingView(RegionTenantHeaderView):
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         onlyname = request.GET.get("onlyname", True)
         res, body = region_api.list_maven_settings(enterprise_id, region_name)
-        redata = body.get("list")
+        # NOTE: region API result may be None; .get access is a latent risk (backlog).
+        redata = body.get("list")  # type: ignore[union-attr]
         if redata and isinstance(redata, list) and (onlyname is True or onlyname == "true"):
             newdata = []
             for setting in redata:
@@ -376,10 +398,10 @@ class MavenSettingView(RegionTenantHeaderView):
         result = general_message(200, 'query success', '数据中心Maven获取成功', list=redata)
         return Response(status=200, data=result)
 
-    def post(self, request, enterprise_id, region_name, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             res, body = region_api.add_maven_setting(enterprise_id, region_name, request.data)
-            result = general_message(200, 'query success', '添加成功', bean=body.get("bean"))
+            result = general_message(200, 'query success', '添加成功', bean=body.get("bean"))  # type: ignore[union-attr]
         except RegionApiBaseHttpClient.CallApiError as exc:
             if exc.message.get("httpcode") == 400:
                 result = general_message(400, 'maven setting name is exist', '配置名称已存在')
@@ -396,10 +418,10 @@ class MavenSettingView(RegionTenantHeaderView):
 
 
 class MavenSettingRUDView(RegionTenantHeaderView):
-    def get(self, request, enterprise_id, region_name, name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             res, body = region_api.get_maven_setting(enterprise_id, region_name, name)
-            result = general_message(200, 'query success', '获取成功', bean=body.get("bean"))
+            result = general_message(200, 'query success', '获取成功', bean=body.get("bean"))  # type: ignore[union-attr]
         except RegionApiBaseHttpClient.CallApiError as exc:
             if exc.message.get("httpcode") == 404:
                 result = general_message(404, 'maven setting is not exist', '配置不存在')
@@ -414,10 +436,10 @@ class MavenSettingRUDView(RegionTenantHeaderView):
                 result = general_message(500, 'add maven setting failure', '获取配置失败')
         return Response(status=result["code"], data=result)
 
-    def put(self, request, enterprise_id, region_name, name, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             res, body = region_api.update_maven_setting(enterprise_id, region_name, name, request.data)
-            result = general_message(200, 'update success', '修改成功', bean=body.get("bean"))
+            result = general_message(200, 'update success', '修改成功', bean=body.get("bean"))  # type: ignore[union-attr]
         except RegionApiBaseHttpClient.CallApiError as exc:
             if exc.message.get("httpcode") == 404:
                 result = general_message(404, 'maven setting is not exist', '配置不存在')
@@ -432,10 +454,10 @@ class MavenSettingRUDView(RegionTenantHeaderView):
                 result = general_message(500, 'update maven setting failure', '更新配置失败')
         return Response(status=result["code"], data=result)
 
-    def delete(self, request, enterprise_id, region_name, name, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         try:
             res, body = region_api.delete_maven_setting(enterprise_id, region_name, name)
-            result = general_message(200, 'delete success', '删除成功', bean=body.get("bean"))
+            result = general_message(200, 'delete success', '删除成功', bean=body.get("bean"))  # type: ignore[union-attr]
         except RegionApiBaseHttpClient.CallApiError as exc:
             if exc.message.get("httpcode") == 404:
                 result = general_message(404, 'maven setting is not exist', '配置不存在')

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -4,6 +4,8 @@ from www.utils.return_message import general_message
 from rest_framework.response import Response
 from console.repositories.team_repo import team_registry_auth_repo
 from console.utils.reqparse import parse_item
+from typing import Any
+from rest_framework.request import Request
 import logging
 
 logger = logging.getLogger('default')
@@ -13,20 +15,21 @@ from console.views.base import JWTAuthApiView
 
 class HubRegistryView(JWTAuthApiView):
     @never_cache
-    def get(self, request, *args, **kwargs):
-        result = team_services.list_registry_auths('', '', self.user.user_id)
-        auths = [auth.to_dict() for auth in result]
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: Users.user_id is an int AutoField but service expects str (systemic int-as-str; backlog).
+        registry_auths = team_services.list_registry_auths('', '', self.user.user_id)  # type: ignore[arg-type]
+        auths = [auth.to_dict() for auth in registry_auths]
         result = general_message(200, "success", "查询成功", list=auths)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         domain = parse_item(request, "domain", required=True)
         username = parse_item(request, "username", required=True)
         password = parse_item(request, "password", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
         secret_id = parse_item(request, "secret_id", required=True)
         # 检查是否已存在
-        ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)
+        ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)  # type: ignore[arg-type]
         if ra.exists():
             result = general_message(400, "error", "资源已存在")
             return Response(result, status=result["code"])
@@ -66,32 +69,34 @@ class HubRegistryView(JWTAuthApiView):
             result = general_message(500, "creation failed",  "创建失败: {}".format(str(e)))
             return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         secret_id = request.GET.get("secret_id")
         data = {
             "username": parse_item(request, "username", required=True),
             "password": parse_item(request, "password", required=True),
             "hub_type": parse_item(request, "hub_type", required=True),
         }
-        auth = team_registry_auth_repo.get_by_secret_id(secret_id)
+        # NOTE: GET secret_id is Optional[str] but repo expects str (systemic mismatch; backlog).
+        auth = team_registry_auth_repo.get_by_secret_id(secret_id)  # type: ignore[arg-type]
         if not auth:
             result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
             return Response(result, status=result["code"])
-        team_registry_auth_repo.update_team_registry_auth('', '', secret_id, **data)
+        team_registry_auth_repo.update_team_registry_auth('', '', secret_id, **data)  # type: ignore[arg-type]
 
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         secret_id = request.GET.get("secret_id")
-        team_registry_auth_repo.delete_team_registry_auth('', '', secret_id, self.user.user_id)
+        team_registry_auth_repo.delete_team_registry_auth(
+            '', '', secret_id, self.user.user_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
 
 class HubRegistryImageView(JWTAuthApiView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取镜像仓库的命名空间、镜像名称、标签列表或完整镜像地址
         """

--- a/console/views/rke2.py
+++ b/console/views/rke2.py
@@ -2,10 +2,12 @@
 import json
 import logging
 import time
+from typing import Any, Iterator
 
 import yaml
 from django.db import IntegrityError
 from django.http import StreamingHttpResponse
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.repositories.init_cluster import rke_cluster, rke_cluster_node
 from console.utils.k8s_cli import K8sClient
@@ -16,7 +18,7 @@ logger = logging.getLogger("default")
 
 
 class BaseClusterView(AlowAnyApiView):
-    def handle_exception(self, e, message="Operation failed", message_cn="操作失败"):
+    def handle_exception(self, e: Any, message: str = "Operation failed", message_cn: str = "操作失败") -> Response:
         logger.error(f"{message}: {str(e)}")
         result = general_message(500, message, message_cn, bean={"error": str(e)})
         return Response(result, status=500)
@@ -25,27 +27,30 @@ class BaseClusterView(AlowAnyApiView):
 # 获取集群部署状态的接口
 class ClusterRKE(BaseClusterView):
     # get 接口用于获取集群安装状态以及初始化安装集群。
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             cluster_id = request.GET.get("cluster_id", "")
             cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)
+            # NOTE: get_rke_cluster may return None; legacy code accesses attrs directly (backlog).
             result = general_message(200, "Get cluster successful.", "获取集群成功", bean={
-                "event_id": cluster.event_id,
-                "create_status": cluster.create_status,
-                "cluster_name": cluster.cluster_name,
-                "cluster_id": cluster.cluster_id,
-                "server_host": cluster.server_host,
+                "event_id": cluster.event_id,  # type: ignore[union-attr]
+                "create_status": cluster.create_status,  # type: ignore[union-attr]
+                "cluster_name": cluster.cluster_name,  # type: ignore[union-attr]
+                "cluster_id": cluster.cluster_id,  # type: ignore[union-attr]
+                "server_host": cluster.server_host,  # type: ignore[union-attr]
             })
             return Response(result, status=200)
         except Exception as e:
             return self.handle_exception(e, "Failed to get cluster", "获取集群失败")
 
     # 更新集群名称和集群ID
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             cluster_name = request.data.get('cluster_name')
             cluster_id = request.data.get('cluster_id')
-            cluster = rke_cluster.update_cluster(create_status="initialized", cluster_name=cluster_name, cluster_id=cluster_id)
+            cluster = rke_cluster.update_cluster(create_status="initialized",
+                                                 cluster_name=cluster_name,  # type: ignore[arg-type]
+                                                 cluster_id=cluster_id)  # type: ignore[arg-type]
             result = general_message(200, "Get cluster successful.", "获取集群成功", bean={
                 "event_id": cluster.event_id,
                 "create_status": cluster.create_status,
@@ -63,7 +68,7 @@ class ClusterRKE(BaseClusterView):
             return self.handle_exception(e, "Failed to get cluster", "创建集群失败: {}".format(e))
 
     # put 接口用于更新集群的配置文件，脚本执行完成后调用。
-    def put(self, request):
+    def put(self, request: Request) -> Response:
         kubeconfig_file = request.FILES.get('kubeconfig')
         if not kubeconfig_file:
             result = general_message(400, "No kubeconfig file provided.", "未提供kubeconfig文件")
@@ -73,7 +78,7 @@ class ClusterRKE(BaseClusterView):
             kubeconfig_content = kubeconfig_file.read().decode('utf-8')
             cluster = rke_cluster.get_rke_cluster_exclude_integrated()
             server_node = rke_cluster_node.get_server_node(cluster.cluster_id)
-            kubeconfig_content = kubeconfig_content.replace("127.0.0.1", server_node.node_name)
+            kubeconfig_content = kubeconfig_content.replace("127.0.0.1", server_node.node_name)  # type: ignore[union-attr]
             cluster.config = kubeconfig_content
             cluster.save()
             result = general_message(200, "Cluster updated successfully.", "集群更新成功")
@@ -84,7 +89,7 @@ class ClusterRKE(BaseClusterView):
 
 # 节点注册接口
 class InstallRKECluster(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             node_ip = request.GET.get("node_ip", "")
             node_role = request.GET.get("node_role", "")
@@ -96,13 +101,14 @@ class InstallRKECluster(BaseClusterView):
                 cluster, is_server = rke_cluster.only_server(node_ip, event_id)
             else:
                 cluster = rke_cluster.get_rke_cluster(event_id=event_id)
-            if cluster.server_host:
-                node = rke_cluster_node.create_node(cluster.cluster_id, node_name, node_role, node_ip, is_server)
-                if cluster.config:
-                    k8s_api = K8sClient(cluster.config)
+            if cluster.server_host:  # type: ignore[union-attr]
+                node = rke_cluster_node.create_node(
+                    cluster.cluster_id, node_name, node_role, node_ip, is_server)  # type: ignore[union-attr]
+                if cluster.config:  # type: ignore[union-attr]
+                    k8s_api = K8sClient(cluster.config)  # type: ignore[union-attr]
                     k8s_api.nodes_add_worker_rule([node])
             result = general_message(200, "Nodes init successfully.", "节点注册成功",
-                                     bean={"server_ip": cluster.server_host, "is_server": is_server})
+                                     bean={"server_ip": cluster.server_host, "is_server": is_server})  # type: ignore[union-attr]
             return Response(result, status=200)
         except Exception as e:
             return self.handle_exception(e, "Failed to retrieve nodes", "节点注册失败")
@@ -110,16 +116,16 @@ class InstallRKECluster(BaseClusterView):
 
 # 获取节点信息接口
 class ClusterRKENode(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             cluster_id = request.GET.get("cluster_id", "")
             cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)
             nodes_dict = {}
-            if cluster.config:
-                k8s_api = K8sClient(cluster.config)
+            if cluster.config:  # type: ignore[union-attr]
+                k8s_api = K8sClient(cluster.config)  # type: ignore[union-attr]
                 nodes_dict = k8s_api.get_nodes()
 
-            nodes = rke_cluster_node.get_cluster_nodes(cluster.cluster_id)
+            nodes = rke_cluster_node.get_cluster_nodes(cluster.cluster_id)  # type: ignore[union-attr]
             nodes_info = []
             for node in nodes:
                 node_info = nodes_dict.get(node.node_name)
@@ -128,7 +134,7 @@ class ClusterRKENode(BaseClusterView):
                     node_rule = node.node_role.split(",")
                     # 输出结果
                     if "worker" in node_rule and "worker" not in rke_node_rule:
-                        k8s_api = K8sClient(cluster.config)
+                        k8s_api = K8sClient(cluster.config)  # type: ignore[union-attr]
                         k8s_api.nodes_add_worker_rule([node])
                     nodes_info.append(node_info)
                 else:
@@ -155,15 +161,15 @@ class ClusterRKENode(BaseClusterView):
         except Exception as e:
             return self.handle_exception(e, "Failed to retrieve nodes", "获取节点失败")
 
-    def delete(self, request):
+    def delete(self, request: Request) -> Response:
         try:
             cluster_id = request.data.get('cluster_id')
             node_name = request.data.get('node_name')
-            cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)
-            rke_cluster_node.delete_cluster_nodes(cluster.cluster_id, node_name)
-            if not rke_cluster_node.get_cluster_nodes(cluster.cluster_id):
-                cluster.server_host = ""
-                cluster.save()
+            cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)  # type: ignore[arg-type]
+            rke_cluster_node.delete_cluster_nodes(cluster.cluster_id, node_name)  # type: ignore[union-attr,arg-type]
+            if not rke_cluster_node.get_cluster_nodes(cluster.cluster_id):  # type: ignore[union-attr]
+                cluster.server_host = ""  # type: ignore[union-attr]
+                cluster.save()  # type: ignore[union-attr]
             result = general_message(200, "node delete successfully.", "节点删除成功")
             return Response(result, status=200)
         except Exception as e:
@@ -172,14 +178,14 @@ class ClusterRKENode(BaseClusterView):
 
 # 获取节点IP接口
 class ClusterNodeIP(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
 
             cluster = rke_cluster.get_rke_cluster()
-            if not cluster.config:
+            if not cluster.config:  # type: ignore[union-attr]
                 result = general_message(200, "No cluster config available.", "无可用的集群配置", bean=[])
                 return Response(result, status=200)
-            nodes = rke_cluster_node.get_cluster_nodes(cluster.cluster_id)
+            nodes = rke_cluster_node.get_cluster_nodes(cluster.cluster_id)  # type: ignore[union-attr]
             ips = [node.node_name for node in nodes]
             result = general_message(200, "Nodes retrieved successfully.", "节点 ip 获取成功", list=ips)
             return Response(result, status=200)
@@ -189,7 +195,7 @@ class ClusterNodeIP(BaseClusterView):
 
 # 安装 Rainbond
 class ClusterRKEInstallRB(BaseClusterView):
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             # 从请求体中获取 values.yaml 内容
             third_db = request.data.get('third_db')
@@ -209,8 +215,9 @@ class ClusterRKEInstallRB(BaseClusterView):
             if error_message:
                 return self.handle_exception(error_message, "Failed to install Rainbond", "安装Rainbond失败")
             cluster.create_status = "integrating"
-            cluster.third_db = third_db
-            cluster.third_hub = third_hub
+            # NOTE: third_db/third_hub are bool fields; request.data.get returns Any|None (legacy, backlog).
+            cluster.third_db = third_db  # type: ignore[assignment]
+            cluster.third_hub = third_hub  # type: ignore[assignment]
             cluster.save()
             result = general_message(200, "Rainbond installed successfully.", "Rainbond安装成功", bean={})
             return Response(result, status=200)
@@ -220,7 +227,7 @@ class ClusterRKEInstallRB(BaseClusterView):
 
 # 卸载 Rainbond
 class ClusterRKEUNInstallInstallRB(BaseClusterView):
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             cluster = rke_cluster.get_rke_cluster_exclude_integrated()
             if not cluster.config:
@@ -241,18 +248,19 @@ class ClusterRKEUNInstallInstallRB(BaseClusterView):
 
 # 获取 Rainbond 安装状态
 class ClusterRKERBStatus(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             cluster_id = request.GET.get("cluster_id", "")
             cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)
-            if not cluster.config:
+            if not cluster.config:  # type: ignore[union-attr]
                 result = general_message(200, "No cluster config available.", "无可用的集群配置", bean=[])
                 return Response(result, status=200)
-            k8s_api = K8sClient(cluster.config)
-            rb_components_status, rb_installed = k8s_api.rb_components_status(cluster.third_db, cluster.third_hub)
+            k8s_api = K8sClient(cluster.config)  # type: ignore[union-attr]
+            rb_components_status, rb_installed = k8s_api.rb_components_status(cluster.third_db,  # type: ignore[union-attr]
+                                                                            cluster.third_hub)  # type: ignore[union-attr]
             if rb_installed:
-                cluster.create_status = "integrated"
-                cluster.save()
+                cluster.create_status = "integrated"  # type: ignore[union-attr]
+                cluster.save()  # type: ignore[union-attr]
             result = general_message(200, "get rb components status successfully.", "组件状态获取成功",
                                      bean=rb_components_status)
             return Response(result, status=200)
@@ -262,15 +270,15 @@ class ClusterRKERBStatus(BaseClusterView):
 
 # 获取 Rainbond 组件的详细事件信息
 class ClusterRKERBEvent(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             cluster_id = request.GET.get("cluster_id", "")
             pod_name = request.GET.get('pod_name')
             cluster = rke_cluster.get_rke_cluster(cluster_id=cluster_id)
-            if not cluster.config:
+            if not cluster.config:  # type: ignore[union-attr]
                 result = general_message(200, "No cluster config available.", "无可用的集群配置", bean=[])
                 return Response(result, status=200)
-            k8s_api = K8sClient(cluster.config)
+            k8s_api = K8sClient(cluster.config)  # type: ignore[union-attr]
             rb_components_status = k8s_api.rb_component_event(pod_name)
             result = general_message(200, "get rb components status successfully.", "组件状态获取成功",
                                      bean=rb_components_status)
@@ -281,7 +289,7 @@ class ClusterRKERBEvent(BaseClusterView):
 
 # 获取 Rainbond 集群信息
 class RKERegionConfig(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         try:
             cluster = rke_cluster.get_rke_cluster_exclude_integrated()
             if not cluster.config:
@@ -299,7 +307,7 @@ class RKERegionConfig(BaseClusterView):
 
 # SSE 实时获取 Rainbond 组件日志
 class ClusterRBComponentLogSSE(BaseClusterView):
-    def get(self, request):
+    def get(self, request: Request) -> StreamingHttpResponse:
         """
         SSE 接口，实时获取 Rainbond 组件运行日志
         参数:
@@ -329,7 +337,7 @@ class ClusterRBComponentLogSSE(BaseClusterView):
             
             k8s_api = K8sClient(cluster.config)
             
-            def generate_log_stream():
+            def generate_log_stream() -> Iterator[str]:
                 log_stream = None
                 try:
                     # 发送连接成功消息
@@ -443,13 +451,13 @@ class ClusterRBComponentLogSSE(BaseClusterView):
         except Exception as e:
             return self._sse_error(f"Failed to start log stream: {str(e)}", "启动日志流失败")
     
-    def _format_sse_message(self, data):
+    def _format_sse_message(self, data: dict) -> str:
         """格式化 SSE 消息"""
         return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
     
-    def _sse_error(self, error_message, error_message_cn):
+    def _sse_error(self, error_message: str, error_message_cn: str) -> StreamingHttpResponse:
         """返回 SSE 错误响应"""
-        def error_stream():
+        def error_stream() -> Iterator[str]:
             yield self._format_sse_message({
                 "type": "error",
                 "message": error_message,

--- a/console/views/role_prems.py
+++ b/console/views/role_prems.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.exceptions import ParamsError
@@ -20,7 +22,7 @@ logger = logging.getLogger("default")
 
 
 class TeamAddUserView(RegionTenantHeaderView):
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         团队中添加新用户给用户分配一个角色
         ---
@@ -80,24 +82,26 @@ class TeamAddUserView(RegionTenantHeaderView):
             new_information = json.dumps(user_list, ensure_ascii=False)
             comment = operation_log_service.generate_team_comment(
                 operation=Operation.IN,
-                module_name=self.tenant.tenant_alias,
+                # NOTE: tenant_alias/enterprise_id nullable but callees expect str (arg-type backlog).
+                module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                 region=self.response_region,
                 team_name=self.tenant.tenant_name,
                 suffix=suffix)
             operation_log_service.create_team_log(
                 user=self.user,
                 comment=comment,
-                enterprise_id=self.user.enterprise_id,
+                enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name,
                 new_information=new_information)
 
         except ParamsError as e:
             logging.exception(e)
             code = 400
-            result = general_message(code, "params is empty", e.message)
+            # NOTE: py2-style Exception.message attribute (attr-defined backlog).
+            result = general_message(code, "params is empty", e.message)  # type: ignore[attr-defined]
         except UserNotExistError as e:
             code = 400
-            result = general_message(code, "user not exist", e.message)
+            result = general_message(code, "user not exist", e.message)  # type: ignore[attr-defined]
         except Tenants.DoesNotExist as e:
             code = 400
             logger.exception(e)

--- a/console/views/sentry_proxy.py
+++ b/console/views/sentry_proxy.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import re
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from django.http import HttpResponse
@@ -39,7 +40,7 @@ class SentryProxyRequestError(Exception):
     pass
 
 
-def _get_proxy_target():
+def _get_proxy_target() -> str:
     return (
         os.environ.get("RAINBOND_SENTRY_PROXY_TARGET")
         or os.environ.get("RAINBOND_ERROR_REPORTING_PROXY_TARGET")
@@ -48,14 +49,14 @@ def _get_proxy_target():
     ).rstrip("/")
 
 
-def _validate_envelope_path(path):
+def _validate_envelope_path(path: str) -> str:
     request_path = (path or "").lstrip("/")
     if not ENVELOPE_PATH_RE.match(request_path):
         raise ValueError("invalid sentry envelope path")
     return request_path
 
 
-def _build_target_url(path, query_string):
+def _build_target_url(path: str, query_string: str) -> str:
     request_path = _validate_envelope_path(path)
     target = urlsplit(_get_proxy_target())
     if not target.scheme or not target.netloc:
@@ -66,7 +67,7 @@ def _build_target_url(path, query_string):
     return urlunsplit((target.scheme, target.netloc, target_path, query_string, ""))
 
 
-def _build_upstream_headers(request):
+def _build_upstream_headers(request: Any) -> dict:
     headers = {}
     for meta_key, header_name in REQUEST_HEADER_MAP.items():
         value = request.META.get(meta_key)
@@ -79,7 +80,7 @@ def _build_upstream_headers(request):
     return headers
 
 
-def _send_upstream_request(**kwargs):
+def _send_upstream_request(**kwargs: Any) -> Any:
     import requests
     try:
         return requests.request(**kwargs)
@@ -87,7 +88,7 @@ def _send_upstream_request(**kwargs):
         raise SentryProxyRequestError(str(exc))
 
 
-def _add_cors_headers(response, request):
+def _add_cors_headers(response: HttpResponse, request: Any) -> HttpResponse:
     origin = request.META.get("HTTP_ORIGIN")
     response["Access-Control-Allow-Origin"] = origin or "*"
     response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
@@ -102,10 +103,10 @@ def _add_cors_headers(response, request):
 class SentryProxyView(View):
     http_method_names = ["post", "options"]
 
-    def options(self, request, path=""):
+    def options(self, request: Any, path: str = "") -> HttpResponse:
         return _add_cors_headers(HttpResponse(status=204), request)
 
-    def post(self, request, path=""):
+    def post(self, request: Any, path: str = "") -> HttpResponse:
         try:
             target_url = _build_target_url(path, request.META.get("QUERY_STRING", ""))
         except ValueError:

--- a/console/views/service_docker.py
+++ b/console/views/service_docker.py
@@ -2,6 +2,8 @@
 """
   Created on 18/2/7.
 """
+from typing import Any
+
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from console.utils.cache_decorators import never_cache
@@ -12,18 +14,26 @@ from console.repositories.team_repo import team_repo
 from console.repositories.app import service_repo
 import logging
 from django.conf import settings
+from django.http import HttpRequest, HttpResponseBase
 from django.views.generic import View
 from django import http
+from www.models.main import Tenants, TenantServiceInfo
 
 logger = logging.getLogger("default")
 
 
 class DockerContainerView(View):
-    @never_cache
-    def get(self, request, *args, **kwargs):
+    tenantName: str
+    serviceAlias: str
+    tenant: Tenants
+    service: TenantServiceInfo
 
-        self.tenantName = kwargs.get('tenantName', None)
-        self.serviceAlias = kwargs.get('serviceAlias', None)
+    @never_cache
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+
+        # NOTE: kwargs.get returns Any|None for str-typed context attrs (backlog).
+        self.tenantName = kwargs.get('tenantName', None)  # type: ignore[assignment]
+        self.serviceAlias = kwargs.get('serviceAlias', None)  # type: ignore[assignment]
         tenant = team_repo.get_team_by_team_name(self.tenantName)
         if tenant:
             self.tenant = tenant
@@ -37,7 +47,8 @@ class DockerContainerView(View):
             raise http.Http404
 
         context = dict()
-        response = redirect(get_redirect_url("/#/app/{0}/overview".format(self.service.service_alias), request))
+        response: HttpResponseBase = redirect(
+            get_redirect_url("/#/app/{0}/overview".format(self.service.service_alias), request))
         docker_c_id = request.COOKIES.get('docker_c_id', '')
         docker_h_id = request.COOKIES.get('docker_h_id', '')
         docker_s_id = request.COOKIES.get('docker_s_id', '')
@@ -50,8 +61,11 @@ class DockerContainerView(View):
 
             main_url = region_services.get_region_wsurl(self.service.service_region)
             if main_url == "auto":
+                # NOTE: DOCKER_WSS_URL is a dynamic Django setting not on Settings stub (backlog).
                 context["ws_uri"] = '{}://{}:6060/docker_console?nodename={}'.format(
-                    settings.DOCKER_WSS_URL["type"], settings.DOCKER_WSS_URL[self.service.service_region], t_docker_h_id)
+                    settings.DOCKER_WSS_URL["type"],  # type: ignore[misc]
+                    settings.DOCKER_WSS_URL[self.service.service_region],  # type: ignore[misc]
+                    t_docker_h_id)
             else:
                 context["ws_uri"] = "{0}/docker_console?nodename={1}".format(main_url, t_docker_h_id)
 

--- a/console/views/service_share.py
+++ b/console/views/service_share.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+from typing import Any
 
 from console.appstore.appstore import app_store
 from console.enum.component_enum import is_singleton
@@ -22,6 +23,7 @@ from console.utils.reqparse import parse_argument
 from console.views.base import JWTAuthApiView, RegionTenantHeaderView
 from django.db.models import Q
 from goodrain_web import settings
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.crypt import make_uuid
 from www.utils.return_message import error_message, general_message
@@ -34,7 +36,7 @@ NUM_LETTER = re.compile("^(?!\\d+$)[\\da-zA-Z_]+$")
 FIRST_LETTER = re.compile("^[a-zA-Z]")
 
 
-def market_name_format(name):
+def market_name_format(name: str) -> bool:
     if NUM_LETTER.search(name):
         if FIRST_LETTER.search(name):
             return True
@@ -42,11 +44,11 @@ def market_name_format(name):
 
 
 class ServiceShareRecordVersionView(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         app_version = rainbond_app_repo.get_rainbond_app_version_by_id(self.enterprise.enterprise_id, group_id)
-        app_version_list = list()
+        app_version_list: list = list()
         if app_version:
-            app_version_dict = dict()
+            app_version_dict: dict = dict()
             for app_v in app_version:
                 app_version_dict[app_v.app_id] = list(set(app_version_dict.get(app_v.app_id, [])+[app_v.version]))
             app_version_key = list(app_version_dict.keys())
@@ -60,11 +62,11 @@ class ServiceShareRecordVersionView(RegionTenantHeaderView):
 
 
 class ServiceShareRecordView(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, *args, **kwargs):
-        data = []
+    def get(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
+        data: list = []
         skipped_count = 0
-        market = dict()
-        cloud_app = dict()
+        market: dict = dict()
+        cloud_app: dict = dict()
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         total, share_records = share_repo.get_service_share_records_by_groupid(
@@ -94,8 +96,9 @@ class ServiceShareRecordView(RegionTenantHeaderView):
                     mkt = market.get(share_record.share_app_market_name, None)
                     if not mkt:
                         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
+                        # NOTE: enterprise_id nullable & user_id int AutoField; service takes str (systemic, backlog).
                         mkt = app_market_service.get_app_market_by_name(
-                            self.tenant.enterprise_id, share_record.share_app_market_name, user_id=user_id, raise_exception=True)
+                            self.tenant.enterprise_id, share_record.share_app_market_name, user_id=user_id, raise_exception=True)  # type: ignore[arg-type]
                         market[share_record.share_app_market_name] = mkt
 
                     c_app = cloud_app.get(share_record.app_id, None)
@@ -133,7 +136,7 @@ class ServiceShareRecordView(RegionTenantHeaderView):
         result = general_message(200, "success", "获取成功", bean={'total': max(total - skipped_count, 0)}, list=data)
         return Response(result, status=200)
 
-    def post(self, request, team_name, group_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         生成分享订单，会验证是否能够分享
         ---
@@ -154,7 +157,8 @@ class ServiceShareRecordView(RegionTenantHeaderView):
         market_name = None
         if scope == "goodrain":
             target = request.data.get("target")
-            market_name = target.get("store_id")
+            # NOTE: request.data.get may return None; legacy assumes present (backlog).
+            market_name = target.get("store_id")  # type: ignore[union-attr]
             if market_name is None:
                 result = general_message(400, "fail", "参数不全")
                 return Response(result, status=result.get("code", 200))
@@ -177,7 +181,8 @@ class ServiceShareRecordView(RegionTenantHeaderView):
             if data and data["code"] == 400:
                 return Response(data, status=data["code"])
             if snapshot_mode:
-                app = group_service.get_group_or_404(self.tenant, self.response_region, int(group_id))
+                # NOTE: get_group_or_404 takes str group_id; int passed here (systemic int-as-str, backlog).
+                app = group_service.get_group_or_404(self.tenant, self.response_region, int(group_id))  # type: ignore[arg-type]
                 _, hidden_template = app_version_service.get_or_create_hidden_template(self.tenant, self.user, app)
                 snapshot_app_id = hidden_template.app_id if hidden_template else snapshot_app_id
             fields_dict = {
@@ -205,9 +210,10 @@ class ServiceShareRecordView(RegionTenantHeaderView):
 
 
 class ServiceShareRecordInfoView(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, record_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> Response:
         data = None
-        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)
+        # NOTE: record_id path param is str; repo expects int (systemic str-as-int, backlog).
+        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)  # type: ignore[arg-type]
         if share_record:
             app_model_name = None
             app_model_id = None
@@ -220,16 +226,18 @@ class ServiceShareRecordInfoView(RegionTenantHeaderView):
             scope = share_record.scope
             if store_id:
                 user_id = self.user.user_id if os.getenv("USE_SAAS") else None
+                # NOTE: enterprise_id/market_name nullable & user_id int AutoField; service takes str (systemic, backlog).
                 extend, market = app_market_service.get_app_market(
-                    self.tenant.enterprise_id, share_record.share_app_market_name, user_id=user_id, extend="true", raise_exception=True)
+                    self.tenant.enterprise_id, share_record.share_app_market_name, user_id=user_id, extend="true", raise_exception=True)  # type: ignore[arg-type]
                 if market:
                     store_name = market.name
                     store_version = extend.get("version", store_version)
-            app = rainbond_app_repo.get_rainbond_app_by_app_id(share_record.app_id)
+            # NOTE: app_id nullable & ID int AutoField; repo takes str (systemic, backlog).
+            app = rainbond_app_repo.get_rainbond_app_by_app_id(share_record.app_id)  # type: ignore[arg-type]
             if app:
                 app_model_id = share_record.app_id
                 app_model_name = app.app_name
-            app_version = rainbond_app_repo.get_rainbond_app_version_by_record_id(share_record.ID)
+            app_version = rainbond_app_repo.get_rainbond_app_version_by_record_id(share_record.ID)  # type: ignore[arg-type]
             if not app_version and share_record.app_id and share_record.share_version:
                 app_version = rainbond_app_repo.get_app_version(share_record.app_id, share_record.share_version)
             if app_version:
@@ -257,17 +265,20 @@ class ServiceShareRecordInfoView(RegionTenantHeaderView):
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
-    def put(self, request, team_name, group_id, record_id, *args, **kwargs):
+    # NOTE: falls through returning None when no record/status (latent bug, backlog).
+    def put(  # type: ignore[return]
+            self, request: Request, team_name: str, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> Response:
         status = request.data.get("status")
-        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)
+        # NOTE: record_id path param is str; repo expects int (systemic str-as-int, backlog).
+        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)  # type: ignore[arg-type]
         if share_record and status:
             share_record.status = status
             share_record.save()
             result = general_message(200, "success", None, bean=share_record.to_dict())
             return Response(result, status=200)
 
-    def delete(self, request, team_name, group_id, record_id, *args, **kwargs):
-        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)
+    def delete(self, request: Request, team_name: str, group_id: str, record_id: str, *args: Any, **kwargs: Any) -> Response:
+        share_record = share_repo.get_service_share_record_by_id(group_id=group_id, record_id=record_id)  # type: ignore[arg-type]
         if share_record:
             share_record.status = 3
             share_record.save()
@@ -276,7 +287,7 @@ class ServiceShareRecordInfoView(RegionTenantHeaderView):
 
 
 class ServiceShareDeleteView(RegionTenantHeaderView):
-    def delete(self, request, team_name, share_id, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         放弃应用分享操作，放弃时删除分享记录
         ---
@@ -304,8 +315,9 @@ class ServiceShareDeleteView(RegionTenantHeaderView):
             app = share_service.get_app_by_key(key=share_record.app_id)
             if app:
                 app_versions = share_service.get_app_version_by_app_id(app_id=share_record.app_id, is_complete=True)
-                app_versions = [version.arch for version in app_versions]
-                app_versions = list(set(app_versions))
+                # NOTE: app_versions reused QuerySet -> list (legacy reuse, backlog).
+                app_versions = [version.arch for version in app_versions]  # type: ignore[assignment]
+                app_versions = list(set(app_versions))  # type: ignore[assignment]
                 app.arch = ",".join(app_versions)
             share_service.delete_record(share_record)
             result = general_message(200, "delete success", "放弃成功")
@@ -314,12 +326,13 @@ class ServiceShareDeleteView(RegionTenantHeaderView):
             raise e
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2-era Exception.message; preserved for behavior compat (backlog).
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class ServiceShareInfoView(RegionTenantHeaderView):
-    def get(self, request, team_name, share_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询分享的所有应用信息和插件信息
         ---
@@ -335,7 +348,7 @@ class ServiceShareInfoView(RegionTenantHeaderView):
               type: string
               paramType: path
         """
-        data = dict()
+        data: dict = dict()
         scope = request.GET.get("scope")
         share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
         if not share_record:
@@ -349,7 +362,8 @@ class ServiceShareInfoView(RegionTenantHeaderView):
         if share_record.app_id and share_record.share_version:
             snapshot_version = rainbond_app_repo.get_app_version(share_record.app_id, share_record.share_version)
             if share_service.is_snapshot_publish_version(snapshot_version):
-                app_template = json.loads(snapshot_version.app_template)
+                # NOTE: snapshot_version may be None; guarded by is_snapshot_publish_version (backlog).
+                app_template = json.loads(snapshot_version.app_template)  # type: ignore[union-attr]
                 data["publish_mode"] = "snapshot"
                 data["share_service_list"] = app_template.get("apps", [])
                 data["share_plugin_list"] = app_template.get("plugins", [])
@@ -366,7 +380,7 @@ class ServiceShareInfoView(RegionTenantHeaderView):
         result = general_message(200, "query success", "获取成功", bean=data)
         return Response(result, status=200)
 
-    def post(self, request, team_name, share_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         生成分享应用实体，向数据中心发送分享任务
         ---
@@ -421,6 +435,7 @@ class ServiceShareInfoView(RegionTenantHeaderView):
                         return Response(result, status=400)
 
         # 继续给app_template_incomplete赋值
+        # NOTE: user_id int AutoField; create_share_info takes str (systemic int-as-str, backlog).
         code, msg, bean = share_service.create_share_info(
             tenant=self.tenant,
             region_name=self.region_name,
@@ -429,15 +444,16 @@ class ServiceShareInfoView(RegionTenantHeaderView):
             share_user=request.user,
             share_info=request.data,
             use_force=use_force,
-            user_id=user_id
+            user_id=user_id  # type: ignore[arg-type]
         )
-        bean['is_plugin'] = is_plugin
+        # NOTE: bean may be None; legacy assumes dict result (backlog).
+        bean['is_plugin'] = is_plugin  # type: ignore[index]
         result = general_message(code, "create share info", msg, bean=bean)
         return Response(result, status=code)
 
 
 class ServiceShareEventList(RegionTenantHeaderView):
-    def get(self, request, team_name, share_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
             if not share_record:
@@ -472,12 +488,12 @@ class ServiceShareEventList(RegionTenantHeaderView):
             raise e
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class ServiceShareEventPost(RegionTenantHeaderView):
-    def post(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
             if not share_record:
@@ -498,10 +514,10 @@ class ServiceShareEventPost(RegionTenantHeaderView):
             raise e
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
-    def get(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
             if not share_record:
@@ -524,12 +540,12 @@ class ServiceShareEventPost(RegionTenantHeaderView):
             raise e
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class ServicePluginShareEventPost(RegionTenantHeaderView):
-    def post(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
         if not share_record:
             result = general_message(404, "share record not found", "分享流程不存在，请退出重试")
@@ -550,7 +566,7 @@ class ServicePluginShareEventPost(RegionTenantHeaderView):
             result = general_message(200, "sync share event", "分享成功", bean=bean.to_dict())
         return Response(result, status=result["code"])
 
-    def get(self, request, team_name, share_id, event_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, share_id: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
         if not share_record:
             result = general_message(404, "share record not found", "分享流程不存在，请退出重试")
@@ -573,7 +589,7 @@ class ServicePluginShareEventPost(RegionTenantHeaderView):
 
 
 class ServiceShareCompleteView(RegionTenantHeaderView):
-    def post(self, request, team_name, share_id, *args, **kwargs):
+    def post(self, request: Request, team_name: str, share_id: str, *args: Any, **kwargs: Any) -> Response:
         is_plugin = parse_argument(request, 'is_plugin', default=False, value_type=bool)
         share_record = share_service.get_service_share_record_by_ID(ID=share_id, team_name=team_name)
         if not share_record:
@@ -589,7 +605,8 @@ class ServiceShareCompleteView(RegionTenantHeaderView):
             result = general_message(415, "share complete can not do", "组件或插件同步未全部完成")
             return Response(result, status=415)
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        app_market_url = share_service.complete(self.tenant, self.user, share_record, is_plugin, user_id, self.response_region)
+        # NOTE: user_id int AutoField; complete takes str (systemic int-as-str, backlog).
+        app_market_url = share_service.complete(self.tenant, self.user, share_record, is_plugin, user_id, self.response_region)  # type: ignore[arg-type]
         rainbond_app = share_service.get_app_by_app_id(share_record.app_id)
         result = general_message(200, "share complete", "应用分享完成", bean=share_record.to_dict(), app_market_url=app_market_url)
         app = group_repo.get_app_by_pk(share_record.group_id)
@@ -607,7 +624,7 @@ class ServiceShareCompleteView(RegionTenantHeaderView):
 
 
 class ShareRecordView(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询是否有未确认分享订单记录
         ---
@@ -628,42 +645,46 @@ class ShareRecordView(RegionTenantHeaderView):
             result = general_message(
                 200, "the current application does not confirm sharing", "当前应用未确认分享", bean=share_record.to_dict())
             return Response(result, status=200)
+        # NOTE: share_record may be None; legacy assumes present on the fall-through path (backlog).
         result = general_message(
-            200, "the current application is not Shared or Shared", "当前应用未分享或已分享", bean=share_record.to_dict())
+            200, "the current application is not Shared or Shared", "当前应用未分享或已分享", bean=share_record.to_dict())  # type: ignore[union-attr]
         return Response(result, status=200)
 
 
 class ServiceGroupSharedApps(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         scope = request.GET.get("scope", None)
         market_name = request.GET.get("market_id", None)
         preferred_app_id = request.GET.get("preferred_app_id", None)
         preferred_version = request.GET.get("preferred_version", None)
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        data = share_service.get_last_shared_app_and_app_list(self.tenant.enterprise_id, self.tenant, group_id, scope,
-                                                              market_name, user_id, preferred_app_id, preferred_version)
+        # NOTE: enterprise_id/scope nullable & user_id int AutoField; service takes str (systemic, backlog).
+        data = share_service.get_last_shared_app_and_app_list(self.tenant.enterprise_id, self.tenant, group_id, scope,  # type: ignore[arg-type]
+                                                              market_name, user_id, preferred_app_id, preferred_version)  # type: ignore[arg-type]
         result = general_message(
             200, "get shared apps list complete", None, bean=data["last_shared_app"], list=data["app_model_list"])
         return Response(result, status=200)
 
 
 class AppMarketCLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         extend = request.GET.get("extend", "false")
         for_publish = request.GET.get("for_publish", "false").lower() == "true"
         user_id = self.user.user_id if os.getenv("USE_SAAS") and for_publish else None
-        app_markets = app_market_service.get_app_markets(enterprise_id, extend, user_id, for_publish)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        app_markets = app_market_service.get_app_markets(enterprise_id, extend, user_id, for_publish)  # type: ignore[arg-type]
         result = general_message(200, "success", None, list=app_markets)
         return Response(result, status=200)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.data.get("name")
-        if not market_name_format(name):
+        # NOTE: request.data.get is Optional; legacy assumes present str (backlog).
+        if not market_name_format(name):  # type: ignore[arg-type]
             raise ServiceHandleException(msg="name format error", msg_show="标识必须以字母开头且为数字字母组合")
-        if len(name) > 64:
+        if len(name) > 64:  # type: ignore[arg-type]
             raise ServiceHandleException(msg="store note too lang", msg_show="应用市场标识字符串长度不能超过64")
         access_key = request.data.get("access_key")
-        if len(access_key) > 255:
+        if len(access_key) > 255:  # type: ignore[arg-type]
             raise ServiceHandleException(msg="access key too long", msg_show="Access Key 字符串长度不能超过255")
         dt = {
             "name": name,
@@ -675,7 +696,8 @@ class AppMarketCLView(JWTAuthApiView):
         }
 
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        app_market = app_market_service.create_app_market(dt, user_id)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        app_market = app_market_service.create_app_market(dt, user_id)  # type: ignore[arg-type]
         result = general_message(200, "success", None, bean=app_market.to_dict())
         try:
             market = app_store.get_market(app_market)
@@ -686,12 +708,12 @@ class AppMarketCLView(JWTAuthApiView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.ADD, module=OperationModule.APPSTORE, module_name="{}".format(app_store_name))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
 
 class AppMarketBatchCView(JWTAuthApiView):
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         data = []
         market_names = []
         for market in request.data.get("markets", []):
@@ -714,27 +736,29 @@ class AppMarketBatchCView(JWTAuthApiView):
             market_names.append(name)
 
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        app_market = app_market_service.batch_create_app_market(enterprise_id, data, user_id)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        app_market = app_market_service.batch_create_app_market(enterprise_id, data, user_id)  # type: ignore[arg-type]
         app_store_names = ", ".join([mk["alias"] for mk in app_market if mk["name"] in market_names])
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.ADD, module=OperationModule.APPSTORE, module_name=" {}".format(app_store_names))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         result = general_message(200, "success", None, bean=app_market)
         return Response(result, status=200)
 
 
 class AppMarketRUDView(JWTAuthApiView):
-    def get(self, request, enterprise_id, market_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, market_name: str, *args: Any, **kwargs: Any) -> Response:
         extend = request.GET.get("extend", "false")
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        market, _ = app_market_service.get_app_market(enterprise_id, market_name, user_id, extend, raise_exception=True)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        market, _ = app_market_service.get_app_market(enterprise_id, market_name, user_id, extend, raise_exception=True)  # type: ignore[arg-type]
         result = general_message(200, "success", None, list=market)
         return Response(result, status=200)
 
-    def put(self, request, enterprise_id, market_name, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, market_name: str, *args: Any, **kwargs: Any) -> Response:
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)
+        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
         request.data["enterprise_id"] = enterprise_id
         request.data["market_name"] = market_name
         new_market = app_market_service.update_app_market(market_model, request.data)
@@ -748,12 +772,12 @@ class AppMarketRUDView(JWTAuthApiView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.UPDATE, module=OperationModule.APPSTORE, module_name="{}".format(app_store_name))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
-    def delete(self, request, enterprise_id, market_name, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, market_name: str, *args: Any, **kwargs: Any) -> Response:
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)
+        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
         market_model.delete()
         result = general_message(200, "success", None)
         try:
@@ -765,12 +789,12 @@ class AppMarketRUDView(JWTAuthApiView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.APPSTORE, module_name="{}".format(app_store_name))
         operation_log_service.create_component_library_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
 
 class AppMarketAppModelLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, market_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, market_name: str, *args: Any, **kwargs: Any) -> Response:
         query = request.GET.get("query", None)
         query_all = request.GET.get("query_all", False)
         page = int(request.GET.get("page", 1))
@@ -779,15 +803,16 @@ class AppMarketAppModelLView(JWTAuthApiView):
         arch = request.GET.get("arch", "")
         market_model = app_market_service.get_app_market_by_name(enterprise_id, market_name, None, raise_exception=True)
         if is_plugin == "true":
+            # NOTE: query_all from query params is str|bool; service expects bool (backlog).
             data, page, page_size, total = app_market_service.get_market_plugins_apps(
-                market_model, page, page_size, query=query, query_all=query_all, extend=True)
+                market_model, page, page_size, query=query, query_all=query_all, extend=True)  # type: ignore[arg-type]
         else:
             data, page, page_size, total = app_market_service.get_market_app_list(
-                market_model, page, page_size, query=query, query_all=query_all, extend=True, arch=arch)
+                market_model, page, page_size, query=query, query_all=query_all, extend=True, arch=arch)  # type: ignore[arg-type]
         result = general_message(200, msg="success", msg_show=None, list=data, page=page, page_size=page_size, total=total)
         return Response(result, status=200)
 
-    def post(self, request, enterprise_id, market_name, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, market_name: str, *args: Any, **kwargs: Any) -> Response:
         logo = request.data.get("logo")
         base64_logo = ""
         if logo:
@@ -812,35 +837,41 @@ class AppMarketAppModelLView(JWTAuthApiView):
             "introduction": request.data.get("introduction"),
         }
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        market = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        market = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
         rst = app_market_service.create_market_app_model(market, body=dt)
         result = general_message(200, msg="success", msg_show=None, bean=(rst.to_dict() if rst else None))
         return Response(result, status=200)
 
 
 class AppMarketAppModelVersionsLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, market_name, app_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, market_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         query_all = request.GET.get("query_all", False)
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        market_model = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)
-        data = app_market_service.get_market_app_model_versions(market_model, app_id, query_all=query_all, extend=True)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        market_model = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
+        # NOTE: query_all from query params is str|bool; service expects bool (backlog).
+        data = app_market_service.get_market_app_model_versions(market_model, app_id, query_all=query_all, extend=True)  # type: ignore[arg-type]
         result = general_message(200, "success", None, list=data)
         return Response(result, status=200)
 
 
 class AppMarketAppModelVersionsRView(JWTAuthApiView):
-    def get(self, request, enterprise_id, market_name, app_id, version, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, market_name: str, app_id: str, version: str, *args: Any,
+            **kwargs: Any) -> Response:
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        _, market_model = app_market_service.get_app_market(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
         data = app_market_service.get_market_app_model_version(market_model, app_id, version, extend=True)
         result = general_message(200, "success", None, bean=data)
         return Response(result, status=200)
 
 
 class AppMarketOrgModelLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, market_name):
+    def get(self, request: Request, enterprise_id: str, market_name: str) -> Response:
         user_id = self.user.user_id if os.getenv("USE_SAAS") else None
-        market_model = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)
+        # NOTE: user_id int AutoField; service takes str (systemic int-as-str, backlog).
+        market_model = app_market_service.get_app_market_by_name(enterprise_id, market_name, user_id, raise_exception=True)  # type: ignore[arg-type]
         orgs = app_market_service.get_market_orgs(market_model)
         result = general_message(200, msg="success", msg_show=None, list=orgs)
         return Response(result, status=200)

--- a/console/views/service_version.py
+++ b/console/views/service_version.py
@@ -4,9 +4,11 @@
 """
 import logging
 import operator
+from typing import Any
 
 from django.core.paginator import Paginator
 from console.utils.cache_decorators import never_cache
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.virtual_machine import vm_repo
@@ -28,7 +30,7 @@ BUILD_KIND_MAP = {
 
 class AppVersionsView(AppBaseView):
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的构建版本
         ---
@@ -47,8 +49,9 @@ class AppVersionsView(AppBaseView):
         page = request.GET.get("page_num", 1)
         page_size = request.GET.get("page_size", 10)
         body = region_api.get_service_build_versions(self.response_region, self.tenant.tenant_name, self.service.service_alias)
-        build_version_sort = body["bean"]["list"]
-        run_version = body["bean"]["deploy_version"]
+        # NOTE: region_api may return None; indexing assumes dict (index backlog).
+        build_version_sort = body["bean"]["list"]  # type: ignore[index]
+        run_version = body["bean"]["deploy_version"]  # type: ignore[index]
         total_num_list = list()
         for build_version_info in build_version_sort:
             if build_version_info["final_status"] in ("success", "failure"):
@@ -75,7 +78,8 @@ class AppVersionsView(AppBaseView):
             if repo_url and repo_url[0] == "/":
                 kind = "本地文件"
             else:
-                kind = BUILD_KIND_MAP.get(info["kind"])
+                # NOTE: BUILD_KIND_MAP.get may return None; kind inferred str (assignment backlog).
+                kind = BUILD_KIND_MAP.get(info["kind"])  # type: ignore[assignment]
             version = {
                 "event_id": info["event_id"],
                 "build_version": info["build_version"],
@@ -138,7 +142,7 @@ class AppVersionsView(AppBaseView):
 
 class AppVersionManageView(AppBaseView):
     @never_cache
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除组件的某次构建版本
         ---
@@ -171,7 +175,7 @@ class AppVersionManageView(AppBaseView):
         return Response(result, status=result["code"])
 
     @never_cache
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取组件的某个具体版本
         ---
@@ -199,7 +203,7 @@ class AppVersionManageView(AppBaseView):
 
         res, body = region_api.get_service_build_version_by_id(self.response_region, self.tenant.tenant_name,
                                                                self.service.service_alias, version_id)
-        data = body['bean']
+        data = body['bean']  # type: ignore[index]
 
         result = general_message(200, "success", "查询成功", bean={"is_exist": data["status"]})
         return Response(result, status=result["code"])

--- a/console/views/services_toplogical.py
+++ b/console/views/services_toplogical.py
@@ -3,7 +3,9 @@
   Created on 2018/3/21.
 """
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.group import group_repo
@@ -21,7 +23,7 @@ logger = logging.getLogger('default')
 
 
 class TopologicalGraphView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         应用拓扑图(未分组应用无拓扑图, 直接返回列表展示)
         ---
@@ -41,8 +43,10 @@ class TopologicalGraphView(RegionTenantHeaderView):
         code = 200
         if group_id == "-1":
             code = 200
+            # NOTE: latent bug — missing required team_id/enterprise_id args (TypeError if
+            # reached); behavior preserved.
             no_service_list = service_repo.get_no_group_service_status_by_group_id(
-                team_name=self.team_name, region_name=self.response_region)
+                team_name=self.team_name, region_name=self.response_region)  # type: ignore[call-arg]
             result = general_message(200, "query success", "应用查询成功", list=no_service_list)
         else:
             if group_id is None or not group_id.isdigit():
@@ -55,14 +59,16 @@ class TopologicalGraphView(RegionTenantHeaderView):
                 code = 202
                 result = general_message(code, "group is not yours!", "当前组已删除或您无权限查看!", bean={})
                 return Response(result, status=200)
+            # NOTE: enterprise_id is nullable but callee expects str (arg-type backlog).
             topological_info = topological_service.get_group_topological_graph(
-                group_id=group_id, region=self.response_region, team_name=self.team_name, enterprise_id=self.team.enterprise_id)
+                group_id=group_id, region=self.response_region, team_name=self.team_name,
+                enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]
             result = general_message(code, "Obtain topology success.", "获取拓扑图成功", bean=topological_info)
         return Response(result, status=code)
 
 
 class GroupServiceDetView(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         拓扑图中组件详情
         ---
@@ -91,7 +97,7 @@ class GroupServiceDetView(AppBaseView):
 
 
 class TopologicalInternetView(RegionTenantHeaderView):
-    def get(self, request, team_name, group_id, *args, **kwargs):
+    def get(self, request: Request, team_name: str, group_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         拓扑图中Internet详情
         ---
@@ -111,7 +117,7 @@ class TopologicalInternetView(RegionTenantHeaderView):
         if group_id == "-1":
             code = 200
             no_service_list = service_repo.get_no_group_service_status_by_group_id(
-                team_name=self.team_name, region_name=self.response_region)
+                team_name=self.team_name, region_name=self.response_region)  # type: ignore[call-arg]
             result = general_message(200, "query success", "应用获取成功", list=no_service_list)
         else:
             code = 200

--- a/console/views/sms_config.py
+++ b/console/views/sms_config.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.views.base import EnterpriseAdminView
 from console.services.config_service import EnterpriseConfigService
@@ -9,7 +11,7 @@ from www.utils.return_message import general_message
 logger = logging.getLogger("default")
 
 class SMSConfigView(EnterpriseAdminView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取短信配置
         ---
@@ -21,7 +23,8 @@ class SMSConfigView(EnterpriseAdminView):
               paramType: path
         """
         try:
-            config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)
+            # NOTE: Users.user_id is an int AutoField but service expects str (systemic int-as-str; backlog).
+            config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
             sms_config = config_service.get_config_by_key("SMS_CONFIG")
             
             if not sms_config:
@@ -41,8 +44,10 @@ class SMSConfigView(EnterpriseAdminView):
                 "获取成功",
                 bean={
                     "sms_config": {
-                        "enable": sms_config.enable,
-                        "value": eval(sms_config.value) if sms_config.type == "json" else sms_config.value
+                        # NOTE: get_config_by_key may return None; attribute access is a latent risk (backlog).
+                        "enable": sms_config.enable,  # type: ignore[union-attr]
+                        "value": eval(sms_config.value) if sms_config.type == "json"  # type: ignore[union-attr,arg-type]
+                        else sms_config.value  # type: ignore[union-attr]
                     }
                 }
             )
@@ -53,7 +58,7 @@ class SMSConfigView(EnterpriseAdminView):
             result = general_message(500, "获取短信配置失败", "{}".format(e))
             return Response(result, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    def put(self, request, enterprise_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         更新短信配置
         ---
@@ -82,7 +87,7 @@ class SMSConfigView(EnterpriseAdminView):
                     result = general_message(400, "参数错误", "缺少必要的配置字段: {}".format(field))
                     return Response(result, status=status.HTTP_400_BAD_REQUEST)
 
-            config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)
+            config_service = EnterpriseConfigService(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
             # 更新配置
             config = config_service.update_config_by_key("SMS_CONFIG", sms_config)
 

--- a/console/views/sms_verification.py
+++ b/console/views/sms_verification.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import ServiceHandleException
@@ -12,7 +14,7 @@ from www.utils.return_message import general_message
 logger = logging.getLogger("default")
 
 class SMSVerificationView(BaseApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         发送短信验证码
         ---

--- a/console/views/storage_statistics.py
+++ b/console/views/storage_statistics.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.views.base import AlowAnyApiView
 from www.utils.return_message import general_message
@@ -9,7 +11,7 @@ logger = logging.getLogger("default")
 
 
 class StorageStatistics(AlowAnyApiView):
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         """
         获取存储使用统计
         ---

--- a/console/views/task_guidance.py
+++ b/console/views/task_guidance.py
@@ -1,7 +1,9 @@
 # -*- coding: utf8 -*-
 
 import logging
+from typing import Any
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.views.base import EnterpriseHeaderView
@@ -14,11 +16,11 @@ base_task_guidance = BaseTaskGuidance()
 
 
 class BaseGuidance(EnterpriseHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             data = base_task_guidance.list_base_tasks(self.enterprise.enterprise_id)
             result = general_message(200, "success", "请求成功", list=data)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]  # NOTE: py2 Exception.message
         return Response(result, status=result["code"])

--- a/console/views/team.py
+++ b/console/views/team.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+from typing import Any
 
 from console.exception.bcode import ErrK8sServiceNameExists, ErrQualifiedName, ErrNamespaceExists
 from console.exception.exceptions import (NoEnableRegionError, TenantExistError, UserNotExistError)
@@ -36,6 +37,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import transaction
 from django.db.models import Q
 from goodrain_web.tools import JuncheePaginator
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import Tenants
@@ -45,7 +47,7 @@ region_api = RegionInvokeApi()
 logger = logging.getLogger("default")
 
 
-def get_sufix_path(full_url):
+def get_sufix_path(full_url: str) -> str:
     """获取get请求参数路径部分的数据"""
     index = full_url.find("?")
     sufix = ""
@@ -55,7 +57,7 @@ def get_sufix_path(full_url):
 
 
 class UserFuzSerView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         模糊查询用户
         ---
@@ -83,7 +85,7 @@ class UserFuzSerView(JWTAuthApiView):
 
 
 class TeamUserDetaislView(JWTAuthApiView):
-    def get(self, request, team_name, user_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, user_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         用户详情
         ---
@@ -102,13 +104,16 @@ class TeamUserDetaislView(JWTAuthApiView):
         is_team_owner = False
         try:
             team = team_services.get_tenant_by_tenant_name(team_name)
-            data = dict()
+            data: dict = dict()
             data["nick_name"] = self.user.nick_name
             data["email"] = self.user.email
-            role_list = user_kind_role_service.get_user_roles(kind="team", kind_id=team.tenant_id, user=self.user)
+            # NOTE: repo/service lookups return Optional but legacy code assumes present;
+            # systemic int-as-str / nullable enterprise_id mismatches also suppressed (backlog).
+            role_list = user_kind_role_service.get_user_roles(
+                kind="team", kind_id=team.tenant_id, user=self.user)  # type: ignore[union-attr]
             data["teams_identity"] = role_list["roles"]
             data["is_enterprise_admin"] = self.is_enterprise_admin
-            if team.creater == self.user.user_id:
+            if team.creater == self.user.user_id:  # type: ignore[union-attr]
                 is_team_owner = True
             data["is_team_owner"] = is_team_owner
             code = 200
@@ -123,7 +128,7 @@ class TeamUserDetaislView(JWTAuthApiView):
 
 class AddTeamView(JWTAuthApiView):
     @transaction.atomic()
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         新建团队
         ---
@@ -149,14 +154,19 @@ class AddTeamView(JWTAuthApiView):
             if bind_existing_namespace and not namespace:
                 return Response(general_message(400, "failed", "namespace 不能为空"), status=400)
             if not is_qualified_name(namespace):
-                raise ErrQualifiedName(msg="invalid namespace name", msg_show="命名空间只能由小写字母、数字或"-"组成，并且必须以字母开始、以数字或字母结尾")
+                # NOTE: latent bug — msg_show string has ASCII quotes around "-" so Python
+                # tokenizes it as "str" - "str" (runtime TypeError if reached); preserved.
+                raise ErrQualifiedName(msg="invalid namespace name", msg_show="命名空间只能由小写字母、数字或"-"组成，并且必须以字母开始、以数字或字母结尾")  # type: ignore[operator]
             regions = []
             if not team_alias:
                 result = general_message(400, "failed", "团队名不能为空")
                 return Response(result, status=400)
             if useable_regions:
                 regions = useable_regions.split(",")
-            if Tenants.objects.filter(tenant_alias=team_alias, enterprise_id=user.enterprise_id).exists():
+            # NOTE: request.user is typed User|AnonymousUser; .enterprise_id/.user_id only on
+            # the authed user — recurring union-attr suppressed (backlog).
+            if Tenants.objects.filter(
+                    tenant_alias=team_alias, enterprise_id=user.enterprise_id).exists():  # type: ignore[union-attr]
                 result = general_message(400, "failed", "该团队名已存在")
                 return Response(result, status=400)
             else:
@@ -179,7 +189,7 @@ class AddTeamView(JWTAuthApiView):
                     exist_namespace_region = ""
                     for region_name in exist_namespace_region_names:
                         region = region_repo.get_region_by_region_name(region_name)
-                        exist_namespace_region += " {}".format(region.region_alias)
+                        exist_namespace_region += " {}".format(region.region_alias)  # type: ignore[union-attr]
                     return Response(
                         general_message(
                             400,
@@ -194,11 +204,12 @@ class AddTeamView(JWTAuthApiView):
                 },
                     ensure_ascii=False)
                 comment = operation_log_service.generate_team_comment(
-                    operation=Operation.CREATE, module_name=team.tenant_alias, team_name=team.tenant_name)
+                    operation=Operation.CREATE, module_name=team.tenant_alias,  # type: ignore[arg-type]
+                    team_name=team.tenant_name)
                 operation_log_service.create_team_log(
                     user=self.user,
                     comment=comment,
-                    enterprise_id=self.user.enterprise_id,
+                    enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                     team_name=team.tenant_name,
                     new_information=new_information)
                 return Response(general_message(200, "success", "团队添加成功", bean=team.to_dict()))
@@ -215,7 +226,7 @@ class AddTeamView(JWTAuthApiView):
 
 
 class TeamUserView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取某团队下的所有用户(每页展示八个用户)
         ---
@@ -236,7 +247,7 @@ class TeamUserView(RegionTenantHeaderView):
         name = request.GET.get("query", None)
         user_list = team_services.get_team_users(self.tenant, name)
         if not user_list:
-            users = []
+            users: Any = []
             total = 0
         else:
             users_list = list()
@@ -264,7 +275,7 @@ class TeamUserView(RegionTenantHeaderView):
 
 
 class NotJoinTeamUserView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         query = request.GET.get("query")
@@ -273,7 +284,7 @@ class NotJoinTeamUserView(RegionTenantHeaderView):
             result = general_message(404, "not found", "团队不存在")
             return Response(data=result, status=404)
         enterprise = enterprise_repo.get_enterprise_by_enterprise_id(tenant.enterprise_id)
-        user_list = team_services.get_not_join_users(enterprise, tenant, query)
+        user_list = team_services.get_not_join_users(enterprise, tenant, query)  # type: ignore[arg-type]
         total = len(user_list)
         data = user_list[(page - 1) * page_size:page * page_size]
         result = general_message(200, None, None, list=data, page=page, page_size=page_size, total=total)
@@ -281,7 +292,7 @@ class NotJoinTeamUserView(RegionTenantHeaderView):
 
 
 class UserDelView(RegionTenantHeaderView):
-    def delete(self, request, team_name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除租户内的用户
         (可批量可单个)
@@ -304,7 +315,7 @@ class UserDelView(RegionTenantHeaderView):
                 result = general_message(400, "failed", "删除成员不能为空")
                 return Response(result, status=400)
 
-            if request.user.user_id in user_ids:
+            if request.user.user_id in user_ids:  # type: ignore[union-attr]
                 result = general_message(400, "failed", "不能删除自己")
                 return Response(result, status=400)
 
@@ -322,29 +333,30 @@ class UserDelView(RegionTenantHeaderView):
                 result = general_message(200, "delete the success", "删除成功")
                 comment = operation_log_service.generate_team_comment(
                     operation=Operation.IN,
-                    module_name=self.tenant.tenant_alias,
+                    module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                     region=self.response_region,
                     team_name=self.tenant.tenant_name,
                     suffix=suffix)
                 operation_log_service.create_team_log(
-                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,
+                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                     team_name=self.tenant.tenant_name)
             except Tenants.DoesNotExist as e:
                 logger.exception(e)
                 result = general_message(400, "tenant not exist", "{}团队不存在".format(team_name))
             except Exception as e:
                 logger.exception(e)
-                result = error_message(e.message)
+                # NOTE: py2-era Exception.message; absent in py3 (backlog, behavior preserved).
+                result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result)
         except Exception as e:
             code = 500
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=code)
 
 
 class TeamNameModView(RegionTenantHeaderView):
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         修改团队名
         ---
@@ -368,18 +380,19 @@ class TeamNameModView(RegionTenantHeaderView):
                 old_information = json.dumps({"团队名称": self.tenant.tenant_alias}, ensure_ascii=False)
                 team = team_services.update_tenant_info(tenant_name=team_name, new_team_alias=new_team_alias, new_logo=new_logo)
                 new_information = json.dumps({"团队名称": new_team_alias}, ensure_ascii=False)
-                result = general_message(code, "update success", "团队信息修改成功", bean=team.to_dict())
+                result = general_message(
+                    code, "update success", "团队信息修改成功", bean=team.to_dict())  # type: ignore[union-attr]
                 comment = operation_log_service.generate_team_comment(
                     operation=Operation.CHANGE,
-                    module_name=team.tenant_alias,
+                    module_name=team.tenant_alias,  # type: ignore[arg-type,union-attr]
                     region=self.region_name,
-                    team_name=team.tenant_name,
+                    team_name=team.tenant_name,  # type: ignore[union-attr]
                     suffix=" 的名称")
                 operation_log_service.create_team_log(
                     user=self.user,
                     comment=comment,
-                    enterprise_id=self.user.enterprise_id,
-                    team_name=team.tenant_name,
+                    enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+                    team_name=team.tenant_name,  # type: ignore[union-attr]
                     new_information=new_information,
                     old_information=old_information)
             except Exception as e:
@@ -393,7 +406,7 @@ class TeamNameModView(RegionTenantHeaderView):
 
 
 class TeamDelView(JWTAuthApiView):
-    def delete(self, request, team_name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除当前团队
         ---
@@ -409,23 +422,24 @@ class TeamDelView(JWTAuthApiView):
         if tenant is None:
             result = general_message(404, "tenant not exist", "{}团队不存在".format(team_name))
         else:
-            old_region_dict = {"团队名称": tenant.tenant_alias, "团队英文名称": tenant.namespace}
+            old_region_dict: dict = {"团队名称": tenant.tenant_alias, "团队英文名称": tenant.namespace}
             region_list = team_services.delete_by_tenant_id(self.user, tenant)
             old_region_dict["集群"] = region_list
             old_information = json.dumps(old_region_dict, ensure_ascii=False)
             result = general_message(200, "delete a tenant successfully", "删除团队成功")
-            comment = operation_log_service.generate_team_comment(operation=Operation.DELETE, module_name=tenant.tenant_alias)
+            comment = operation_log_service.generate_team_comment(
+                operation=Operation.DELETE, module_name=tenant.tenant_alias)  # type: ignore[arg-type]
             operation_log_service.create_team_log(
                 user=self.user,
                 comment=comment,
-                enterprise_id=self.user.enterprise_id,
+                enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=tenant.tenant_name,
                 old_information=old_information)
         return Response(result, status=result["code"])
 
 
 class TeamExitView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         退出当前团队
         ---
@@ -438,21 +452,24 @@ class TeamExitView(RegionTenantHeaderView):
         """
         if self.is_team_owner:
             return Response(general_message(409, "not allow exit.", "您是当前团队创建者，不能退出此团队"), status=409)
-        code, msg_show = team_services.exit_current_team(team_name=team_name, user_id=request.user.user_id)
+        code, msg_show = team_services.exit_current_team(
+            team_name=team_name, user_id=request.user.user_id)  # type: ignore[union-attr]
         if code == 200:
             result = general_message(code=code, msg="success", msg_show=msg_show)
             tenant = team_services.get_tenant_by_tenant_name(team_name)
             comment = operation_log_service.generate_team_comment(
-                operation=Operation.EXIT, module_name=tenant.tenant_alias, team_name=tenant.tenant_name)
+                operation=Operation.EXIT, module_name=tenant.tenant_alias,  # type: ignore[arg-type,union-attr]
+                team_name=tenant.tenant_name)  # type: ignore[union-attr]
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=tenant.tenant_name)
+                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+                team_name=tenant.tenant_name)  # type: ignore[union-attr]
         else:
             result = general_message(code=code, msg="failed", msg_show=msg_show)
         return Response(result, status=result.get("code", 200))
 
 
 class TeamRegionInitView(JWTAuthApiView):
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         """
         初始化团队和数据中心信息
         ---
@@ -490,12 +507,15 @@ class TeamRegionInitView(JWTAuthApiView):
 
             team = team_services.create_team(self.user, enterprise, [region_name], team_alias)
             # 为团队开通默认数据中心并在数据中心创建租户
-            tenant_region = region_services.create_tenant_on_region(enterprise.enterprise_id, team.tenant_name, team.region,
-                                                                    team.namespace)
+            # NOTE: latent bug — Tenants has no attribute "region" (AttributeError if reached); preserved.
+            tenant_region = region_services.create_tenant_on_region(
+                enterprise.enterprise_id, team.tenant_name, team.region,  # type: ignore[attr-defined]
+                team.namespace)
             # 公有云，如果没有领过资源包，为开通的数据中心领取免费资源包
             if settings.MODULES.get('SSO_LOGIN'):
-                result = region_services.get_enterprise_free_resource(tenant_region.tenant_id, enterprise.enterprise_id,
-                                                                      tenant_region.region_name, self.user.nick_name)
+                result = region_services.get_enterprise_free_resource(
+                    tenant_region.tenant_id, enterprise.enterprise_id,
+                    tenant_region.region_name, self.user.nick_name)  # type: ignore[arg-type]
                 logger.debug("get free resource on [{}] to team {}: {}".format(tenant_region.region_name, team.tenant_name,
                                                                                result))
             self.user.is_active = True
@@ -505,12 +525,12 @@ class TeamRegionInitView(JWTAuthApiView):
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class ApplicantsView(RegionTenantHeaderView):
-    def get(self, request, team_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         初始化团队和数据中心信息
         ---
@@ -547,65 +567,67 @@ class ApplicantsView(RegionTenantHeaderView):
         result = general_message(200, "success", "查询成功", list=rt_list, total=total)
         return Response(result, status=result["code"])
 
-    def put(self, request, team_name, *args, **kwargs):
+    def put(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """管理员审核用户"""
         user_id = request.data.get("user_id")
         action = request.data.get("action")
         role_ids = request.data.get("role_ids")
-        join = apply_repo.get_applicants_by_id_team_name(user_id=user_id, team_name=team_name)
-        user = user_services.get_user_by_user_id(user_id)
+        join = apply_repo.get_applicants_by_id_team_name(user_id=user_id, team_name=team_name)  # type: ignore[arg-type]
+        user = user_services.get_user_by_user_id(user_id)  # type: ignore[arg-type]
         if action is True:
             join.update(is_pass=1)
             team = team_repo.get_team_by_team_name(team_name=team_name)
-            team_services.add_user_to_team(tenant=team, user_id=user_id, role_ids=role_ids)
+            team_services.add_user_to_team(tenant=team, user_id=user_id, role_ids=role_ids)  # type: ignore[arg-type]
             # 发送通知
             info = "同意"
-            self.send_user_message_for_apply_info(user_id=user_id, team_name=team.tenant_name, info=info)
+            self.send_user_message_for_apply_info(
+                user_id=user_id, team_name=team.tenant_name, info=info)  # type: ignore[arg-type,union-attr]
             comment = operation_log_service.generate_team_comment(
                 operation="{0}用户 {1} 加入".format(Operation.THROUGH.value, user.get_name()),
-                module_name=team.tenant_alias,
-                team_name=team.tenant_name,
+                module_name=team.tenant_alias,  # type: ignore[arg-type,union-attr]
+                team_name=team.tenant_name,  # type: ignore[union-attr]
                 suffix=" 的申请")
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=team.tenant_name)
+                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+                team_name=team.tenant_name)  # type: ignore[union-attr]
             return Response(general_message(200, "join success", "加入成功"), status=200)
         else:
             join.update(is_pass=2)
             info = "拒绝"
-            self.send_user_message_for_apply_info(user_id=user_id, team_name=team_name, info=info)
+            self.send_user_message_for_apply_info(user_id=user_id, team_name=team_name, info=info)  # type: ignore[arg-type]
             comment = operation_log_service.generate_team_comment(
                 operation="{0}用户 {1} 加入".format(Operation.REJECT.value, user.get_name()),
-                module_name=self.tenant.tenant_alias,
+                module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name,
                 suffix=" 的申请")
             operation_log_service.create_team_log(
-                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,
+                user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
                 team_name=self.tenant.tenant_name)
             return Response(general_message(200, "join rejected", "拒绝成功"), status=200)
 
     # 用户加入团队，发送站内信给用户
-    def send_user_message_for_apply_info(self, user_id, team_name, info):
+    def send_user_message_for_apply_info(self, user_id: str, team_name: str, info: str) -> None:
         tenant = team_repo.get_tenant_by_tenant_name(tenant_name=team_name)
         message_id = make_uuid()
-        content = '{0}团队{1}您加入该团队'.format(tenant.tenant_alias, info)
+        content = '{0}团队{1}您加入该团队'.format(tenant.tenant_alias, info)  # type: ignore[union-attr]
         UserMessage.objects.create(
             message_id=message_id, receiver_id=user_id, content=content, msg_type="warn", title="用户加入团队信息")
 
 
 class MonitorAlarmStatusView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         alarm_config = platform_config_service.get_config_by_key("IS_ALARM")
-        if alarm_config.enable is False:
+        if alarm_config.enable is False:  # type: ignore[union-attr]
             return Response(general_message(200, "status is close", "报警关闭状态", bean={"is_alarm": False}), status=200)
         else:
             return Response(general_message(200, "status is open", "报警开启状态", bean={"is_alarm": True}), status=200)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改开启、关闭报警状态
         """
-        user_id = request.user.user_id
-        enterprise_id = request.user.enterprise_id
+        user_id = request.user.user_id  # type: ignore[union-attr]
+        enterprise_id = request.user.enterprise_id  # type: ignore[union-attr]
         admin = enterprise_user_perm_repo.is_admin(user_id=user_id, eid=enterprise_id)
         is_alarm = request.data.get("is_alarm")
         if admin:
@@ -622,19 +644,19 @@ class MonitorAlarmStatusView(JWTAuthApiView):
 
 
 class RegisterStatusView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         register_config = platform_config_service.get_config_by_key("IS_REGIST")
-        if register_config.enable is False:
+        if register_config.enable is False:  # type: ignore[union-attr]
             return Response(general_message(200, "status is close", "注册关闭状态", bean={"is_regist": False}), status=200)
         else:
             return Response(general_message(200, "status is open", "注册开启状态", bean={"is_regist": True}), status=200)
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改开启、关闭注册状态
         """
-        user_id = request.user.user_id
-        enterprise_id = request.user.enterprise_id
+        user_id = request.user.user_id  # type: ignore[union-attr]
+        enterprise_id = request.user.enterprise_id  # type: ignore[union-attr]
         admin = enterprise_user_perm_repo.is_admin(user_id=user_id, eid=enterprise_id)
         is_regist = request.data.get("is_regist")
         if admin:
@@ -644,48 +666,51 @@ class RegisterStatusView(JWTAuthApiView):
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.CLOSE, module=OperationModule.USER, module_name=OperationModule.REGISTER.value)
                 operation_log_service.create_enterprise_log(
-                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
                 return Response(general_message(200, "close register", "关闭注册"), status=200)
             else:
                 platform_config_service.update_config("IS_REGIST", {"enable": True, "value": None})
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.OPEN, module=OperationModule.USER, module_name=OperationModule.REGISTER.value)
                 operation_log_service.create_enterprise_log(
-                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
                 return Response(general_message(200, "open register", "开启注册"), status=200)
         else:
             return Response(general_message(400, "no jurisdiction", "没有权限"), status=400)
 
 
 class EnterpriseInfoView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询企业信息
         """
         enter = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id=self.team.enterprise_id)
-        ent = enter.to_dict()
+        ent = enter.to_dict()  # type: ignore[union-attr]
         is_ent = False
         try:
             res, body = region_api.get_api_version_v2(self.team.tenant_name, self.response_region)
             if res.status == 200 and body is not None and "enterprise" in body["raw"]:
                 is_ent = True
         except region_api.CallApiError as e:
-            logger.warning("数据中心{0}不可达,无法获取相关信息: {1}".format(self.response_region.region_name, e.message))
+            # NOTE: response_region is a str (region name); .region_name is invalid and
+            # Exception.message is py2-only — both would raise if reached (preserved).
+            logger.warning("数据中心{0}不可达,无法获取相关信息: {1}".format(
+                self.response_region.region_name, e.message))  # type: ignore[attr-defined]
         ent["is_enterprise"] = is_ent
         result = general_message(200, "success", "查询成功", bean=ent)
         return Response(result, status=result["code"])
 
 
 class InitDefaultInfoView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         初始化默认信息
         """
         enter = enterprise_repo.get_enterprise_by_enterprise_id(enterprise_id=self.enterprise.enterprise_id)
-        ent = enter.to_dict()
+        ent = enter.to_dict()  # type: ignore[union-attr]
         is_ent = False
         ent["is_enterprise"] = is_ent
-        regions = region_repo.get_regions_by_enterprise_id(self.enterprise.enterprise_id, 1)
+        regions = region_repo.get_regions_by_enterprise_id(self.enterprise.enterprise_id, 1)  # type: ignore[arg-type]
         ent["disable_install_cluster_log"] = False
         ent["default_region"] = regions[0].to_dict()
         result = general_message(200, "success", "查询成功", bean=ent)
@@ -693,7 +718,7 @@ class InitDefaultInfoView(JWTAuthApiView):
 
 
 class UserApplyStatusView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """查询用户的申请状态"""
         try:
             user_id = request.GET.get("user_id", None)
@@ -703,17 +728,17 @@ class UserApplyStatusView(JWTAuthApiView):
                 result = general_message(200, "success", "查询成功", list=status_list)
                 return Response(result, status=result["code"])
             else:
-                user_list = apply_repo.get_applicants_team(user_id=self.user.user_id)
+                user_list = apply_repo.get_applicants_team(user_id=self.user.user_id)  # type: ignore[arg-type]
                 status_list = [user_status.to_dict() for user_status in user_list]
                 result = general_message(200, "success", "查询成功", list=status_list)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=result["code"])
 
 
 class JoinTeamView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """查看指定用户加入的团队的状态"""
         user_id = request.GET.get("user_id", None)
         users = enterprise_repo.get_enterprise_users(self.enterprise.enterprise_id)
@@ -728,7 +753,7 @@ class JoinTeamView(JWTAuthApiView):
                 team["team_owner"] = team_creater[apply_teams_creater[team["team_id"]]]
             result = general_message(200, "success", "查询成功", list=team_list)
         else:
-            apply_user = apply_repo.get_applicants_team(user_id=self.user.user_id)
+            apply_user = apply_repo.get_applicants_team(user_id=self.user.user_id)  # type: ignore[arg-type]
             apply_team_ids = [apply.team_id for apply in apply_user]
             apply_teams = team_repo.get_team_by_team_ids(apply_team_ids)
             apply_teams_creater = {apply_team.tenant_id: apply_team.creater for apply_team in apply_teams}
@@ -738,53 +763,58 @@ class JoinTeamView(JWTAuthApiView):
             result = general_message(200, "success", "查询成功", list=team_list)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """指定用户加入指定团队"""
         user_id = self.user.user_id
         team_name = request.data.get("team_name")
         tenant = Tenants.objects.filter(tenant_name=team_name).first()
-        info = apply_service.create_applicants(user_id=user_id, team_name=team_name)
+        info = apply_service.create_applicants(user_id=user_id, team_name=team_name)  # type: ignore[arg-type]
         result = general_message(200, "apply success", "申请加入")
         if info:
-            admins = team_repo.get_tenant_admin_by_tenant_id(tenant)
-            self.send_user_message_to_tenantadmin(admins=admins, team_name=team_name, nick_name=self.user.get_name())
+            admins = team_repo.get_tenant_admin_by_tenant_id(tenant)  # type: ignore[arg-type]
+            self.send_user_message_to_tenantadmin(
+                admins=admins, team_name=team_name, nick_name=self.user.get_name())  # type: ignore[arg-type]
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.APPLYJOIN, module_name=tenant.tenant_alias, team_name=tenant.tenant_name)
+            operation=Operation.APPLYJOIN, module_name=tenant.tenant_alias,  # type: ignore[arg-type,union-attr]
+            team_name=tenant.tenant_name)  # type: ignore[union-attr]
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=tenant.tenant_name)  # type: ignore[union-attr]
         return Response(result, status=result["code"])
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         user_id = self.user.user_id
         team_name = request.data.get("team_name")
-        applicant = apply_repo.get_applicants_by_id_team_name(user_id=user_id, team_name=team_name)
+        applicant = apply_repo.get_applicants_by_id_team_name(user_id=user_id, team_name=team_name)  # type: ignore[arg-type]
         if not applicant:
             raise AbortRequest(msg="not found applicant", msg_show="该申请不存在", status_code=404)
         if applicant and applicant[0].is_pass == 1:
             result = general_message(409, "joined the team, applicant cannot be cancelled",
                                      "您已加入该团队，无法撤销申请")
             return Response(result, status=409)
-        apply_service.delete_applicants(user_id=user_id, team_name=team_name)
+        apply_service.delete_applicants(user_id=user_id, team_name=team_name)  # type: ignore[arg-type]
         result = general_message(200, "success", None)
         tenant = Tenants.objects.filter(tenant_name=team_name).first()
         comment = operation_log_service.generate_team_comment(
-            operation=Operation.CANCEL_JOIN, module_name=tenant.tenant_alias, team_name=tenant.tenant_name,
+            operation=Operation.CANCEL_JOIN, module_name=tenant.tenant_alias,  # type: ignore[arg-type,union-attr]
+            team_name=tenant.tenant_name,  # type: ignore[union-attr]
             suffix=" 的申请")
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=tenant.tenant_name)  # type: ignore[union-attr]
         return Response(result, status=200)
 
     # 用户加入团队，给管理员发送站内信
-    def send_user_message_to_tenantadmin(self, admins, team_name, nick_name):
+    def send_user_message_to_tenantadmin(self, admins: Any, team_name: str, nick_name: str) -> None:
         tenant = team_repo.get_tenant_by_tenant_name(tenant_name=team_name)
         logger.debug('---------admin---------->{0}'.format(admins))
         for admin in admins:
             message_id = make_uuid()
-            content = '{0}用户申请加入{1}团队'.format(nick_name, tenant.tenant_alias)
+            content = '{0}用户申请加入{1}团队'.format(nick_name, tenant.tenant_alias)  # type: ignore[union-attr]
             UserMessage.objects.create(
                 message_id=message_id, receiver_id=admin.user_id, content=content, msg_type="warn", title="团队加入信息")
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除用户加入团队被拒绝记录
         :param request:
@@ -805,20 +835,21 @@ class JoinTeamView(JWTAuthApiView):
                     apply_repo.delete_applicants_record(user_id=user_id, team_name=team_name, is_pass=int(is_pass))
                 else:
                     user_id = self.user.user_id
-                    apply_repo.delete_applicants_record(user_id=user_id, team_name=team_name, is_pass=int(is_pass))
+                    apply_repo.delete_applicants_record(
+                        user_id=user_id, team_name=team_name, is_pass=int(is_pass))  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
 
 class TeamUserCanJoin(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         """指定用户可以加入哪些团队"""
-        tenants = team_repo.get_tenants_by_user_id(user_id=self.user.user_id)
+        tenants = team_repo.get_tenants_by_user_id(user_id=self.user.user_id)  # type: ignore[arg-type]
         team_names = tenants.values("tenant_name")
         # 已加入的团队
         team_name_list = [t_name.get("tenant_name") for t_name in team_names]
         team_list = team_repo.get_teams_by_enterprise_id(enterprise_id)
-        apply_team = apply_repo.get_append_applicants_team(user_id=self.user.user_id)
+        apply_team = apply_repo.get_append_applicants_team(user_id=self.user.user_id)  # type: ignore[arg-type]
         # 已申请过的团队
         applied_team = [team_name.team_name for team_name in apply_team]
         can_join_team_list = []
@@ -840,7 +871,7 @@ class TeamUserCanJoin(JWTAuthApiView):
 
 
 class AllUserView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取企业下用户信息列表
         """
@@ -850,28 +881,31 @@ class AllUserView(JWTAuthApiView):
             page_size = int(request.GET.get("page_size", 5))
             user_name = request.GET.get("user_name", None)
             if not enterprise_id:
-                enter = console_enterprise_service.get_enterprise_by_id(enterprise_id=self.user.enterprise_id)
-                enterprise_id = enter.enterprise_id
+                enter = console_enterprise_service.get_enterprise_by_id(
+                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
+                enterprise_id = enter.enterprise_id  # type: ignore[union-attr]
             enter = console_enterprise_service.get_enterprise_by_id(enterprise_id=enterprise_id)
             if user_name:
                 euser = user_services.get_user_by_user_name(enterprise_id, user_name)
-                list = []
+                list: Any = []
                 if not euser:
                     result = general_message("0000", "success", "查询成功", list=list, total=0)
                     return Response(result)
-                result_map = dict()
+                result_map: dict = dict()
                 result_map["user_id"] = euser.user_id
                 result_map["email"] = euser.email
                 result_map["nick_name"] = euser.nick_name
                 result_map["phone"] = euser.phone if euser.phone else "暂无"
                 result_map["create_time"] = time_to_str(euser.create_time, "%Y-%m-%d %H:%M:%S")
-                tenant_list = user_services.get_user_tenants(euser.user_id)
+                tenant_list = user_services.get_user_tenants(euser.user_id)  # type: ignore[arg-type]
                 result_map["tenants"] = tenant_list
-                result_map["enterprise_alias"] = enter.enterprise_alias
+                result_map["enterprise_alias"] = enter.enterprise_alias  # type: ignore[union-attr]
                 list.append(result_map)
                 result = general_message("0000", "success", "查询成功", list=list, total=1)
                 return Response(result)
-            user_list = user_repo.get_user_by_enterprise_id(enterprise_id=enterprise_id)
+            # NOTE: latent bug — UserRepo has no method get_user_by_enterprise_id
+            # (AttributeError if reached); behavior preserved (backlog).
+            user_list = user_repo.get_user_by_enterprise_id(enterprise_id=enterprise_id)  # type: ignore[attr-defined]
             for user1 in user_list:
                 if user1.nick_name == self.user.nick_name:
                     user_list.delete(user1)
@@ -887,7 +921,7 @@ class AllUserView(JWTAuthApiView):
                 result_map["create_time"] = time_to_str(user.create_time, "%Y-%m-%d %H:%M:%S")
                 tenant_list = user_services.get_user_tenants(user.user_id)
                 result_map["tenants"] = tenant_list
-                result_map["enterprise_alias"] = enter.enterprise_alias
+                result_map["enterprise_alias"] = enter.enterprise_alias  # type: ignore[union-attr]
                 list.append(result_map)
 
             result = general_message("0000", "success", "查询成功", list=list, total=user_paginator.count)
@@ -897,7 +931,7 @@ class AllUserView(JWTAuthApiView):
             result = error_message()
         return Response(result)
 
-    def delete(self, request, tenant_name, user_id, *args, **kwargs):
+    def delete(self, request: Request, tenant_name: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除用户
         ---
@@ -925,7 +959,7 @@ class AllUserView(JWTAuthApiView):
 
 # 企业管理员添加用户
 class AdminAddUserView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         管理员添加成员到团队
         ---
@@ -979,11 +1013,13 @@ class AdminAddUserView(JWTAuthApiView):
                 if not team:
                     raise ServiceHandleException(msg_show="团队不存在", msg="no found team", status_code=404)
                 # 校验用户信息
-                user_services.check_params(user_name, email, password, re_password, self.user.enterprise_id)
+                user_services.check_params(
+                    user_name, email, password, re_password, self.user.enterprise_id)  # type: ignore[arg-type]
                 client_ip = user_services.get_client_ip(request)
                 enterprise = console_enterprise_service.get_enterprise_by_enterprise_id(self.user.enterprise_id)
                 # 创建用户
-                user = user_services.create_user_set_password(user_name, email, password, "admin add", enterprise, client_ip)
+                user = user_services.create_user_set_password(
+                    user_name, email, password, "admin add", enterprise, client_ip)  # type: ignore[arg-type]
                 # 创建用户团队关系表
                 team_services.add_user_role_to_team(tenant=team, user_ids=[user.user_id], role_ids=role_ids)
                 user.is_active = True
@@ -991,27 +1027,28 @@ class AdminAddUserView(JWTAuthApiView):
                 # 转换user_name为符合k8s命名空间规范的名称
                 normalized_namespace = normalize_name_for_k8s_namespace(user_name)
                 team = team_services.create_team(user, enterprise, ["rainbond"], "", normalized_namespace, "")
-                region_services.create_tenant_on_region(enterprise.enterprise_id, team.tenant_name, "rainbond",
-                                                        team.namespace)
+                region_services.create_tenant_on_region(
+                    enterprise.enterprise_id, team.tenant_name, "rainbond",  # type: ignore[union-attr]
+                    team.namespace)
 
                 result = general_message(200, "success", "添加用户成功")
             else:
                 result = general_message(400, "not role", "创建用户时角色不能为空")
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result)
 
 
 class CertificateView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         bean = {"is_certificate": 1}
         result = general_message(200, "success", "获取成功", bean=bean)
         return Response(result)
 
 
 class TeamSortDomainQueryView(RegionTenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取团队下域名访问量排序
         ---
@@ -1036,19 +1073,20 @@ class TeamSortDomainQueryView(RegionTenantHeaderView):
             end = page * page_size
             try:
                 res, body = region_api.get_query_domain_access(region_name, team_name, sufix)
-                total = len(body["data"]["result"])
-                domains = body["data"]["result"]
+                total = len(body["data"]["result"])  # type: ignore[index]
+                domains = body["data"]["result"]  # type: ignore[index]
                 for domain in domains:
                     total_traffic += int(domain["value"][1])
-                    domain_list = body["data"]["result"][start:end]
+                    domain_list = body["data"]["result"][start:end]  # type: ignore[index]
             except Exception as e:
                 logger.debug(e)
             bean = {"total": total, "total_traffic": total_traffic}
             result = general_message(200, "success", "查询成功", list=domain_list, bean=bean)
             return Response(result, status=200)
         else:
-            start = request.GET.get("start", None)
-            end = request.GET.get("end", None)
+            # NOTE: start/end reused with different types across branches (behavior preserved).
+            start = request.GET.get("start", None)  # type: ignore[assignment]
+            end = request.GET.get("end", None)  # type: ignore[assignment]
             body = {}
             sufix = "?query=ceil(sum(increase(gateway_requests%7B" \
                 + "namespace%3D%22{0}%22%7D%5B1h%5D)))&start={1}&end={2}&step=60".format(self.tenant.tenant_id, start, end)
@@ -1061,7 +1099,7 @@ class TeamSortDomainQueryView(RegionTenantHeaderView):
 
 
 class TeamSortServiceQueryView(RegionTenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取团队下组件访问量排序
         ---
@@ -1080,14 +1118,14 @@ class TeamSortServiceQueryView(RegionTenantHeaderView):
         # 对外组件访问量
         try:
             res, body = region_api.get_query_service_access(region_name, team_name, sufix_outer)
-            outer_service_list = body["data"]["result"][0:10]
+            outer_service_list = body["data"]["result"][0:10]  # type: ignore[index]
         except Exception as e:
             logger.debug(e)
             outer_service_list = []
         # 对外组件访问量
         try:
             res, body = region_api.get_query_service_access(region_name, team_name, sufix_inner)
-            inner_service_list = body["data"]["result"][0:10]
+            inner_service_list = body["data"]["result"][0:10]  # type: ignore[index]
         except Exception as e:
             logger.debug(e)
             inner_service_list = []
@@ -1101,9 +1139,9 @@ class TeamSortServiceQueryView(RegionTenantHeaderView):
                 service_id_list.append(service_oj["metric"]["service"])
         service_traffic_list = []
         for service_id in service_id_list:
-            service_dict = dict()
-            metric = dict()
-            value = []
+            service_dict: dict = dict()
+            metric: dict = dict()
+            value: list = []
             service_dict["metric"] = metric
             service_dict["value"] = value
             traffic_num = 0
@@ -1135,7 +1173,7 @@ class TeamSortServiceQueryView(RegionTenantHeaderView):
 
 
 class TeamCheckKubernetesServiceName(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         k8s_service_name = parse_item(request, "k8s_service_name", required=True)
         is_valid = True
         try:
@@ -1154,9 +1192,9 @@ class TeamsPermissionCreateApp(JWTAuthApiView):
     Teams with permission to create apps
     """
 
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         teams = list()
-        tenants = enterprise_repo.get_enterprise_user_teams(enterprise_id, self.user.user_id)
+        tenants = enterprise_repo.get_enterprise_user_teams(enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         if tenants:
             for tenant in tenants:
                 teams.append(team_services.team_with_region_info(tenant, self.user))
@@ -1165,7 +1203,7 @@ class TeamsPermissionCreateApp(JWTAuthApiView):
 
 
 class TeamCheckResourceName(JWTAuthApiView):
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         name = parse_item(request, "name", required=True)
         rtype = parse_item(request, "type", required=True)
         region_name = parse_item(request, "region_name", required=True)
@@ -1174,23 +1212,26 @@ class TeamCheckResourceName(JWTAuthApiView):
 
 
 class TeamRegistryAuthLView(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
-        result = team_services.list_registry_auths(self.tenant.tenant_id, self.region_name, self.user.user_id)
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        result = team_services.list_registry_auths(
+            self.tenant.tenant_id, self.region_name, self.user.user_id)  # type: ignore[arg-type]
         auths = [auth.to_dict() for auth in result]
         result = general_message(200, "success", "查询成功", list=auths)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         domain = parse_item(request, "domain", required=True)
         username = parse_item(request, "username", required=True)
         password = parse_item(request, "password", required=True)
-        team_services.create_registry_auth(self.tenant, self.region_name, domain, username, password)
+        # NOTE: latent bug — create_registry_auth requires hub_type and user_id which are
+        # not passed (TypeError if reached); behavior preserved (backlog).
+        team_services.create_registry_auth(self.tenant, self.region_name, domain, username, password)  # type: ignore[call-arg]
         result = general_message(200, "success", "创建成功")
         return Response(result, status=result["code"])
 
 
 class TeamRegistryAuthRUDView(RegionTenantHeaderView):
-    def put(self, request, secret_id, *args, **kwargs):
+    def put(self, request: Request, secret_id: str, *args: Any, **kwargs: Any) -> Response:
         data = {
             "username": parse_item(request, "username", required=True),
             "password": parse_item(request, "password", required=True)
@@ -1199,14 +1240,14 @@ class TeamRegistryAuthRUDView(RegionTenantHeaderView):
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result["code"])
 
-    def delete(self, request, secret_id, *args, **kwargs):
-        team_services.delete_registry_auth(self.tenant, self.region_name, secret_id, self.user.user_id)
+    def delete(self, request: Request, secret_id: str, *args: Any, **kwargs: Any) -> Response:
+        team_services.delete_registry_auth(self.tenant, self.region_name, secret_id, self.user.user_id)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
 
 class ClusterNamespacesView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取集群中未被 Rainbond 管理的 namespace 列表（含创建时间）
         ---
@@ -1221,7 +1262,8 @@ class ClusterNamespacesView(JWTAuthApiView):
         if not region:
             return Response(general_message(400, "failed", "region 参数不能为空"), status=400)
         try:
-            _, body = region_api.list_namespaces(self.user.enterprise_id, region, "unmanaged", namespace_format="detail")
+            _, body = region_api.list_namespaces(
+                self.user.enterprise_id, region, "unmanaged", namespace_format="detail")  # type: ignore[arg-type]
             return Response(general_message(200, "success", "success", bean=body))
         except ServiceHandleException as e:
             logger.exception(e)

--- a/console/views/team_overview.py
+++ b/console/views/team_overview.py
@@ -1,11 +1,14 @@
+from typing import Any
+
 from console.views.base import JWTAuthApiView
+from rest_framework.request import Request
 from rest_framework.response import Response
 from console.services.team_services import TeamService
 from www.utils.return_message import general_message
 
 
 class UserTeamDetailsView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         获取用户创建的团队详情
         ---

--- a/console/views/team_resources.py
+++ b/console/views/team_resources.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any, Iterator, Optional
 
 import yaml
 from django.http.response import StreamingHttpResponse
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.repositories.app import service_repo
@@ -17,7 +19,7 @@ region_api = RegionInvokeApi()
 logger = logging.getLogger("default")
 
 
-def get_team_resource_namespace(view, fallback=None):
+def get_team_resource_namespace(view: Any, fallback: Optional[str] = None) -> Any:
     tenant = getattr(view, "tenant", None)
     if tenant is not None:
         namespace = getattr(tenant, "namespace", None)
@@ -29,7 +31,7 @@ def get_team_resource_namespace(view, fallback=None):
     return fallback
 
 
-def build_helm_install_body(body, namespace=None):
+def build_helm_install_body(body: Optional[dict], namespace: Optional[str] = None) -> dict:
     payload = dict(body or {})
     if namespace and not payload.get("namespace"):
         payload["namespace"] = namespace
@@ -55,14 +57,14 @@ def build_helm_install_body(body, namespace=None):
     return payload
 
 
-def first_non_empty(*values):
+def first_non_empty(*values: Any) -> Any:
     for value in values:
         if value:
             return value
     return ""
 
 
-def get_request_operator(request):
+def get_request_operator(request: Any) -> Any:
     try:
         user = getattr(request, "user", None)
     except Exception:
@@ -74,7 +76,7 @@ def get_request_operator(request):
     )
 
 
-def normalize_helm_values_yaml(*candidates):
+def normalize_helm_values_yaml(*candidates: Any) -> str:
     for value in candidates:
         if value in (None, ""):
             continue
@@ -86,7 +88,7 @@ def normalize_helm_values_yaml(*candidates):
     return ""
 
 
-def build_helm_release_source_info(record=None, release=None):
+def build_helm_release_source_info(record: Optional[dict] = None, release: Optional[dict] = None) -> dict:
     release = release or {}
     record = record or {}
     source_type = record.get("source_type") or "legacy"
@@ -100,7 +102,8 @@ def build_helm_release_source_info(record=None, release=None):
     }
 
 
-def persist_helm_release_source(request, team_name, region_name, namespace, raw_body, install_body, response_body):
+def persist_helm_release_source(request: Any, team_name: str, region_name: str, namespace: Optional[str],
+                                raw_body: dict, install_body: dict, response_body: Optional[dict]) -> None:
     release_name = first_non_empty(
         (response_body or {}).get("release_name"),
         install_body.get("release_name"),
@@ -130,12 +133,13 @@ def persist_helm_release_source(request, team_name, region_name, namespace, raw_
     )
 
 
-def enrich_helm_release_list(bean, region_name, namespace):
+def enrich_helm_release_list(bean: Optional[dict], region_name: str, namespace: Optional[str]) -> Any:
     releases = (bean or {}).get("list") or []
     release_names = [item.get("name") for item in releases if item.get("name")]
     source_map = {}
     try:
-        source_map = helm_release_source_repo.list_by_releases(region_name, namespace, release_names)
+        # NOTE: namespace is Optional[str] but repo expects str (systemic mismatch; backlog).
+        source_map = helm_release_source_repo.list_by_releases(region_name, namespace, release_names)  # type: ignore[arg-type]
     except Exception as e:
         logger.exception("list helm release source failed: %s", e)
     for item in releases:
@@ -145,35 +149,38 @@ def enrich_helm_release_list(bean, region_name, namespace):
     return bean
 
 
-def enrich_helm_release_detail(bean, region_name, namespace, release_name):
+def enrich_helm_release_detail(bean: Optional[dict], region_name: str, namespace: Optional[str],
+                               release_name: str) -> Any:
     summary = ((bean or {}).get("summary")) or {}
     item_namespace = summary.get("namespace") or namespace
     record = None
     try:
-        record = helm_release_source_repo.get_by_release(region_name, item_namespace, release_name)
+        record = helm_release_source_repo.get_by_release(region_name, item_namespace, release_name)  # type: ignore[arg-type]
     except Exception as e:
         logger.exception("get helm release source failed: %s", e)
     values_yaml = normalize_helm_values_yaml((record or {}).get("values_yaml"))
     if values_yaml:
         summary["values"] = values_yaml
     summary["source_info"] = build_helm_release_source_info(record, summary)
-    bean["summary"] = summary
+    # NOTE: bean may be None; indexed assignment is a latent risk (backlog).
+    bean["summary"] = summary  # type: ignore[index]
     return bean
 
 
 class NsResourceTypesView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         res, data = region_api.get_tenant_ns_resource_types(region_name, team_name)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        # NOTE: region API result may be None; .get access is a latent risk (backlog).
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class NsResourcesView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_tenant_ns_resources(region_name, team_name, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def post(self, request, team_name, region_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         content_type = request.META.get("CONTENT_TYPE")
         res, data = region_api.post_tenant_ns_resource(
@@ -183,65 +190,68 @@ class NsResourcesView(TenantHeaderView):
 
 
 class TeamComponentsView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         components = service_repo.list_basic_infos_by_team_and_region(self.tenant.tenant_id, region_name)
         return Response(general_message(200, "success", "OK", list=components))
 
 
 class NsResourceDetailView(TenantHeaderView):
-    def get(self, request, team_name, region_name, name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_tenant_ns_resource(region_name, team_name, name, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def put(self, request, team_name, region_name, name, *args, **kwargs):
+    def put(self, request: Request, team_name: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         content_type = request.META.get("CONTENT_TYPE")
         res, data = region_api.put_tenant_ns_resource(
             region_name, team_name, name, request.body, params=params, content_type=content_type)
-        return Response(general_message(200, "success", "更新成功", bean=data.get("bean")))
+        return Response(general_message(200, "success", "更新成功", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def delete(self, request, team_name, region_name, name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, region_name: str, name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         region_api.delete_tenant_ns_resource(region_name, team_name, name, params=params)
         return Response(general_message(200, "success", "删除成功"))
 
 
 class HelmReleasesView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         res, data = region_api.get_tenant_helm_releases(region_name, team_name, namespace=namespace)
-        bean = enrich_helm_release_list(data.get("bean") or {}, region_name, namespace)
+        bean = enrich_helm_release_list(data.get("bean") or {}, region_name, namespace)  # type: ignore[union-attr]
         return Response(general_message(200, "success", "OK", bean=bean))
 
-    def post(self, request, team_name, region_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         raw_body = dict(request.data or {})
         body = build_helm_install_body(raw_body, namespace=namespace)
         res, data = region_api.install_tenant_helm_release(region_name, team_name, body)
         try:
-            persist_helm_release_source(request, team_name, region_name, namespace, raw_body, body, data.get("bean") or {})
+            persist_helm_release_source(
+                request, team_name, region_name, namespace,
+                raw_body, body, data.get("bean") or {})  # type: ignore[union-attr]
         except Exception as e:
             logger.exception("persist helm release source failed: %s", e)
-        return Response(general_message(200, "success", "安装成功", bean=data.get("bean")))
+        return Response(general_message(200, "success", "安装成功", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class HelmChartPreviewView(TenantHeaderView):
-    def post(self, request, team_name, region_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         body = build_helm_install_body(request.data or {}, namespace=namespace)
         res, data = region_api.preview_tenant_helm_chart(region_name, team_name, body)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class HelmReleaseDetailView(TenantHeaderView):
-    def get(self, request, team_name, region_name, release_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, release_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         res, data = region_api.get_tenant_helm_release_detail(region_name, team_name, release_name, namespace=namespace)
-        bean = enrich_helm_release_detail(data.get("bean") or {}, region_name, namespace, release_name)
+        bean = enrich_helm_release_detail(
+            data.get("bean") or {}, region_name, namespace, release_name)  # type: ignore[union-attr]
         return Response(general_message(200, "success", "OK", bean=bean))
 
-    def put(self, request, team_name, region_name, release_name, *args, **kwargs):
+    def put(self, request: Request, team_name: str, region_name: str, release_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         raw_body = dict(request.data or {})
         body = build_helm_install_body(request.data or {}, namespace=namespace)
@@ -258,9 +268,10 @@ class HelmReleaseDetailView(TenantHeaderView):
             )
         except Exception as e:
             logger.exception("persist helm release source failed: %s", e)
-        return Response(general_message(200, "success", "升级成功", bean=data.get("bean")))
+        return Response(general_message(200, "success", "升级成功", bean=data.get("bean")))  # type: ignore[union-attr]
 
-    def delete(self, request, team_name, region_name, release_name, *args, **kwargs):
+    def delete(self, request: Request, team_name: str, region_name: str, release_name: str, *args: Any,
+               **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         region_api.uninstall_tenant_helm_release(region_name, team_name, release_name, namespace=namespace)
         try:
@@ -275,44 +286,47 @@ class HelmReleaseDetailView(TenantHeaderView):
 
 
 class HelmReleaseHistoryView(TenantHeaderView):
-    def get(self, request, team_name, region_name, release_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, release_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         res, data = region_api.get_tenant_helm_release_history(region_name, team_name, release_name, namespace=namespace)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class HelmReleaseRollbackView(TenantHeaderView):
-    def post(self, request, team_name, region_name, release_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, region_name: str, release_name: str, *args: Any, **kwargs: Any) -> Response:
         namespace = get_team_resource_namespace(self, team_name)
         body = dict(request.data or {})
         if namespace and not body.get("namespace"):
             body["namespace"] = namespace
         res, data = region_api.rollback_tenant_helm_release(region_name, team_name, release_name, body)
-        return Response(general_message(200, "success", "回滚成功", bean=data.get("bean")))
+        return Response(general_message(200, "success", "回滚成功", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class ResourceCenterWorkloadDetailView(TenantHeaderView):
-    def get(self, request, team_name, region_name, resource, name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, resource: str, name: str, *args: Any,
+            **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_resource_center_workload_detail(region_name, team_name, resource, name, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class ResourceCenterPodDetailView(TenantHeaderView):
-    def get(self, request, team_name, region_name, pod_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, pod_name: str, *args: Any,
+            **kwargs: Any) -> Response:
         res, data = region_api.get_resource_center_pod_detail(region_name, team_name, pod_name)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class ResourceCenterEventsView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         params = {k: v for k, v in request.GET.items()}
         res, data = region_api.get_resource_center_events(region_name, team_name, params=params)
-        return Response(general_message(200, "success", "OK", bean=data.get("bean")))
+        return Response(general_message(200, "success", "OK", bean=data.get("bean")))  # type: ignore[union-attr]
 
 
 class ResourceCenterPodLogsView(TenantHeaderView):
-    def get(self, request, team_name, region_name, pod_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, pod_name: str, *args: Any,
+            **kwargs: Any) -> StreamingHttpResponse:
         params = {k: v for k, v in request.GET.items()}
         logger.info(
             "resource center pod logs request user_id=%s team=%s region=%s pod=%s params=%s",
@@ -335,7 +349,7 @@ class ResourceCenterPodLogsView(TenantHeaderView):
             getattr(getattr(stream, "headers", None), "get", lambda *x: None)("Transfer-Encoding"),
         )
 
-        def iter_stream():
+        def iter_stream() -> Iterator[Any]:
             chunk_count = 0
             try:
                 # Flush one SSE comment frame immediately so EventSource can
@@ -389,7 +403,7 @@ class ResourceCenterPodLogsView(TenantHeaderView):
 
 
 class ResourceCenterWSInfoView(TenantHeaderView):
-    def get(self, request, team_name, region_name, *args, **kwargs):
+    def get(self, request: Request, team_name: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         bean = {
             "event_websocket_url": ws_service.get_event_log_ws(request, region_name),
             "namespace": self.tenant.namespace or self.tenant.tenant_name,

--- a/console/views/upgrade.py
+++ b/console/views/upgrade.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 import requests
 from django.http import JsonResponse
@@ -9,6 +10,7 @@ from console.views.base import JWTAuthApiView
 from www.apiclient.regionapi import RegionInvokeApi
 from console.repositories.region_repo import region_repo
 from www.utils.return_message import general_message
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 region_api = RegionInvokeApi()
@@ -17,21 +19,22 @@ VERSION_INFO_TIMEOUT = 2
 
 class UpgradeView(JWTAuthApiView):
     @never_cache
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         regions = region_repo.get_all_regions()
-        body = {}
+        body: dict = {}
         for region in regions:
             resp = region_api.upgrade_region(region.region_name, request.data)
             body[region.region_name] = resp
         result = general_message(200, "success", "请求成功", bean=body)
         return Response(result, status=200)
 
-    def get(self, request, region_name, *args, **kwargs):
+    def get(self, request: Request, region_name: str, *args: Any, **kwargs: Any) -> Response:
         resp = region_api.list_upgrade_status(region_name)
-        result = general_message(200, "success", "请求成功", list=resp.get("list", []))
+        # NOTE: region API result may be None; .get access is a latent risk (backlog).
+        result = general_message(200, "success", "请求成功", list=resp.get("list", []))  # type: ignore[union-attr]
         return Response(result, status=200)
 
-def fetch_json_data():
+def fetch_json_data() -> Any:
     if is_cloud_market_disabled():
         return None
 
@@ -44,7 +47,7 @@ def fetch_json_data():
         return None
 
 class UpgradeVersionLView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> JsonResponse:
         data = fetch_json_data()
         if data is None:
             return JsonResponse([], status=200, safe=False)
@@ -53,7 +56,7 @@ class UpgradeVersionLView(JWTAuthApiView):
 
 
 class UpgradeVersionRView(JWTAuthApiView):
-    def get(self, request, version, *args, **kwargs):
+    def get(self, request: Request, version: str, *args: Any, **kwargs: Any) -> JsonResponse:
         data = fetch_json_data()
         if data is None:
             return JsonResponse({}, status=200, safe=False)
@@ -62,7 +65,7 @@ class UpgradeVersionRView(JWTAuthApiView):
 
 
 class UpgradeVersionImagesView(JWTAuthApiView):
-    def get(self, request, version, *args, **kwargs):
+    def get(self, request: Request, version: str, *args: Any, **kwargs: Any) -> JsonResponse:
         data = fetch_json_data()
         if data is None:
             return JsonResponse({}, status=200, safe=False)

--- a/console/views/user.py
+++ b/console/views/user.py
@@ -2,6 +2,9 @@
 import json
 import logging
 import os
+from typing import Any
+
+from rest_framework.request import Request
 
 from console.enum.enterprise_enum import EnterpriseRolesEnum
 from console.exception.bcode import ErrEnterpriseNotFound, ErrUserNotFound
@@ -38,7 +41,7 @@ logger = logging.getLogger("default")
 
 
 class CheckSourceView(AlowAnyApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         判断是sso还是私有云
         ---
@@ -48,7 +51,7 @@ class CheckSourceView(AlowAnyApiView):
             # if isinstance(user, AnonymousUser):
             if settings.MODULES.get('SSO_LOGIN'):
                 code = 200
-                data = dict()
+                data: dict = dict()
                 url = "https://sso.goodrain.com/#/login/"
                 data["url"] = url
                 data["is_public"] = True
@@ -66,15 +69,16 @@ class CheckSourceView(AlowAnyApiView):
                 return Response(result, status=code)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]  # NOTE: py2 Exception.message
             return Response(result, status=500)
 
 
 class UserLoginView(BaseApiView):
-    allowed_methods = ('POST', )
+    # NOTE: APIView.allowed_methods typed list[str]; legacy tuple override (backlog).
+    allowed_methods = ('POST', )  # type: ignore[assignment]
 
     @never_cache
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         """
         用户登录接口
         ---
@@ -126,12 +130,12 @@ class UserLoginView(BaseApiView):
         except Exception as e:
             logger.exception(e)
             code = 500
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=code)
 
 
 class UserLogoutView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         用户登出
         ---
@@ -153,7 +157,7 @@ class UserLogoutView(JWTAuthApiView):
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.EXIT, module=OperationModule.LOGIN, module_name="")
                 operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                            enterprise_id=self.user.enterprise_id)
+                                                            enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
                 response = Response(result, status=code)
                 response.delete_cookie('tenant_name')
                 response.delete_cookie('uid', domain='.goodrain.com')
@@ -161,12 +165,12 @@ class UserLogoutView(JWTAuthApiView):
                 return response
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class UserPemTraView(TeamOwnerView):
-    def post(self, request, team_name, *args, **kwargs):
+    def post(self, request: Request, team_name: str, *args: Any, **kwargs: Any) -> Response:
         """
         移交团队管理权
         ---
@@ -183,28 +187,29 @@ class UserPemTraView(TeamOwnerView):
               paramType: body
         """
         user_id = request.data.get("user_id")
-        self.tenant.creater = user_id
+        self.tenant.creater = user_id  # type: ignore[assignment]
         self.tenant.save()
         result = general_message(msg="success", msg_show="移交成功", code=200)
-        user = user_services.get_user_by_user_id(user_id)
+        user = user_services.get_user_by_user_id(user_id)  # type: ignore[arg-type]
         comment = operation_log_service.generate_team_comment(
             operation=Operation.TRUN_OVER,
-            module_name=self.tenant.tenant_alias,
+            module_name=self.tenant.tenant_alias,  # type: ignore[arg-type]
             region=self.response_region,
             team_name=self.tenant.tenant_name,
             suffix=" 给用户 {}".format(user.get_name()))
         operation_log_service.create_team_log(
-            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id, team_name=self.tenant.tenant_name)
+            user=self.user, comment=comment, enterprise_id=self.user.enterprise_id,  # type: ignore[arg-type]
+            team_name=self.tenant.tenant_name)
         return Response(result, status=200)
 
 
 class AdminUserLCView(EnterpriseAdminView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         users = user_services.get_admin_users(enterprise_id)
         result = general_message(200, "success", "获取企业管理员列表成功", list=users)
         return Response(result)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         roles = parse_item(request, "roles", required=True, error="at least one role needs to be specified")
         if not set(roles).issubset(EnterpriseRolesEnum.names()):
             raise AbortRequest("invalid roles", msg_show="角色不正确")
@@ -213,7 +218,7 @@ class AdminUserLCView(EnterpriseAdminView):
         if user_id == self.user.user_id:
             raise AbortRequest("cannot edit your own role", msg_show="不可操作自己的角色")
         try:
-            user = user_services.get_user_by_user_id(user_id)
+            user = user_services.get_user_by_user_id(user_id)  # type: ignore[arg-type]
         except UserNotExistError:
             raise ErrUserNotFound
 
@@ -226,13 +231,13 @@ class AdminUserLCView(EnterpriseAdminView):
             operation=Operation.CREATE, module=OperationModule.ENTERPRISEADMIN,
             module_name=" {}".format(user.get_name()))
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(general_message(201, "success", None), status=201)
 
 
 class AdminUserView(EnterpriseAdminView):
-    def delete(self, request, enterprise_id, user_id, *args, **kwargs):
-        if str(request.user.user_id) == user_id:
+    def delete(self, request: Request, enterprise_id: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
+        if str(request.user.user_id) == user_id:  # type: ignore[union-attr]
             result = general_message(400, "fail", "不可删除自己")
             return Response(result, 400)
         try:
@@ -243,7 +248,7 @@ class AdminUserView(EnterpriseAdminView):
                 operation=Operation.DELETE, module=OperationModule.ENTERPRISEADMIN,
                 module_name=" {}".format(user.get_name()))
             operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                        enterprise_id=self.user.enterprise_id)
+                                                        enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
             return Response(result, 200)
         except ErrAdminUserDoesNotExist as e:
             logger.debug(e)
@@ -254,11 +259,11 @@ class AdminUserView(EnterpriseAdminView):
             result = general_message(400, "fail", None)
             return Response(result, 400)
 
-    def put(self, request, enterprise_id, user_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         roles = parse_item(request, "roles", required=True, error="at least one role needs to be specified")
         if not set(roles).issubset(EnterpriseRolesEnum.names()):
             raise AbortRequest("invalid roles", msg_show="角色不正确")
-        if str(request.user.user_id) == user_id:
+        if str(request.user.user_id) == user_id:  # type: ignore[union-attr]
             raise AbortRequest("changing your role is not allowed", "不可修改自己的角色")
         user_services.update_roles(enterprise_id, user_id, roles)
         result = general_message(200, "success", None)
@@ -266,22 +271,22 @@ class AdminUserView(EnterpriseAdminView):
 
 
 class EnterPriseUsersCLView(JWTAuthApiView):
-    def get(self, request, enterprise_id, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
         name = request.GET.get("query")
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         data = []
         try:
-            users, total = user_services.get_user_by_eid(enterprise_id, name, page, page_size)
+            users, total = user_services.get_user_by_eid(enterprise_id, name, page, page_size)  # type: ignore[arg-type]
         except Exception as e:
             logger.debug(e)
-            users = []
+            users = []  # type: ignore[assignment]
             total = 0
         if users:
             for user in users:
                 default_favorite_name = None
                 default_favorite_url = None
-                user_default_favorite = user_repo.get_user_default_favorite(user.user_id)
+                user_default_favorite = user_repo.get_user_default_favorite(user.user_id)  # type: ignore[arg-type]
                 if user_default_favorite:
                     default_favorite_name = user_default_favorite.name
                     default_favorite_url = user_default_favorite.url
@@ -298,7 +303,7 @@ class EnterPriseUsersCLView(JWTAuthApiView):
         result = general_message(200, "success", None, list=data, page_size=page_size, page=page, total=total)
         return Response(result, status=200)
 
-    def post(self, request, enterprise_id, *args, **kwargs):
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
 
         tenant_name = request.data.get("tenant_name", None)
         user_name = request.data.get("user_name", None)
@@ -308,23 +313,27 @@ class EnterPriseUsersCLView(JWTAuthApiView):
         role_ids = request.data.get("role_ids", None)
         phone = request.data.get("phone", None)
         real_name = request.data.get("real_name", None)
-        tenant = team_services.get_tenant_by_tenant_name(tenant_name)
-        if len(password) < 8:
+        tenant = team_services.get_tenant_by_tenant_name(tenant_name)  # type: ignore[arg-type]
+        if len(password) < 8:  # type: ignore[arg-type]
             result = general_message(400, "len error", "密码长度最少为8位")
             return Response(result)
         # check user info
-        user_services.check_params(user_name, email, password, re_password, request.user.enterprise_id, phone)
+        # NOTE: request.data params Optional and request.user is Union; service expects str (legacy, backlog).
+        user_services.check_params(user_name, email, password, re_password,  # type: ignore[arg-type]
+                                   request.user.enterprise_id, phone)  # type: ignore[union-attr]
         client_ip = user_services.get_client_ip(request)
         enterprise = enterprise_services.get_enterprise_by_enterprise_id(enterprise_id)
         # create user
-        oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)
+        oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)  # type: ignore[union-attr]
 
         if oauth_instance:
-            user = user_services.create_enterprise_center_user_set_password(user_name, email, password, "admin add", enterprise,
-                                                                            client_ip, phone, real_name, oauth_instance)
+            user = user_services.create_enterprise_center_user_set_password(
+                user_name, email, password, "admin add", enterprise,  # type: ignore[arg-type]
+                client_ip, phone, real_name, oauth_instance)  # type: ignore[arg-type]
         else:
-            user = user_services.create_user_set_password(user_name, email, password, "admin add", enterprise, client_ip, phone,
-                                                          real_name)
+            user = user_services.create_user_set_password(
+                user_name, email, password, "admin add", enterprise, client_ip, phone,  # type: ignore[arg-type]
+                real_name)
         result = general_message(200, "success", "添加用户成功")
         # USE_SAAS 模式下，自动为新用户创建默认团队（和正常注册流程一致）
         if os.getenv("USE_SAAS") and not tenant:
@@ -348,7 +357,7 @@ class EnterPriseUsersCLView(JWTAuthApiView):
                 "user_id": user.user_id,
                 "tenant_id": tenant.ID,
                 "identity": "",
-                "enterprise_id": enterprise.ID,
+                "enterprise_id": enterprise.ID,  # type: ignore[union-attr]
             }
             team_repo.create_team_perms(**create_perm_param)
             if role_ids:
@@ -358,35 +367,37 @@ class EnterPriseUsersCLView(JWTAuthApiView):
                 result = general_message(200, "success", "添加用户成功")
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.ADD, module=OperationModule.USER, module_name="{}".format(user.get_name()))
-        operation_log_service.create_enterprise_log(user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+        operation_log_service.create_enterprise_log(user=self.user, comment=comment,
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result)
 
 
 class EnterPriseUsersUDView(JWTAuthApiView):
     @transaction.atomic()
-    def put(self, request, enterprise_id, user_id, *args, **kwargs):
+    def put(self, request: Request, enterprise_id: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         password = request.data.get("password", None)
         real_name = request.data.get("real_name", None)
         phone = request.data.get("phone", None)
 
-        user = user_services.update_user_set_password(enterprise_id, user_id, password, real_name, phone)
+        user = user_services.update_user_set_password(enterprise_id, user_id, password, real_name,  # type: ignore[arg-type]
+                                                      phone)  # type: ignore[arg-type]
         user.save()
-        oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)
+        oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)  # type: ignore[union-attr]
         if oauth_instance:
             data = {
                 "password": password,
                 "real_name": real_name,
                 "phone": phone,
             }
-            oauth_instance.update_user(enterprise_id, user.enterprise_center_user_id, data)
+            oauth_instance.update_user(enterprise_id, user.enterprise_center_user_id, data)  # type: ignore[attr-defined]
         result = general_message(200, "success", "更新用户成功")
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.CHANGE, module=OperationModule.USER, module_name="{} 的信息".format(user.get_name()))
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
-    def delete(self, request, enterprise_id, user_id, *args, **kwargs):
+    def delete(self, request: Request, enterprise_id: str, user_id: str, *args: Any, **kwargs: Any) -> Response:
         user = user_repo.get_enterprise_user_by_id(enterprise_id, user_id)
         if not user:
             result = general_message(400, "fail", "未找到该用户")
@@ -394,21 +405,22 @@ class EnterPriseUsersUDView(JWTAuthApiView):
         user_services.delete_user(user_id)
         oauth_instance, oauth_user = user_services.check_user_is_enterprise_center_user(user_id)
         if oauth_instance:
-            oauth_instance.delete_user(enterprise_id, user.enterprise_center_user_id)
+            oauth_instance.delete_user(enterprise_id, user.enterprise_center_user_id)  # type: ignore[attr-defined]
         all_oauth_user = oauth_user_repo.get_all_user_oauth(user_id)
         all_oauth_user.delete()
         result = general_message(200, "success", "删除用户成功")
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.USER, module_name="{}".format(user.get_name()))
-        operation_log_service.create_enterprise_log(user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+        operation_log_service.create_enterprise_log(user=self.user, comment=comment,
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
 
 class AdministratorJoinTeamView(EnterpriseAdminView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         nojoin_user_ids = []
         team_name = request.data.get("team_name")
-        team = team_services.get_enterprise_tenant_by_tenant_name(self.user.enterprise_id, team_name)
+        team = team_services.get_enterprise_tenant_by_tenant_name(self.user.enterprise_id, team_name)  # type: ignore[arg-type]
         if not team:
             raise ServiceHandleException(msg="no found team", msg_show="团队不存在", status_code=404)
         users = team_services.get_team_users(team)
@@ -421,7 +433,7 @@ class AdministratorJoinTeamView(EnterpriseAdminView):
 
 
 class AdminRolesView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         from console.utils.perms import ENTERPRISE
         roles = list()
         for role in ENTERPRISE:

--- a/console/views/user_accesstoken.py
+++ b/console/views/user_accesstoken.py
@@ -1,11 +1,13 @@
 # -*- coding: utf8 -*-
 import logging
+from typing import Any
 
 from console.exception.main import ServiceHandleException
 from console.services.operation_log import operation_log_service, OperationModule, Operation
 from console.services.user_accesstoken_services import user_access_services
 from console.views.base import JWTAuthApiView
 from django.db import IntegrityError
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import general_message
@@ -15,18 +17,21 @@ logger = logging.getLogger("default")
 
 
 class UserAccessTokenCLView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         note = request.data.get("note")
         age = request.data.get("age")
         if not note:
             raise ServiceHandleException(msg="note can't be null", msg_show="注释不能为空")
         try:
-            access_key = user_access_services.create_user_access_key(note, request.user.user_id, age)
+            # NOTE: request.user is the DRF/Django User|AnonymousUser stub; user_id is on
+            # the concrete Users model (union-attr backlog).
+            access_key = user_access_services.create_user_access_key(note, request.user.user_id, age)  # type: ignore[union-attr]
             result = general_message(200, None, None, bean=access_key.to_dict())
             comment = operation_log_service.generate_generic_comment(
                 operation=Operation.CREATE, module=OperationModule.ACCESSKEY, module_name=note)
+            # NOTE: enterprise_id is nullable but service expects str (arg-type backlog).
             operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                        enterprise_id=self.user.enterprise_id)
+                                                        enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
             return Response(result, status=200)
         except ValueError as e:
             logger.exception(e)
@@ -34,25 +39,27 @@ class UserAccessTokenCLView(JWTAuthApiView):
         except IntegrityError:
             raise ServiceHandleException(msg="note duplicate", msg_show="令牌用途不能重复")
 
-    def get(self, request, *args, **kwargs):
-        access_key_list = user_access_services.get_user_access_key(request.user.user_id)
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        access_key_list = user_access_services.get_user_access_key(request.user.user_id)  # type: ignore[union-attr]
         result = general_message(200, "success", None, list=access_key_list.values("note", "expire_time", "user_id", "ID"))
         return Response(result, status=200)
 
 
 class UserAccessTokenRUDView(JWTAuthApiView):
-    def get(self, request, id, **kwargs):
-        access_key = user_access_services.get_user_access_key_by_id(request.user.user_id, id).values(
-            "note", "expire_time", "user_id", "ID").first()
+    def get(self, request: Request, id: str, **kwargs: Any) -> Response:
+        access_key = user_access_services.get_user_access_key_by_id(
+            request.user.user_id, id).values(  # type: ignore[union-attr]
+                "note", "expire_time", "user_id", "ID").first()
         if not access_key:
             result = general_message(404, "no found access key", "未找到该凭证")
             return Response(result, status=404)
         result = general_message(200, "success", None, bean=access_key)
         return Response(result, status=200)
 
-    def put(self, request, id, **kwargs):
+    def put(self, request: Request, id: str, **kwargs: Any) -> Response:
         try:
-            access_key = user_access_services.update_user_access_key_by_id(request.user.user_id, id)
+            access_key = user_access_services.update_user_access_key_by_id(
+                request.user.user_id, id)  # type: ignore[union-attr]
         except IntegrityError as e:
             logger.exception(e)
             raise ServiceHandleException(msg="access key duplicate", msg_show="刷新失败，请重试")
@@ -63,15 +70,16 @@ class UserAccessTokenRUDView(JWTAuthApiView):
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.REGENERATED, module=OperationModule.ACCESSKEY, module_name=access_key.note)
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)
 
-    def delete(self, request, id, **kwargs):
-        user_access_services.delete_user_access_key_by_id(request.user.user_id, id)
+    def delete(self, request: Request, id: str, **kwargs: Any) -> Response:
+        user_access_services.delete_user_access_key_by_id(request.user.user_id, id)  # type: ignore[union-attr]
         result = general_message(200, "success", None)
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.ACCESSKEY,
-            module_name=access_key.note if access_key else "")
+            # NOTE: latent bug — `access_key` is undefined in delete(); behavior preserved.
+            module_name=access_key.note if access_key else "")  # type: ignore[name-defined]
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                    enterprise_id=self.user.enterprise_id)
+                                                    enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)

--- a/console/views/user_operation.py
+++ b/console/views/user_operation.py
@@ -5,6 +5,7 @@ import os
 import re
 import time
 from datetime import datetime, timedelta
+from typing import Any
 
 from console.exception.exceptions import UserFavoriteNotExistError
 from console.forms.users_operation import RegisterForm
@@ -29,6 +30,7 @@ from console.utils.validation import normalize_name_for_k8s_namespace
 from console.views.base import BaseApiView, JWTAuthApiView
 from django import forms
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.models.main import Users
 from www.utils.crypt import AuthCode, make_uuid
@@ -44,7 +46,7 @@ from console.services.sms_service import sms_service
 logger = logging.getLogger("default")
 
 
-def password_len(value):
+def password_len(value: str) -> None:
     if len(value) < 8:
         raise forms.ValidationError("密码长度至少为8位")
 
@@ -57,13 +59,14 @@ class PasswordResetForm(forms.Form):
         'password_repeat': "两次输入的密码不一致",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(PasswordResetForm, self).__init__(*args, **kwargs)
-        self.helper.form_tag = False
-        self.helper.help_text_inline = True
-        self.helper.error_text_inline = True
+        # NOTE: helper is a crispy-forms attr not declared on forms.Form (legacy, backlog).
+        self.helper.form_tag = False  # type: ignore[attr-defined]
+        self.helper.help_text_inline = True  # type: ignore[attr-defined]
+        self.helper.error_text_inline = True  # type: ignore[attr-defined]
 
-    def clean(self):
+    def clean(self) -> None:
         password = self.cleaned_data.get('password')
         password_repeat = self.cleaned_data.get('password_repeat')
 
@@ -75,9 +78,10 @@ class PasswordResetForm(forms.Form):
 
 
 class TenantServiceView(BaseApiView):
-    allowed_methods = ('POST', )
+    # NOTE: APIView declares allowed_methods as list[str]; tuple here is a legacy mismatch (backlog).
+    allowed_methods = ('POST', )  # type: ignore[assignment]
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         注册用户、需要先访问captcha路由来获取验证码
         ---
@@ -159,9 +163,11 @@ class TenantServiceView(BaseApiView):
                 enterprise = enterprise_services.get_enterprise_first()
                 if not enterprise:
                     enter_name = request.data.get("enter_name", None)
-                    enterprise = enterprise_services.create_enterprise(enterprise_name=None, enterprise_alias=enter_name)
+                    # NOTE: create_enterprise expects str name; legacy passes None (backlog).
+                    enterprise = enterprise_services.create_enterprise(enterprise_name=None, enterprise_alias=enter_name)  # type: ignore[arg-type]
                     # 创建用户在企业的权限
-                    user_services.make_user_as_admin_for_enterprise(user.user_id, enterprise.enterprise_id)
+                    # NOTE: user_id is int AutoField; service takes str (systemic int-as-str, backlog).
+                    user_services.make_user_as_admin_for_enterprise(user.user_id, enterprise.enterprise_id)  # type: ignore[arg-type]
                     team = team_services.create_team(user, enterprise, ["rainbond"], "", "default", "")
                     region_services.create_tenant_on_region(enterprise.enterprise_id, team.tenant_name, "rainbond",
                                                                 team.namespace)
@@ -190,12 +196,13 @@ class TenantServiceView(BaseApiView):
                         "user_id": user.user_id,
                         "tenant_id": value,
                         "identity": "viewer",
-                        "enterprise_id": enterprise.ID
+                        # NOTE: get_enterprise_first may return None; legacy assumes present (backlog).
+                        "enterprise_id": enterprise.ID  # type: ignore[union-attr]
                     })
                     if not perm:
                         result = general_message(400, "invited failed", "团队关联失败，注册失败")
                         return Response(result, status=400)
-                data = dict()
+                data: dict = dict()
                 data["user_id"] = user.user_id
                 data["nick_name"] = user.nick_name
                 data["email"] = user.email
@@ -224,7 +231,8 @@ class TenantServiceView(BaseApiView):
 
 
 class SendResetEmail(BaseApiView):
-    def post(self, request, *args, **kwargs):
+    # NOTE: falls through returning None when email length <= 5 (latent bug, backlog).
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # type: ignore[return]
         """
         发送忘记密码邮件
         ---
@@ -269,12 +277,13 @@ class SendResetEmail(BaseApiView):
                 return Response(result, status=code)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            # NOTE: py2-era Exception.message; preserved for behavior compat (backlog).
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class PasswordResetBegin(BaseApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         忘记密码
         ---
@@ -312,12 +321,12 @@ class PasswordResetBegin(BaseApiView):
                 return Response(result, status=400)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class ChangeLoginPassword(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改密码
         ---
@@ -344,21 +353,22 @@ class ChangeLoginPassword(JWTAuthApiView):
             new_password2 = request.data.get("new_password2", None)
             u = request.user
             code = 400
-            if not user_services.check_user_password(user_id=u.user_id, password=password):
+            # NOTE: request.user is User|AnonymousUser & request.data.get is Optional; auth/inputs assumed valid (backlog).
+            if not user_services.check_user_password(user_id=u.user_id, password=password):  # type: ignore[union-attr, arg-type]
                 result = general_message(400, "old password error", "旧密码错误")
             elif new_password != new_password2:
                 result = general_message(400, "two password disagree", "两个密码不一致")
             elif password == new_password:
                 result = general_message(400, "old and new password agree", "新旧密码一致")
             else:
-                status, info = user_services.update_password(user_id=u.user_id, new_password=new_password)
-                oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)
+                status, info = user_services.update_password(user_id=u.user_id, new_password=new_password)  # type: ignore[union-attr, arg-type]
+                oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)  # type: ignore[union-attr]
                 if oauth_instance:
                     data = {
                         "password": new_password,
-                        "real_name": request.user.real_name,
+                        "real_name": request.user.real_name,  # type: ignore[union-attr]
                     }
-                    oauth_instance.update_user(request.user.enterprise_id, request.user.enterprise_center_user_id, data)
+                    oauth_instance.update_user(request.user.enterprise_id, request.user.enterprise_center_user_id, data)  # type: ignore[union-attr]
                 if status:
                     code = 200
                     result = general_message(200, "change password success", "密码修改成功")
@@ -367,12 +377,12 @@ class ChangeLoginPassword(JWTAuthApiView):
             return Response(result, status=code)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class UserDetailsView(JWTAuthApiView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询我的详情
         ---
@@ -380,8 +390,9 @@ class UserDetailsView(JWTAuthApiView):
         team_name = request.GET.get("team_name", "")
         code = 200
         user = self.user
-        tenants = team_services.get_current_user_tenants(user_id=user.user_id, team_name=team_name)
-        user_detail = dict()
+        # NOTE: user_id is int AutoField; service takes str (systemic int-as-str, backlog).
+        tenants = team_services.get_current_user_tenants(user_id=user.user_id, team_name=team_name)  # type: ignore[arg-type]
+        user_detail: dict = dict()
         user_detail["user_id"] = user.user_id
         user_detail["user_name"] = user.nick_name
         user_detail["real_name"] = user.real_name
@@ -393,13 +404,15 @@ class UserDetailsView(JWTAuthApiView):
         enterprise = enterprise_services.get_enterprise_by_enterprise_id(user.enterprise_id)
         # Fix: Handle case where enterprise doesn't exist (e.g., after cross-cluster restore)
         user_detail["is_enterprise_active"] = enterprise.is_active if enterprise else False
-        initial_marker = agent_access_service.ensure_initial_enterprise_admin_marker(user.enterprise_id)
+        # NOTE: enterprise_id nullable; service takes str (systemic nullable, backlog).
+        initial_marker = agent_access_service.ensure_initial_enterprise_admin_marker(user.enterprise_id)  # type: ignore[arg-type]
         if initial_marker and initial_marker.user_id == user.user_id:
             self.is_enterprise_admin = True
         user_detail["is_enterprise_admin"] = self.is_enterprise_admin
         user_detail["is_initial_enterprise_admin"] = bool(initial_marker and initial_marker.user_id == user.user_id)
         # enterprise roles
-        user_detail["roles"] = user_services.list_roles(user.enterprise_id, user.user_id)
+        # NOTE: enterprise_id nullable & user_id int AutoField; service takes str (systemic, backlog).
+        user_detail["roles"] = user_services.list_roles(user.enterprise_id, user.user_id)  # type: ignore[arg-type]
         # enterprise permissions
         user_detail["permissions"] = list_enterprise_perms_by_roles(user_detail["roles"])
         owner_tenant_list = []
@@ -434,19 +447,21 @@ class UserDetailsView(JWTAuthApiView):
         # 合并列表，所有者列表在前
         tenant_list = owner_tenant_list + member_tenant_list
         user_detail["teams"] = tenant_list
+        # NOTE: request.user is User|AnonymousUser; auth guarantees authenticated user (backlog).
         oauth_services = oauth_user_repo.get_user_oauth_services_info(
-            eid=request.user.enterprise_id, user_id=request.user.user_id)
+            eid=request.user.enterprise_id, user_id=request.user.user_id)  # type: ignore[union-attr]
         user_detail["oauth_services"] = oauth_services
         result = general_message(code, "Obtain my details to be successful.", "获取我的详情成功", bean=user_detail)
         return Response(result, status=code)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             # 只更新传了值的字段
             if "real_name" in request.data:
-                self.user.real_name = request.data.get("real_name")
+                # NOTE: request.data.get is Optional; real_name field is non-null str (backlog).
+                self.user.real_name = request.data.get("real_name")  # type: ignore[assignment]
             if "email" in request.data:
-                self.user.email = request.data.get("email")
+                self.user.email = request.data.get("email")  # type: ignore[assignment]
             if "logo" in request.data:
                 self.user.logo = request.data.get("logo")
 
@@ -485,10 +500,11 @@ class UserDetailsView(JWTAuthApiView):
             return Response(result, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class UserFavoriteLCView(JWTAuthApiView):
-    def get(self, request, enterprise_id):
+    def get(self, request: Request, enterprise_id: str) -> Response:
         data = []
         try:
-            user_favorites = user_repo.get_user_favorite(request.user.user_id)
+            # NOTE: request.user is User|AnonymousUser; auth guarantees authenticated user (backlog).
+            user_favorites = user_repo.get_user_favorite(request.user.user_id)  # type: ignore[union-attr]
             if user_favorites:
                 for user_favorite in user_favorites:
                     data.append({
@@ -505,23 +521,24 @@ class UserFavoriteLCView(JWTAuthApiView):
         result = general_message(200, "success", None, list=data)
         return Response(result, status=status.HTTP_200_OK)
 
-    def post(self, request, enterprise_id):
+    def post(self, request: Request, enterprise_id: str) -> Response:
         name = request.data.get("name")
         url = request.data.get("url")
         is_default = request.data.get("is_default", False)
         if name and url:
             try:
 
-                old_favorite = user_repo.get_user_favorite_by_name(request.user.user_id, name)
+                old_favorite = user_repo.get_user_favorite_by_name(request.user.user_id, name)  # type: ignore[union-attr]
                 if old_favorite:
                     result = general_message(400, "fail", "收藏视图名称已存在")
                     return Response(result, status=status.HTTP_400_BAD_REQUEST)
-                user_repo.create_user_favorite(request.user.user_id, name, url, is_default)
+                user_repo.create_user_favorite(request.user.user_id, name, url, is_default)  # type: ignore[union-attr]
                 result = general_message(200, "success", "收藏视图创建成功")
                 comment = operation_log_service.generate_generic_comment(
                     operation=Operation.ADD, module=OperationModule.FAVORITE, module_name=" {}".format(name))
+                # NOTE: enterprise_id nullable; create_enterprise_log takes str (systemic, backlog).
                 operation_log_service.create_enterprise_log(
-                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)
+                    user=self.user, comment=comment, enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
                 return Response(result, status=status.HTTP_200_OK)
             except Exception as e:
                 logger.debug(e)
@@ -533,7 +550,7 @@ class UserFavoriteLCView(JWTAuthApiView):
 
 
 class UserFavoriteUDView(JWTAuthApiView):
-    def put(self, request, enterprise_id, favorite_id):
+    def put(self, request: Request, enterprise_id: str, favorite_id: str) -> Response:
         result = general_message(200, "success", "更新成功")
         name = request.data.get("name")
         url = request.data.get("url")
@@ -542,8 +559,9 @@ class UserFavoriteUDView(JWTAuthApiView):
         if not (name and url):
             result = general_message(400, "fail", "参数错误")
         try:
-            user_favorite = user_repo.get_user_favorite_by_ID(request.user.user_id, favorite_id)
-            rst = user_repo.update_user_favorite(user_favorite, name, url, custom_sort, is_default)
+            # NOTE: request.user union & request.data.get Optional; auth/inputs assumed valid (backlog).
+            user_favorite = user_repo.get_user_favorite_by_ID(request.user.user_id, favorite_id)  # type: ignore[union-attr]
+            rst = user_repo.update_user_favorite(user_favorite, name, url, custom_sort, is_default)  # type: ignore[arg-type]
             if not rst:
                 result = general_message(200, "fail", "更新视图失败")
         except UserFavoriteNotExistError as e:
@@ -551,14 +569,15 @@ class UserFavoriteUDView(JWTAuthApiView):
             result = general_message(404, "fail", "收藏视图不存在")
         return Response(result, status=status.HTTP_200_OK)
 
-    def delete(self, request, enterprise_id, favorite_id):
+    def delete(self, request: Request, enterprise_id: str, favorite_id: str) -> Response:
         result = general_message(200, "success", "删除成功")
         try:
-            user_repo.delete_user_favorite_by_id(request.user.user_id, favorite_id)
+            user_repo.delete_user_favorite_by_id(request.user.user_id, favorite_id)  # type: ignore[union-attr]
+            # NOTE: `favorite` is undefined here — latent NameError on the happy path (real bug, backlog).
             comment = operation_log_service.generate_generic_comment(
-                operation=Operation.DELETE, module=OperationModule.FAVORITE, module_name=" {}".format(favorite.name))
+                operation=Operation.DELETE, module=OperationModule.FAVORITE, module_name=" {}".format(favorite.name))  # type: ignore[name-defined]
             operation_log_service.create_enterprise_log(user=self.user, comment=comment,
-                                                        enterprise_id=self.user.enterprise_id)
+                                                        enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         except UserFavoriteNotExistError as e:
             logger.debug(e)
             result = general_message(404, "fail", "收藏视图不存在")
@@ -566,7 +585,7 @@ class UserFavoriteUDView(JWTAuthApiView):
 
 
 class UserInviteView(JWTAuthApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             team_id = request.data.get("team_id")
             role_id = request.data.get("role_id", "")
@@ -594,50 +613,53 @@ class UserInviteView(JWTAuthApiView):
             result = general_message(200, "success", "邀请创建成功", 
                                   bean={"invite_id": invite.invitation_id})
             return Response(result, status=200)
-            
+
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class UserInviteJoinView(JWTAuthApiView):
-    def get(self, request, invitation_id, *args, **kwargs):
+    def get(self, request: Request, invitation_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         获取用户邀请信息
         ---
         """
         try:
             invite = team_invitation_repo.get_invitation_by_id(invitation_id)
-            
+
             # 检查邀请是否过期
-            if invite.expired_time < datetime.now():
+            # NOTE: get_invitation_by_id may return None; legacy assumes present (backlog).
+            if invite.expired_time < datetime.now():  # type: ignore[union-attr]
                 result = general_message(400, "invitation expired", "邀请已过期")
                 return Response(result, status=400)
-            
-            team = team_repo.get_team_by_team_id(invite.tenant_id)
-            inviter = user_repo.get_user_by_user_id(invite.inviter_id)
+
+            team = team_repo.get_team_by_team_id(invite.tenant_id)  # type: ignore[union-attr]
+            # NOTE: inviter_id int AutoField; get_user_by_user_id takes str (systemic int-as-str, backlog).
+            inviter = user_repo.get_user_by_user_id(invite.inviter_id)  # type: ignore[union-attr, arg-type]
             # 检查用户是否已加入团队
-            is_member = team_repo.get_tenant_perms(team.ID, request.user.user_id)
+            # NOTE: team.ID int AutoField; get_tenant_perms takes str (systemic int-as-str, backlog).
+            is_member = team_repo.get_tenant_perms(team.ID, request.user.user_id)  # type: ignore[arg-type, union-attr]
             invite_info = {
-                "invite_id": invite.invitation_id,
-                "team_name": team.tenant_name, 
+                "invite_id": invite.invitation_id,  # type: ignore[union-attr]
+                "team_name": team.tenant_name,
                 "team_alias": team.tenant_alias,
-                "invite_time": invite.create_time,
+                "invite_time": invite.create_time,  # type: ignore[union-attr]
                 "inviter": inviter.real_name if inviter.real_name else inviter.nick_name,
-                "expired_time": invite.expired_time,
+                "expired_time": invite.expired_time,  # type: ignore[union-attr]
                 "is_member": bool(is_member),  # 添加是否已是团队成员的标识
-                "is_accepted": invite.is_accepted,
+                "is_accepted": invite.is_accepted,  # type: ignore[union-attr]
             }
             result = general_message(200, "success", "获取邀请信息成功", bean=invite_info)
             return Response(result, status=200)
-        
+
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
-    def post(self, request, invitation_id, *args, **kwargs):
+    def post(self, request: Request, invitation_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         处理用户邀请
         ---
@@ -684,7 +706,8 @@ class UserInviteJoinView(JWTAuthApiView):
                 if not perm:
                     result = general_message(400, "failed", "加入团队失败")
                     return Response(result, status=400)
-                ur = UserRole(user_id=self.user.user_id, role_id=invite.role_id)
+                # NOTE: invite.role_id may be None; UserRole.role_id expects str|int (backlog).
+                ur = UserRole(user_id=self.user.user_id, role_id=invite.role_id)  # type: ignore[misc]
                 ur.save()
                 msg = "已接受邀请"
             else:
@@ -698,12 +721,12 @@ class UserInviteJoinView(JWTAuthApiView):
 
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
 
 
 class RegisterByPhoneView(BaseApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         手机号注册
         ---
@@ -746,7 +769,8 @@ class RegisterByPhoneView(BaseApiView):
                 return Response(result, status=status.HTTP_400_BAD_REQUEST)
 
             # 用户名格式校验
-            if not re.match(r'^[a-zA-Z0-9_-]{3,24}$', nick_name):
+            # NOTE: request.data.get is Optional; re.match expects str (backlog).
+            if not re.match(r'^[a-zA-Z0-9_-]{3,24}$', nick_name):  # type: ignore[arg-type]
                 result = general_message(400, "参数错误", "用户名只能包含字母、数字、下划线和中划线,长度在3-24位之间")
                 return Response(result, status=status.HTTP_400_BAD_REQUEST)
             # 获取企业信息
@@ -757,7 +781,8 @@ class RegisterByPhoneView(BaseApiView):
                     msg_show="企业信息不存在",
                     status_code=404
                 )
-            user = user_service.register_by_phone(enterprise.enterprise_id, phone, code, nick_name)
+            # NOTE: request.data.get values are Optional; service expects str (backlog).
+            user = user_service.register_by_phone(enterprise.enterprise_id, phone, code, nick_name)  # type: ignore[arg-type]
 
             try:
                 regions = region_repo.get_usable_regions(enterprise.enterprise_id)
@@ -796,7 +821,7 @@ class RegisterByPhoneView(BaseApiView):
 
 
 class LoginByPhoneView(BaseApiView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         手机号登录
         ---
@@ -820,7 +845,8 @@ class LoginByPhoneView(BaseApiView):
                 result = general_message(400, "参数错误", "参数不完整")
                 return Response(result, status=status.HTTP_400_BAD_REQUEST)
 
-            user = user_service.login_by_phone(phone, code)
+            # NOTE: request.data.get values are Optional; service expects str (backlog).
+            user = user_service.login_by_phone(phone, code)  # type: ignore[arg-type]
             login_event = LoginEvent(user, login_event_repo, request=request)
             login_event.login()
             # 生成token

--- a/console/views/webhook.py
+++ b/console/views/webhook.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pickle
 import re
+from typing import Any, Optional, Tuple
 
 from console.constants import AppConstants
 from console.models.main import DeployRelation
@@ -17,6 +18,7 @@ from console.services.user_services import user_services
 from console.views.app_config.base import AppBaseView
 from console.views.base import AlowAnyApiView
 from docker_image import reference
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.models.main import Tenants, TenantServiceInfo
 from www.utils.return_message import error_message, general_message
@@ -25,7 +27,7 @@ logger = logging.getLogger("default")
 
 
 class WebHooksDeploy(AlowAnyApiView):
-    def post(self, request, service_id, *args, **kwargs):
+    def post(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         github，gitlab 回调接口 触发自动部署
 
@@ -82,7 +84,8 @@ class WebHooksDeploy(AlowAnyApiView):
                     return Response(result, status=200)
                 clone_url = repository.get("clone_url")
                 ssh_url = repository.get("ssh_url")
-                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)
+                # NOTE: service_obj.git_url is nullable; _check_warehouse takes str (systemic, backlog).
+                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(200, msg, msg_show), status=200)
 
@@ -143,7 +146,7 @@ class WebHooksDeploy(AlowAnyApiView):
                 git_http_url = repository.get("git_http_url")
                 gitlab_ssh_url = repository.get("git_ssh_url")
 
-                code, msg, msg_show = self._check_warehouse(service_obj.git_url, git_http_url, gitlab_ssh_url)
+                code, msg, msg_show = self._check_warehouse(service_obj.git_url, git_http_url, gitlab_ssh_url)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(200, msg, msg_show), status=200)
 
@@ -190,7 +193,7 @@ class WebHooksDeploy(AlowAnyApiView):
                 clone_url = repository.get("clone_url")
                 ssh_url = repository.get("ssh_url")
 
-                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)
+                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(200, msg, msg_show), status=200)
 
@@ -237,7 +240,7 @@ class WebHooksDeploy(AlowAnyApiView):
                 clone_url = repository.get("clone_url")
                 ssh_url = repository.get("ssh_url")
 
-                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)
+                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(200, msg, msg_show), status=200)
 
@@ -292,7 +295,7 @@ class WebHooksDeploy(AlowAnyApiView):
                     return Response(result, status=200)
                 clone_url = repository.get("clone_url")
                 ssh_url = repository.get("ssh_url")
-                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)
+                code, msg, msg_show = self._check_warehouse(service_obj.git_url, clone_url, ssh_url)  # type: ignore[arg-type]
                 if code != 200:
                     return Response(general_message(200, msg, msg_show), status=200)
 
@@ -321,7 +324,7 @@ class WebHooksDeploy(AlowAnyApiView):
             logger.exception(e)
             return Response("Internal error occurred", status=500)
 
-    def _check_warehouse(self, service_git_url, clone_url, ssh_url):
+    def _check_warehouse(self, service_git_url: str, clone_url: str, ssh_url: str) -> Tuple[int, str, Optional[str]]:
         # 判断地址是否相同
         # service_url = urlparse(service_git_url)
         # http_url = urlparse(clone_url)
@@ -343,7 +346,7 @@ class WebHooksDeploy(AlowAnyApiView):
 
 
 class GetWebHooksUrl(AppBaseView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         判断该组件是否有webhooks自动部署功能，有则返回URL
         """
@@ -434,7 +437,7 @@ class GetWebHooksUrl(AppBaseView):
 
 
 class ImageWebHooksTrigger(AppBaseView):
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """镜像更新自动部署触发条件"""
         try:
             service_webhook = service_webhooks_repo.get_or_create_service_webhook(self.service.service_id, "image_webhooks")
@@ -449,7 +452,8 @@ class ImageWebHooksTrigger(AppBaseView):
                                          ensure_ascii=False)
         except Exception as e:
             logger.exception(e)
-            return error_message(e.message)
+            # NOTE: py2-era Exception.message; preserved for behavior compat (backlog).
+            return error_message(e.message)  # type: ignore[attr-defined]
         new_information = json.dumps({"组件": self.service.service_cname, "Tag触发": trigger}, ensure_ascii=False)
         comment = operation_log_service.generate_component_comment(
             operation=Operation.CHANGE,
@@ -484,7 +488,7 @@ class ImageWebHooksTrigger(AppBaseView):
 
 
 class WebHooksStatus(AppBaseView):
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         开启或关闭自动部署功能
         ---
@@ -547,13 +551,13 @@ class WebHooksStatus(AppBaseView):
                 service_alias=self.service.service_alias)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)
         return Response(result, status=200)
 
 
 class CustomWebHooksDeploy(AlowAnyApiView):
-    def post(self, request, service_id, *args, **kwargs):
+    def post(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         """自定义回调接口处发自动部署"""
         logger.debug(request.data)
         import base64
@@ -585,7 +589,7 @@ class UpdateSecretKey(AppBaseView):
     修改部署秘钥
     """
 
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             secret_key = request.data.get("secret_key", None)
             if not secret_key:
@@ -620,7 +624,7 @@ class UpdateSecretKey(AppBaseView):
                 return Response(result, 404)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
         return Response(result, status=500)
 
 
@@ -629,7 +633,7 @@ class ImageWebHooksDeploy(AlowAnyApiView):
     镜像仓库webhooks回调地址
     """
 
-    def post(self, request, service_id, *args, **kwargs):
+    def post(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             service_obj = TenantServiceInfo.objects.get(service_id=service_id)
             if not service_obj:
@@ -638,7 +642,8 @@ class ImageWebHooksDeploy(AlowAnyApiView):
             tenant_obj = Tenants.objects.get(tenant_id=service_obj.tenant_id)
             service_webhook = service_webhooks_repo.get_service_webhooks_by_service_id_and_type(
                 service_obj.service_id, "image_webhooks")
-            if not service_webhook.state:
+            # NOTE: repo may return None webhook; legacy assumes present (backlog).
+            if not service_webhook.state:  # type: ignore[union-attr]
                 result = general_message(400, "failed", "组件关闭了自动构建")
                 return Response(result, status=400)
             data = request.data
@@ -683,9 +688,9 @@ class ImageWebHooksDeploy(AlowAnyApiView):
                 return Response(result, status=400)
 
             # 标签匹配
-            if service_webhook.trigger:
+            if service_webhook.trigger:  # type: ignore[union-attr]
                 # 如果有正则表达式根据正则触发
-                if not re.match(service_webhook.trigger, tag):
+                if not re.match(service_webhook.trigger, tag):  # type: ignore[union-attr]
                     result = general_message(400, "failed", "镜像tag与正则表达式不匹配")
                     return Response(result, status=400)
                 service_repo.change_service_image_tag(service_obj, tag)
@@ -708,5 +713,5 @@ class ImageWebHooksDeploy(AlowAnyApiView):
                 return Response(result, status=400)
         except Exception as e:
             logger.exception(e)
-            result = error_message(e.message)
+            result = error_message(e.message)  # type: ignore[attr-defined]
             return Response(result, status=500)

--- a/console/views/yaml_resource.py
+++ b/console/views/yaml_resource.py
@@ -1,39 +1,45 @@
+from typing import Any
+
 from console.services.yaml_k8s_resource import yaml_k8s_resource
 from console.views.base import RegionTenantHeaderView
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from www.utils.return_message import general_message
 
 
 class YamlResourceName(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.GET.get("event_id")
         app_id = request.GET.get("group_id")
         namespace = self.tenant.namespace
         tenant_id = self.tenant.tenant_id
         region_id = self.region.region_id
         enterprise_id = self.enterprise.enterprise_id
-        res = yaml_k8s_resource.yaml_k8s_resource_name(event_id, app_id, tenant_id, namespace, region_id, enterprise_id)
+        # NOTE: GET params are Optional and event_id maps to int param; service expects str/int (legacy mismatch, backlog).
+        res = yaml_k8s_resource.yaml_k8s_resource_name(
+            event_id, app_id, tenant_id, namespace, region_id, enterprise_id)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=res), status=200)
 
 
 class YamlResourceDetailed(RegionTenantHeaderView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.GET.get("event_id")
         app_id = request.GET.get("group_id")
         namespace = self.tenant.namespace
         tenant_id = self.tenant.tenant_id
         region_id = self.region.region_id
         enterprise_id = self.enterprise.enterprise_id
-        res = yaml_k8s_resource.yaml_k8s_resource_detailed(event_id, app_id, tenant_id, namespace, region_id, enterprise_id)
+        res = yaml_k8s_resource.yaml_k8s_resource_detailed(
+            event_id, app_id, tenant_id, namespace, region_id, enterprise_id)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", bean=res), status=200)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         event_id = request.data.get("event_id")
         app_id = request.data.get("group_id")
         namespace = self.tenant.namespace
         tenant = self.tenant
         enterprise_id = self.enterprise.enterprise_id
-        res = yaml_k8s_resource.yaml_k8s_resource_import(event_id, app_id, tenant, namespace, self.region, enterprise_id,
-                                                         self.user)
+        res = yaml_k8s_resource.yaml_k8s_resource_import(
+            event_id, app_id, tenant, namespace, self.region, enterprise_id, self.user)  # type: ignore[arg-type]
         return Response(general_message(200, "success", "查询成功", list=res), status=200)

--- a/mypy.ini
+++ b/mypy.ini
@@ -495,3 +495,17 @@ check_untyped_defs = True
 [mypy-console.services.tenant_region_service]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# ---- P5: views layer, annotated one batch at a time ----
+# V0: base view classes (context-attribute typing convention) + small leaf packages.
+[mypy-console.views.base]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.app.*]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.platform_resources.*]
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -509,3 +509,8 @@ check_untyped_defs = True
 [mypy-console.views.platform_resources.*]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# V1: app_config/ subpackage (AppBaseView + component-config views).
+[mypy-console.views.app_config.*]
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -519,3 +519,12 @@ check_untyped_defs = True
 [mypy-console.views.app_create.*]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# V3: center_pool/ + plugin/ subpackages.
+[mypy-console.views.center_pool.*]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.plugin.*]
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -529,6 +529,35 @@ check_untyped_defs = True
 disallow_untyped_defs = True
 check_untyped_defs = True
 
+# V5: more large top-level views.
+[mypy-console.views.service_share]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.user_operation]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.oauth]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.webhook]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.public_areas]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.mcp_query]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.adaptor]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
 # V4: largest top-level views.
 [mypy-console.views.team]
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -528,3 +528,20 @@ check_untyped_defs = True
 [mypy-console.views.plugin.*]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# V4: largest top-level views.
+[mypy-console.views.team]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.enterprise]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.app_manage]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.app_overview]
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -529,6 +529,15 @@ check_untyped_defs = True
 disallow_untyped_defs = True
 check_untyped_defs = True
 
+# V6: all remaining top-level views — whole console.views package now strict.
+[mypy-console.views]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-console.views.*]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
 # V5: more large top-level views.
 [mypy-console.views.service_share]
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -514,3 +514,8 @@ check_untyped_defs = True
 [mypy-console.views.app_config.*]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# V2: app_create/ subpackage (source/image/compose/vm create flows).
+[mypy-console.views.app_create.*]
+disallow_untyped_defs = True
+check_untyped_defs = True


### PR DESCRIPTION
## What

P5 of the mypy adoption plan: annotate the **entire `console/views/` layer** and bring it into the mypy strict whitelist. Follows P4 (services, #1959) which already typed `console/services/`, `console/repositories/`, and `www/apiclient/regionapi.py`.

After this PR, `[mypy-console.views.*]` is strict and error-free under the full-tree gate.

## How it was done (7 incremental commits)

- **V0** — `base.py` (the keystone): establishes the convention for view context attributes. `self.user/tenant/team/region/app/enterprise/...` are populated in `initial()` before any handler runs, so they are typed to their runtime contract (non-Optional model types) via class-level annotations, with a single `# type: ignore[assignment]` on each transient `None` default. This keeps subclass view bodies free of `union-attr` noise. Plus the small leaf packages `app/`, `platform_resources/`.
- **V1–V3** — subpackages `app_config/`, `app_create/`, `center_pool/`, `plugin/`.
- **V4–V6** — all top-level view modules.

## Guarantees / review notes

- **No behavior changes.** Only signatures, imports, `# type: ignore` + `# NOTE`, and a handful of behavior-preserving local variable renames (to split same-named vars of different types). Every file was verified with an AST diff that strips annotations/imports — the executable AST is identical except for the reviewed renames.
- Legacy mismatches surfaced by the checker (systemic int-as-str ids, nullable `enterprise_id`, regionapi `Optional` response data, py2-style `Exception.message`, defensive DRF exception-handler attribute access) are suppressed with `# type: ignore` + a `# NOTE`, never "fixed" — preserving existing behavior. Genuine latent bugs found this way are catalogued for a separate fix PR.
- One cascade into the already-whitelisted `operation_log.py` (it imports `AppBaseView`) was handled.

## Verification (every batch)

- single-module strict (`--disallow-untyped-defs --check-untyped-defs`) → 0
- full-tree gate (`mypy console/ www/ openapi/`) → all whitelisted modules 0
- unit-test gate (`scripts/run_pytest.py console/tests`) → 0 failures

`openapi/` typing and the regionapi-response `TypedDict` work will follow in separate PRs.