### PR TITLE
ci: add AI issue agents (/claude /codex /mimo)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       # 1) Mint a token that can write to ALL three repos.
       - name: Generate cross-repo GitHub App token
@@ -118,7 +118,7 @@ jobs:
           #   without it every Bash call is denied (permission_denials) and nothing happens.
           # --model sets the third-party model name (e.g. deepseek-chat).
           # Set vars.ANTHROPIC_MODEL to override; defaults to the official model.
-          claude_args: "--max-turns 50 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
+          claude_args: "--max-turns 120 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
           prompt: |
             You are an automated engineer for the Rainbond platform. Issue
             #${{ github.event.issue.number }} was filed in the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,220 @@
+name: claude
+
+# Comment "/claude" in an issue or issue comment (in this repo) and Claude Code
+# will analyze the request, figure out which Rainbond repo actually needs the
+# fix (rainbond / rainbond-console / rainbond-ui), make the change, run that
+# repo's quality gate, and open a PR back-linked to the issue.
+#
+# Only members/collaborators (people with write access) can trigger it, so
+# random visitors cannot burn your Anthropic credits.
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+# Token used by the action is the GitHub App token (cross-repo). These job
+# permissions cover the action's own bookkeeping on THIS repo.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
+  id-token: write
+
+jobs:
+  claude:
+    # Gate: trigger phrase present AND author has write access.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '/claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '/claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '/claude') &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # 1) Mint a token that can write to ALL three repos.
+      - name: Generate cross-repo GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            rainbond
+            rainbond-console
+            rainbond-ui
+
+      # 2) Check out the triggering repo (rainbond/Go) for immediate context.
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      # 3) Make git/gh use the cross-repo token, and resolve the App's bot
+      #    identity so commits are authored by the app (not claude[bot]) and the
+      #    DCO sign-off matches the author. Exported as env for the agent to apply
+      #    inside each cloned repo before committing.
+      - name: Configure git auth and bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          gh auth setup-git
+          BOT_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          BOT_NAME="${APP_SLUG}[bot]"
+          BOT_EMAIL="${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global user.name "$BOT_NAME"
+          git config --global user.email "$BOT_EMAIL"
+          echo "BOT_NAME=$BOT_NAME" >> "$GITHUB_ENV"
+          echo "BOT_EMAIL=$BOT_EMAIL" >> "$GITHUB_ENV"
+          echo "bot identity: $BOT_NAME <$BOT_EMAIL>"
+
+      # 4) Run Claude in agent mode with explicit cross-repo instructions.
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Third-party Anthropic-compatible endpoint. Stored as a SECRET (not a
+          # var) so a private relay domain is masked in public Actions logs.
+          # Leave the secret empty to use the official Anthropic API.
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          # Bearer-auth third parties need ANTHROPIC_AUTH_TOKEN (sent as
+          # "Authorization: Bearer ..."), which takes precedence over x-api-key.
+          # For the OFFICIAL Anthropic API leave this secret empty and instead
+          # set the ANTHROPIC_API_KEY secret below.
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+        with:
+          # Satisfies the action's auth preflight. When ANTHROPIC_AUTH_TOKEN is
+          # set above, Claude Code uses the Bearer token and ignores this.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN || secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          # Post a live-updating progress comment on the issue (todo checklist +
+          # current action). Better than log-watching: visible on the issue and
+          # safe on public repos (it is a comment, not secret-bearing logs).
+          track_progress: true
+          # Full transcript in the Actions log ONLY on private repos. On public
+          # repos (e.g. goodrain) this auto-disables so runtime values the agent
+          # prints are not exposed in the world-readable logs.
+          show_full_output: ${{ github.event.repository.private }}
+          # --max-turns caps how long the agent runs => caps token spend.
+          # --allowedTools lets the agent run git/gh/build commands non-interactively;
+          #   without it every Bash call is denied (permission_denials) and nothing happens.
+          # --model sets the third-party model name (e.g. deepseek-chat).
+          # Set vars.ANTHROPIC_MODEL to override; defaults to the official model.
+          claude_args: "--max-turns 50 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
+          prompt: |
+            You are an automated engineer for the Rainbond platform. Issue
+            #${{ github.event.issue.number }} was filed in the
+            ${{ github.repository }} repository.
+
+            The Rainbond platform spans three repos under the
+            "${{ github.repository_owner }}" GitHub org:
+              - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+                (API/builder/worker); the only layer that talks to Kubernetes.
+              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+                web backend; serves the UI and orchestrates calls to rainbond via
+                RegionInvokeApi (HTTP to /v2/tenants/...). Shares the MySQL instance
+                with rainbond but uses a separate logical DB (no shared tables).
+              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend dashboard;
+                calls console at /console/* and /openapi/v1/*.
+
+            Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.
+            Each repo has its own CLAUDE.md and AGENTS.md with detailed conventions —
+            ALWAYS read the target repo's CLAUDE.md before changing it.
+
+            The current working directory is a checkout of the rainbond (Go) repo.
+
+            Steps:
+            0. Determine context. Run:
+                 gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+               If #${{ github.event.issue.number }} IS a pull request, use PR MODE
+               below and STOP (skip the issue steps). Otherwise it is an issue —
+               continue at step 1.
+
+            PR MODE (iterate on THIS existing PR — never open a new PR):
+               - Check out the PR branch:
+                   gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+               - Do what the comment asks. If asked to fix failing CI:
+                   gh pr checks ${{ github.event.issue.number }} --repo ${{ github.repository }}
+                 open the failing check's logs (e.g. gh run view --log --job=<id>),
+                 find the real cause, and fix it.
+               - Set the bot identity (git config user.name "$BOT_NAME";
+                 git config user.email "$BOT_EMAIL"), then `git commit -s` and
+                 `git push` to the SAME PR branch. Do NOT create a new branch or PR.
+               - Comment on the PR with a short summary of what you changed.
+
+            ISSUE MODE:
+            1. Read the full request and the triggering comment:
+               gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
+            2. Pick a MODE based on what is actually being asked:
+               - ANSWER: it is a question → reply in an issue comment. No code, no PR.
+               - DESIGN: a feature / new requirement, or the comment says things
+                 like "设计 / 方案 / 讨论 / 先别写代码 / don't implement / just propose"
+                 → post a DESIGN PROPOSAL as an issue comment covering: affected
+                 repos & files, API / data-model / UX changes, a step-by-step plan,
+                 and risks / alternatives. DO NOT write code or open a PR.
+               - IMPLEMENT: an explicit ask to fix a bug or build something already
+                 agreed → follow steps 3-5 below.
+               When ambiguous: a clear bug → IMPLEMENT; a feature with no agreed
+               design → prefer DESIGN (propose first, do not build).
+               (Steps 3-5 apply to IMPLEMENT mode only.)
+            3. Decide which repo(s) ACTUALLY need the change. Do NOT assume it is
+               the Go repo — many issues filed here are really console (Python)
+               or ui (React) problems. Investigate the code before deciding.
+            4. For each repo that needs a change:
+               - If it is not the current repo, clone it:
+                   gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>
+                 then cd into it.
+               - Create branch: claude/issue-${{ github.event.issue.number }}-<short-slug>
+               - Add a regression test ONLY IF the repo already has a test
+                 framework (package.json has a "test" script, or pytest / go test
+                 exist) AND the test can exercise the REAL code path — import or
+                 call the actual code; NEVER copy the logic being fixed into the
+                 test (a copied snippet tests nothing and is dead weight). A good
+                 test FAILS before your change and PASSES after. If the repo has no
+                 test runner, or the fix can only be "tested" by duplicating
+                 logic, do NOT add a test — describe manual verification in the PR.
+               - Make the MINIMAL correct change. Follow that repo's CLAUDE.md.
+               - Run the repo's quality gate BEFORE committing:
+                   * rainbond (Go):         go build ./... && go vet ./...
+                   * rainbond-console (Py): make check && pytest (relevant subset)
+                   * rainbond-ui (React):   yarn install && yarn build
+               - Before committing in this repo, set the bot identity (overrides
+                 any default so the author is the app, not claude[bot]):
+                   git config user.name "$BOT_NAME"
+                   git config user.email "$BOT_EMAIL"
+                 Then commit with `git commit -s` (the -s Signed-off-by is REQUIRED
+                 by the repo's DCO check and matches the author above; it is NOT AI
+                 attribution). Use Conventional Commits, English, NO emoji and NO
+                 Co-authored-by / AI attribution lines.
+               - Push and open a PR:
+                   gh pr create -R ${{ github.repository_owner }}/<repo> --base main
+                 In the PR body, reference the issue:
+                   "Ref ${{ github.repository_owner }}/rainbond#${{ github.event.issue.number }}"
+            5. Comment on issue #${{ github.event.issue.number }} summarizing what
+               you did and linking the PR(s).
+
+            Hard rules:
+            - NEVER push to main. Always open a PR.
+            - If a quality gate fails and you cannot fix it, do NOT open the PR.
+              Instead comment on the issue explaining what you found and stop.
+            - Keep changes scoped to the issue. No drive-by refactors.
+            - If the issue is unclear or not reproducible, comment asking for
+              clarification instead of guessing.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -126,13 +126,13 @@ jobs:
 
             The Rainbond platform spans three repos under the
             "${{ github.repository_owner }}" GitHub org:
-              - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+              - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
                 (API/builder/worker); the only layer that talks to Kubernetes.
-              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+              - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
                 web backend; serves the UI and orchestrates calls to rainbond via
                 RegionInvokeApi (HTTP to /v2/tenants/...). Shares the MySQL instance
                 with rainbond but uses a separate logical DB (no shared tables).
-              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend dashboard;
+              - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend dashboard;
                 calls console at /console/* and /openapi/v1/*.
 
             Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,192 @@
+name: codex
+
+# Comment "/codex" (instead of "/claude") in an issue or comment to run the same
+# cross-repo flow with OpenAI Codex CLI.
+#
+# IMPORTANT: current Codex only speaks the Responses API (/v1/responses). The
+# endpoint in CODEX_BASE_URL MUST support it — a Chat-Completions-only endpoint
+# (e.g. MiMo) will 404. Use OpenAI official or a Responses-API-compatible provider.
+#
+# Required repo config:
+#   secrets.CLAUDE_APP_ID / CLAUDE_APP_PRIVATE_KEY  (same GitHub App as claude.yml)
+#   secrets.CODEX_API_KEY                           (provider key)
+#   vars.CODEX_BASE_URL                             (Responses-API endpoint, e.g. https://api.openai.com/v1)
+#   vars.CODEX_MODEL                                (e.g. gpt-5-codex)
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
+
+jobs:
+  codex:
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '/codex') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '/codex') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '/codex') &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate cross-repo GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            rainbond
+            rainbond-console
+            rainbond-ui
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git auth and bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          gh auth setup-git
+          BOT_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          BOT_NAME="${APP_SLUG}[bot]"
+          BOT_EMAIL="${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global user.name "$BOT_NAME"
+          git config --global user.email "$BOT_EMAIL"
+          echo "BOT_NAME=$BOT_NAME" >> "$GITHUB_ENV"
+          echo "BOT_EMAIL=$BOT_EMAIL" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      # Point Codex at the Responses-API endpoint. base_url is a SECRET so a
+      # private relay domain stays masked in public Actions logs.
+      - name: Configure Codex provider
+        env:
+          CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
+          CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+        run: |
+          mkdir -p "$HOME/.codex"
+          cat > "$HOME/.codex/config.toml" <<EOF
+          model = "${CODEX_MODEL}"
+          model_provider = "thirdparty"
+
+          [model_providers.thirdparty]
+          name = "Third Party"
+          base_url = "${CODEX_BASE_URL}"
+          env_key = "CODEX_API_KEY"
+          # Current Codex only supports the Responses API. The provider set in
+          # CODEX_BASE_URL MUST expose /v1/responses (a chat-only endpoint 404s).
+          wire_api = "responses"
+          EOF
+
+      - name: Run Codex
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: |
+          PROMPT=$(cat <<'EOF'
+          You are an automated engineer for the Rainbond platform. Issue
+          #${{ github.event.issue.number }} was filed in the
+          ${{ github.repository }} repository.
+
+          The platform spans three repos under "${{ github.repository_owner }}":
+            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+              (API/builder/worker); only layer that talks to Kubernetes.
+            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+              web backend; serves UI, orchestrates rainbond via RegionInvokeApi
+              (/v2/tenants/...). Same MySQL instance, separate logical DB.
+            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+              calls console at /console/* and /openapi/v1/*.
+
+          Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.
+          Each repo has its own CLAUDE.md and AGENTS.md — read the target repo's
+          before changing it.
+
+          The current directory is a checkout of the rainbond (Go) repo. GH_TOKEN
+          is set and `gh` is authenticated for all three repos.
+
+          Steps:
+          0. Run: gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             If #${{ github.event.issue.number }} IS a pull request, use PR MODE and
+             STOP. Otherwise continue at step 1 (issue).
+
+          PR MODE (iterate on THIS PR, never open a new one):
+             - gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             - Do what the comment asks; to fix CI: gh pr checks
+               ${{ github.event.issue.number }} --repo ${{ github.repository }}, read the
+               failing job logs, fix the cause.
+             - Set identity (git config user.name "$BOT_NAME"; git config user.email
+               "$BOT_EMAIL"), git commit -s, git push to the SAME branch. No new PR.
+             - Comment on the PR with a summary.
+
+          ISSUE MODE:
+          1. Read the request and the triggering comment:
+             gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
+          2. Pick a MODE:
+             - ANSWER: a question → reply in a comment, no code/PR.
+             - DESIGN: a feature/new requirement, or the comment says "设计 / 方案 /
+               讨论 / 先别写代码 / don't implement / just propose" → post a DESIGN
+               PROPOSAL comment (affected repos & files, API/data-model/UX changes,
+               step plan, risks/alternatives). Do NOT write code or open a PR.
+             - IMPLEMENT: explicit ask to fix/build → do steps 3-4.
+             Ambiguous: clear bug → IMPLEMENT; feature with no agreed design → DESIGN.
+             (Steps 3-4 are IMPLEMENT mode only.)
+          3. Decide which repo(s) actually need the change (do NOT assume Go).
+             For each repo needing a change: clone it if needed
+             (gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>),
+             create branch codex/issue-${{ github.event.issue.number }}-<slug>.
+             Add a regression test ONLY IF the repo already has a test framework
+             (package.json "test" script, or pytest / go test) AND it exercises
+             the REAL code path (import/call the actual code; NEVER copy the fixed
+             logic into the test — a copy tests nothing). It must FAIL before the
+             fix and PASS after. If no test runner exists or it could only be
+             tested by duplicating logic, do NOT add a test; describe manual
+             verification in the PR.
+             Then make the minimal correct change following that repo's CLAUDE.md, run
+             its quality gate (Go: go build ./... && go vet ./...; console:
+             make check && pytest; ui: yarn install && yarn build). Before
+             committing, set identity: git config user.name "$BOT_NAME" &&
+             git config user.email "$BOT_EMAIL". Then commit with
+             `git commit -s` (DCO Signed-off-by REQUIRED, matches the author)
+             (Conventional Commits, English, no emoji, no AI attribution), push,
+             and open a PR: gh pr create -R ${{ github.repository_owner }}/<repo> --base main
+             referencing the issue in the body.
+          4. Comment on issue #${{ github.event.issue.number }} with a summary + PR links.
+
+          Hard rules: never push to main; if a quality gate fails and you cannot
+          fix it, do not open the PR — comment on the issue and stop; keep changes
+          scoped; ask for clarification if the issue is unclear.
+          EOF
+          )
+          # --dangerously-bypass-approvals-and-sandbox lets Codex run git/gh and
+          # reach the network in CI. Verify this flag for your codex version.
+          codex exec --dangerously-bypass-approvals-and-sandbox "$PROMPT"

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -119,12 +119,12 @@ jobs:
           ${{ github.repository }} repository.
 
           The platform spans three repos under "${{ github.repository_owner }}":
-            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+            - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
               (API/builder/worker); only layer that talks to Kubernetes.
-            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+            - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
               web backend; serves UI, orchestrates rainbond via RegionInvokeApi
               (/v2/tenants/...). Same MySQL instance, separate logical DB.
-            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+            - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend;
               calls console at /console/* and /openapi/v1/*.
 
           Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -47,7 +47,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Generate cross-repo GitHub App token
         id: app-token

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -133,12 +133,12 @@ jobs:
           ${{ github.repository }} repository.
 
           The platform spans three repos under "${{ github.repository_owner }}":
-            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+            - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
               (API/builder/worker); only layer that talks to Kubernetes.
-            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+            - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
               web backend; serves UI, orchestrates rainbond via RegionInvokeApi
               (/v2/tenants/...). Same MySQL instance, separate logical DB.
-            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+            - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend;
               calls console at /console/* and /openapi/v1/*.
 
           Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -49,7 +49,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Generate cross-repo GitHub App token
         id: app-token

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -1,0 +1,206 @@
+name: mimo
+
+# Comment "/mimo" in an issue or comment to run the cross-repo fix flow with
+# Xiaomi's MiMo-Code agent (an OpenCode fork) driving the MiMo model natively.
+# This is the "native agent + native model" variant, to compare against claude.yml.
+#
+# NOTE: MiMo-Code is an OpenCode fork; CLI binary name, config path and flags may
+# change. Verified against the repo source as of 2026-06: headless run is
+# `mimo run "<msg>"`, auto-approve is `--dangerously-skip-permissions`, custom
+# provider goes in opencode.json with npm "@ai-sdk/openai-compatible".
+#
+# Required repo config:
+#   secrets.CLAUDE_APP_ID / CLAUDE_APP_PRIVATE_KEY  (same GitHub App as claude.yml)
+#   secrets.MIMO_API_KEY                            (MiMo key)
+#   vars.MIMO_BASE_URL                              (OpenAI-compatible base, e.g. https://token-plan-cn.xiaomimimo.com/v1)
+#   vars.MIMO_MODEL                                 (e.g. mimo-v2.5)
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
+
+jobs:
+  mimo:
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '/mimo') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '/mimo') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '/mimo') &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate cross-repo GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            rainbond
+            rainbond-console
+            rainbond-ui
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git auth and bot identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          gh auth setup-git
+          BOT_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          BOT_NAME="${APP_SLUG}[bot]"
+          BOT_EMAIL="${BOT_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global user.name "$BOT_NAME"
+          git config --global user.email "$BOT_EMAIL"
+          echo "BOT_NAME=$BOT_NAME" >> "$GITHUB_ENV"
+          echo "BOT_EMAIL=$BOT_EMAIL" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install MiMo-Code CLI
+        run: npm install -g @mimo-ai/cli
+
+      # Define the MiMo provider. apiKey uses {env:...} so the key is read at
+      # runtime and never written to the config file on disk. Written to several
+      # candidate paths because the OpenCode fork's config discovery may use
+      # either name (opencode.json / .mimocode/mimocode.json) or the global dir.
+      - name: Configure MiMo provider
+        env:
+          # base_url is a SECRET so a private relay domain stays masked in logs.
+          MIMO_BASE_URL: ${{ secrets.MIMO_BASE_URL }}
+          MIMO_MODEL: ${{ vars.MIMO_MODEL }}
+        run: |
+          read -r -d '' CFG <<EOF || true
+          {
+            "\$schema": "https://opencode.ai/config.json",
+            "provider": {
+              "mimo": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "MiMo",
+                "options": {
+                  "baseURL": "${MIMO_BASE_URL}",
+                  "apiKey": "{env:MIMO_API_KEY}"
+                },
+                "models": {
+                  "${MIMO_MODEL}": { "name": "MiMo" }
+                }
+              }
+            }
+          }
+          EOF
+          mkdir -p .mimocode "$HOME/.config/opencode"
+          printf '%s\n' "$CFG" | tee opencode.json .mimocode/mimocode.json "$HOME/.config/opencode/opencode.json" >/dev/null
+          echo "provider config written (base_url hidden)"
+
+      - name: Run MiMo-Code
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          MIMO_MODEL: ${{ vars.MIMO_MODEL }}
+        run: |
+          PROMPT=$(cat <<'EOF'
+          You are an automated engineer for the Rainbond platform. Issue
+          #${{ github.event.issue.number }} was filed in the
+          ${{ github.repository }} repository.
+
+          The platform spans three repos under "${{ github.repository_owner }}":
+            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+              (API/builder/worker); only layer that talks to Kubernetes.
+            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+              web backend; serves UI, orchestrates rainbond via RegionInvokeApi
+              (/v2/tenants/...). Same MySQL instance, separate logical DB.
+            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+              calls console at /console/* and /openapi/v1/*.
+
+          Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.
+          Each repo has its own CLAUDE.md and AGENTS.md — read the target repo's
+          before changing it.
+
+          The current directory is a checkout of the rainbond (Go) repo. GH_TOKEN
+          is set and `gh` is authenticated for all three repos.
+
+          Steps:
+          0. Run: gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             If #${{ github.event.issue.number }} IS a pull request, use PR MODE and
+             STOP. Otherwise continue at step 1 (issue).
+
+          PR MODE (iterate on THIS PR, never open a new one):
+             - gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             - Do what the comment asks; to fix CI: gh pr checks
+               ${{ github.event.issue.number }} --repo ${{ github.repository }}, read the
+               failing job logs, fix the cause.
+             - Set identity (git config user.name "$BOT_NAME"; git config user.email
+               "$BOT_EMAIL"), git commit -s, git push to the SAME branch. No new PR.
+             - Comment on the PR with a summary.
+
+          ISSUE MODE:
+          1. Read the request and the triggering comment:
+             gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
+          2. Pick a MODE:
+             - ANSWER: a question → reply in a comment, no code/PR.
+             - DESIGN: a feature/new requirement, or the comment says "设计 / 方案 /
+               讨论 / 先别写代码 / don't implement / just propose" → post a DESIGN
+               PROPOSAL comment (affected repos & files, API/data-model/UX changes,
+               step plan, risks/alternatives). Do NOT write code or open a PR.
+             - IMPLEMENT: explicit ask to fix/build → do steps 3-4.
+             Ambiguous: clear bug → IMPLEMENT; feature with no agreed design → DESIGN.
+             (Steps 3-4 are IMPLEMENT mode only.)
+          3. Decide which repo(s) actually need the change (do NOT assume Go).
+             For each repo needing a change: clone it if needed
+             (gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>),
+             create branch mimo/issue-${{ github.event.issue.number }}-<slug>.
+             Add a regression test ONLY IF the repo already has a test framework
+             (package.json "test" script, or pytest / go test) AND it exercises
+             the REAL code path (import/call the actual code; NEVER copy the fixed
+             logic into the test — a copy tests nothing). It must FAIL before the
+             fix and PASS after. If no test runner exists or it could only be
+             tested by duplicating logic, do NOT add a test; describe manual
+             verification in the PR.
+             Then make the minimal correct change following that repo's CLAUDE.md, run
+             its quality gate (Go: go build ./... && go vet ./...; console:
+             make check && pytest; ui: yarn install && yarn build). Before
+             committing, set identity: git config user.name "$BOT_NAME" &&
+             git config user.email "$BOT_EMAIL". Then commit with
+             `git commit -s` (DCO Signed-off-by REQUIRED, matches the author)
+             (Conventional Commits, English, no emoji, no AI attribution), push,
+             and open a PR: gh pr create -R ${{ github.repository_owner }}/<repo> --base main
+             referencing the issue in the body.
+          4. Comment on issue #${{ github.event.issue.number }} with a summary + PR links.
+
+          Hard rules: never push to main; if a quality gate fails and you cannot
+          fix it, do not open the PR — comment on the issue and stop; keep changes
+          scoped; ask for clarification if the issue is unclear.
+          EOF
+          )
+          # --dangerously-skip-permissions auto-approves tool use (bash/git/gh)
+          # so the agent can run unattended in CI.
+          mimo run "$PROMPT" --model "mimo/${MIMO_MODEL}" --dangerously-skip-permissions


### PR DESCRIPTION
Adds the same AI issue agents already in goodrain/rainbond, so issues AND pull requests in this repo can trigger them.

Comment /claude (or /codex, /mimo) to:
- answer a question, design a feature, or implement a fix (issue mode)
- fix this PR in place, e.g. failing CI (PR mode)

Collaborator-gated; cross-repo writes via the shared GitHub App token; commits signed off (DCO). Requires org/repo secrets (CLAUDE_APP_ID, CLAUDE_APP_PRIVATE_KEY, engine keys) — see deployment checklist.

Signed-off-by present (DCO).