### PR TITLE
chore: mypy strict typing for the openapi layer (P5)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -583,3 +583,12 @@ check_untyped_defs = True
 [mypy-console.views.app_overview]
 disallow_untyped_defs = True
 check_untyped_defs = True
+
+# ---- P5 openapi: whole openapi package annotated and strict ----
+[mypy-openapi]
+disallow_untyped_defs = True
+check_untyped_defs = True
+
+[mypy-openapi.*]
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/openapi/auth/authentication.py
+++ b/openapi/auth/authentication.py
@@ -3,8 +3,10 @@
 
 import logging
 import os
+from typing import Any
 
 from rest_framework import authentication, exceptions
+from rest_framework.request import Request
 
 from openapi.services.api_user_service import apiUserService
 from www.models.main import Users, TenantEnterprise
@@ -13,7 +15,7 @@ logger = logging.getLogger("default")
 
 
 class OpenAPIAuthentication(authentication.TokenAuthentication):
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> Any:
         # 优先检查 X-Internal-Token (内部服务调用)
         internal_token = request.META.get('HTTP_X_INTERNAL_TOKEN')
         if internal_token:
@@ -42,7 +44,7 @@ class OpenAPIAuthentication(authentication.TokenAuthentication):
 
 
 class OpenAPIManageAuthentication(authentication.TokenAuthentication):
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> Any:
         token = request.META.get('HTTP_AUTHORIZATION')
         if not token:
             raise exceptions.AuthenticationFailed('No token')

--- a/openapi/auth/permissions.py
+++ b/openapi/auth/permissions.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
 from openapi.services.api_user_service import apiUserService
 
 logger = logging.getLogger("default")
 
 
 class OpenAPIPermissions(BasePermission):
-    def has_perms(self, user, perms):
+    def has_perms(self, user: Any, perms: Any) -> bool:
         if isinstance(user, AnonymousUser):
             return False
         user_perms = apiUserService.get_permissions_by_user(user, user.enterprise_id)
@@ -20,7 +22,7 @@ class OpenAPIPermissions(BasePermission):
                 return True
         return False
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: Any) -> bool:
         '''
         check permission
         '''

--- a/openapi/auth/views.py
+++ b/openapi/auth/views.py
@@ -3,6 +3,7 @@
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -32,7 +33,7 @@ class TokenInfoView(APIView):
         ),
         tags=['openapi-auth'],
         operation_description="企业管理员账号密码获取API-Token")
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         username = request.data.get("username", None)
         password = request.data.get("password", None)
         if not username or not password:

--- a/openapi/mcp/serializers.py
+++ b/openapi/mcp/serializers.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rest_framework import serializers
 
 class RegionSerializer(serializers.Serializer):
@@ -60,7 +62,7 @@ class ComponentLogSerializer(serializers.Serializer):
     class Meta:
         fields = "__all__"
 
-    def to_representation(self, instance):
+    def to_representation(self, instance: Any) -> Any:
         """自定义日志输出格式"""
         if isinstance(instance, str):
             return {"message": instance}

--- a/openapi/mcp/views.py
+++ b/openapi/mcp/views.py
@@ -1,5 +1,7 @@
 import time
+from typing import Any, Optional, Tuple
 
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status as http_status
 from drf_yasg.utils import swagger_auto_schema
@@ -57,7 +59,7 @@ class McpRegionsView(BaseOpenAPIView):
         },
         tags=['集群管理']
     )
-    def get(self, request):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """获取集群列表"""
         try:
             # 获取企业下的所有集群
@@ -88,12 +90,13 @@ class McpTeamsView(BaseOpenAPIView):
         },
         tags=['团队管理']
     )
-    def get(self, request):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """获取团队列表"""
         try:
             teams = team_services.list_user_teams(
                 enterprise_id=self.enterprise.enterprise_id,
-                user=request.user,
+                # NOTE: request.user typed User|AnonymousUser; expected Users (arg-type).
+                user=request.user,  # type: ignore[arg-type]
                 name=request.GET.get('name', None)
             )
             serializer = TeamSerializer(teams, many=True)
@@ -120,7 +123,7 @@ class McpAppsView(BaseOpenAPIView):
         },
         tags=['应用管理']
     )
-    def get(self, request, team_alias, region_name):
+    def get(self, request: Request, team_alias: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """获取团队下的应用列表"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
@@ -154,7 +157,7 @@ class McpAppView(BaseOpenAPIView):
         },
         tags=['应用管理']
     )
-    def post(self, request, team_alias, region_name):
+    def post(self, request: Request, team_alias: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         """创建应用"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
@@ -207,20 +210,22 @@ class McpComponentsView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def get(self, request, team_alias, app_id):
+    def get(self, request: Request, team_alias: str, app_id: int, *args: Any, **kwargs: Any) -> Response:
         """获取应用下的组件列表"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
             if not team:
                 return Response(general_message(404, "team not found", "团队不存在"), status=http_status.HTTP_404_NOT_FOUND)
-            app = group_repo.get_app_by_pk(app_id)
+            # NOTE: get_app_by_pk typed to expect str & may return None (arg-type/union-attr).
+            app = group_repo.get_app_by_pk(app_id)  # type: ignore[arg-type]
 
+            # NOTE: group_id/enterprise_id stub types (int->str, str|None) legacy mismatch.
             components = service_repo.get_group_service_by_group_id(
-                group_id=app_id,
-                region_name=app.region_name,
+                group_id=app_id,  # type: ignore[arg-type]
+                region_name=app.region_name,  # type: ignore[union-attr]
                 team_id=team.tenant_id,
                 team_name=team.tenant_name,
-                enterprise_id=team.enterprise_id
+                enterprise_id=team.enterprise_id  # type: ignore[arg-type]
             )
             serializer = ComponentBaseSerializer(components, many=True)
             result = general_message(200, "success", "获取成功", list=serializer.data)
@@ -249,7 +254,7 @@ class McpComponentView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def post(self, request, team_alias, app_id):
+    def post(self, request: Request, team_alias: str, app_id: int, *args: Any, **kwargs: Any) -> Response:
         """创建组件"""
         try:
             # 获取团队信息
@@ -258,7 +263,7 @@ class McpComponentView(BaseOpenAPIView):
                 return Response(general_message(404, "team not found", "团队不存在"), status=http_status.HTTP_404_NOT_FOUND)
 
             # 获取应用信息
-            app = group_repo.get_app_by_pk(app_id)
+            app = group_repo.get_app_by_pk(app_id)  # type: ignore[arg-type]
             if not app:
                 return Response(general_message(404, "app not found", "应用不存在"), status=http_status.HTTP_404_NOT_FOUND)
 
@@ -302,7 +307,7 @@ class McpComponentDetailView(BaseOpenAPIView):
     - 查看组件的运行实例（Pod）信息
     """
     
-    def _get_team_and_component(self, team_alias, component_id):
+    def _get_team_and_component(self, team_alias: str, component_id: str) -> Tuple[Any, Any, Optional[Response]]:
         """获取团队和组件信息"""
         team = team_services.get_team_by_team_alias(team_alias)
         if not team:
@@ -320,7 +325,7 @@ class McpComponentDetailView(BaseOpenAPIView):
         
         return team, component, None
     
-    def _get_component_status(self, component, team):
+    def _get_component_status(self, component: Any, team: Any) -> Any:
         """获取组件状态"""
         try:
             status_info = region_api.check_service_status(
@@ -329,12 +334,13 @@ class McpComponentDetailView(BaseOpenAPIView):
                 component.service_alias,
                 team.enterprise_id
             )
-            return status_info.get("bean", {}).get("status_cn", "未知")
+            # NOTE: regionapi return typed dict|None by stubs; may be None (backlog).
+            return status_info.get("bean", {}).get("status_cn", "未知")  # type: ignore[union-attr]
         except Exception as e:
             print(f"获取组件状态失败：{e}")
             return "未知"
     
-    def _build_access_url(self, domain):
+    def _build_access_url(self, domain: Any) -> Any:
         """构建访问 URL"""
         if hasattr(domain, 'domain_name'):  # HTTP 域名
             protocol = "https" if domain.certificate_id > 0 else "http"
@@ -345,11 +351,11 @@ class McpComponentDetailView(BaseOpenAPIView):
         else:  # TCP 域名
             return domain.end_point
     
-    def _merge_access_urls_to_ports(self, ports, http_domains, tcp_domains):
+    def _merge_access_urls_to_ports(self, ports: Any, http_domains: Any, tcp_domains: Any) -> list:
         """将访问地址信息合并到端口中"""
         # 创建端口到域名的映射，提高查询效率
-        http_domain_map = {}
-        tcp_domain_map = {}
+        http_domain_map: dict = {}
+        tcp_domain_map: dict = {}
         
         for domain in http_domains:
             port = domain.container_port
@@ -398,7 +404,8 @@ class McpComponentDetailView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def get(self, request, team_alias, app_id, component_id):
+    def get(self, request: Request, team_alias: str, app_id: int, component_id: str,
+            *args: Any, **kwargs: Any) -> Response:
         """获取组件详情"""
         try:
             # 获取团队和组件信息
@@ -465,7 +472,8 @@ class McpComponentLogsView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def get(self, request, team_alias, app_id, component_id):
+    def get(self, request: Request, team_alias: str, app_id: int, component_id: str,
+            *args: Any, **kwargs: Any) -> Response:
         """获取组件日志"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
@@ -489,7 +497,7 @@ class McpComponentLogsView(BaseOpenAPIView):
                 service_alias=component.service_alias,
                 pod_name=pod_name,
                 container_name=container_name,
-                follow=follow
+                follow=follow  # type: ignore[arg-type]
             )
             
             return Response(log_stream, status=http_status.HTTP_200_OK)
@@ -514,7 +522,8 @@ class McpComponentPortsView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def get(self, request, team_alias, app_id, component_id):
+    def get(self, request: Request, team_alias: str, app_id: int, component_id: str,
+            *args: Any, **kwargs: Any) -> Response:
         """获取组件端口列表"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
@@ -543,7 +552,8 @@ class McpComponentPortsView(BaseOpenAPIView):
         },
         tags=['组件管理']
     )
-    def post(self, request, team_alias, app_id, component_id):
+    def post(self, request: Request, team_alias: str, app_id: int, component_id: str,
+             *args: Any, **kwargs: Any) -> Response:
         """添加组件端口"""
         try:
             team = team_services.get_team_by_team_alias(team_alias)
@@ -575,7 +585,7 @@ class McpComponentPortsView(BaseOpenAPIView):
                 component,
                 port,
                 protocol,
-                port_alias=None,
+                port_alias=None,  # type: ignore[arg-type]
                 is_inner_service=True,
                 is_outer_service=False  # 先创建端口，然后再开启对外服务
             )
@@ -589,7 +599,7 @@ class McpComponentPortsView(BaseOpenAPIView):
                 from console.repositories.group import group_repo
                 
                 region = region_repo.get_region_by_region_name(component.service_region)
-                app = group_repo.get_app_by_pk(app_id)
+                app = group_repo.get_app_by_pk(app_id)  # type: ignore[arg-type]
                 
                 # 获取刚添加的端口对象
                 deal_port = port_service.get_service_port_by_port(component, port)
@@ -607,8 +617,8 @@ class McpComponentPortsView(BaseOpenAPIView):
             if not new_port:
                 return Response(general_message(500, "get port failed", "获取端口信息失败"), status=http_status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-            serializer = PortBaseSerializer(new_port)
-            result = general_message(200, "success", "端口添加成功", bean=serializer.data)
+            port_serializer = PortBaseSerializer(new_port)
+            result = general_message(200, "success", "端口添加成功", bean=port_serializer.data)
             return Response(result, status=http_status.HTTP_200_OK)
         except region_api.CallApiError as e:
             return Response(general_message(500, "region error", "集群接口调用失败"), status=http_status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/openapi/models/main.py
+++ b/openapi/models/main.py
@@ -10,7 +10,7 @@ class BaseModel(models.Model):
 
     ID = models.AutoField(primary_key=True, max_length=10)
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         opts = self._meta
         data = {}
         for f in opts.concrete_fields:

--- a/openapi/serializer/app_serializer.py
+++ b/openapi/serializer/app_serializer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import re
+from typing import Any
 
 from openapi.serializer.utils import DateCharField
 from rest_framework import serializers, validators
@@ -103,7 +104,7 @@ class MarketInstallSerializer(serializers.Serializer):
     region_name = serializers.CharField(max_length=64, help_text="数据中心名")
     service_list = ServiceBaseInfoSerializer(many=True)
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
 
@@ -124,7 +125,8 @@ class ListUpgradeSerializer(serializers.Serializer):
     enterprise_id = serializers.CharField(max_length=64, help_text="企业id")
     can_upgrade = serializers.BooleanField(help_text="可升级")
     upgrade_versions = serializers.ListField(help_text="可升级的版本列表")
-    source = serializers.CharField(max_length=32, help_text="应用模型来源")
+    # NOTE: field name shadows Field base attr "source"; legacy field declaration.
+    source = serializers.CharField(max_length=32, help_text="应用模型来源")  # type: ignore[assignment]
 
 
 class UpgradeBaseSerializer(serializers.Serializer):
@@ -167,27 +169,28 @@ class ListServiceEventsResponse(serializers.Serializer):
     events = AppServiceEventsSerializer(many=True)
 
 
-def new_memory_validator(value):
+def new_memory_validator(value: Any) -> None:
     if not isinstance(value, int):
         raise serializers.ValidationError('请输入int类型数据')
     if value % 64 == 1:
         raise serializers.ValidationError('参数不正确，请输入64的倍数')
     if value > 65536 or value < 64:
-        raise serializers.ValidationError('参数超出范围，请选择64~65536之间的整数值', value)
+        # NOTE: ValidationError 2nd positional arg expects str|None; value is int (legacy).
+        raise serializers.ValidationError('参数超出范围，请选择64~65536之间的整数值', value)  # type: ignore[arg-type]
 
 
-def new_cpu_validator(value):
+def new_cpu_validator(value: Any) -> None:
     if not isinstance(value, int):
         raise serializers.ValidationError('请输入int类型数据')
     if value < 0:
         raise serializers.ValidationError('请输入正整数数据')
 
 
-def new_node_validator(value):
+def new_node_validator(value: Any) -> None:
     if not isinstance(value, int):
         raise serializers.ValidationError('请输入int类型数据')
     if value > 100 or value < 1:
-        raise serializers.ValidationError('参数超出范围，请选择1~100之间的整数值', value)
+        raise serializers.ValidationError('参数超出范围，请选择1~100之间的整数值', value)  # type: ignore[arg-type]
 
 
 class AppServiceTelescopicVerticalSerializer(serializers.Serializer):
@@ -215,7 +218,7 @@ class TeamAppsCloseSerializers(serializers.Serializer):
 class MonitorDataSerializers(serializers.Serializer):
     value = serializers.ListField()
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
 
@@ -223,12 +226,13 @@ class ComponentMonitorBaseSerializers(serializers.Serializer):
     resultType = serializers.CharField(max_length=64, required=False, help_text="返回类型")
     result = MonitorDataSerializers(many=True)
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
 
 class ComponentMonitorItemsSerializers(serializers.Serializer):
-    data = ComponentMonitorBaseSerializers(required=False)
+    # NOTE: field name "data" shadows Serializer.data property; legacy field declaration.
+    data = ComponentMonitorBaseSerializers(required=False)  # type: ignore[assignment]
     monitor_item = serializers.CharField(max_length=32, help_text="监控项")
     status = serializers.CharField(max_length=32, required=False, help_text="监控状态")
 
@@ -240,9 +244,11 @@ class ComponentMonitorSerializers(serializers.Serializer):
     service_alias = serializers.CharField(max_length=64, help_text="组件昵称")
 
 
-def name_validator(value):
+def name_validator(value: Any) -> None:
     if not NAME_LETTER.search(value) or not FIRST_LETTER.search(value):
-        raise validators.ValidationError(code=400, detail="变量名不合法， 请输入以字母开头且为数字、大小写字母、'_'、'-'的组合")
+        # NOTE: validators module has no ValidationError (latent bug; should be serializers.); backlog.
+        raise validators.ValidationError(  # type: ignore[attr-defined]
+            code=400, detail="变量名不合法， 请输入以字母开头且为数字、大小写字母、'_'、'-'的组合")
 
 
 class ComponentEnvsBaseSerializers(serializers.Serializer):
@@ -336,7 +342,7 @@ class HelmChartSerializer(serializers.Serializer):
     overrides = serializers.CharField(max_length=512, required=False, help_text="配置参数")
 
 
-def gray_ratio_validator(value):
+def gray_ratio_validator(value: Any) -> None:
     if not isinstance(value, int):
         raise serializers.ValidationError('灰度比例必须为整数')
     if value < 0 or value > 100:

--- a/openapi/serializer/appstore_serializer.py
+++ b/openapi/serializer/appstore_serializer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: abe
+from typing import Any
+
 from rest_framework import serializers
 
 from openapi.serializer.utils import urlregex
@@ -21,7 +23,7 @@ class ListAppStoreInfosRespSerializer(serializers.Serializer):
 class UpdAppStoreInfoReqSerializer(serializers.Serializer):
     access_url = serializers.CharField(help_text="应用市场API地址")
 
-    def validate_access_url(self, access_url):
+    def validate_access_url(self, access_url: Any) -> Any:
         if not urlregex.match(access_url):
             raise serializers.ValidationError("应用市场API地址非法")
         return access_url

--- a/openapi/serializer/config_serializers.py
+++ b/openapi/serializer/config_serializers.py
@@ -8,7 +8,8 @@ class ConfigBaseSerializer(serializers.Serializer):
 
 
 class MonitorQueryOverviewSeralizer(serializers.Serializer):
-    data = serializers.DictField(help_text="查询数据")
+    # NOTE: field named "data" shadows Serializer.data property; legacy field.
+    data = serializers.DictField(help_text="查询数据")  # type: ignore[assignment]
     status = serializers.CharField(help_text="查询状态", max_length=64)
 
 class AppRankOverviewSeralizer(serializers.Serializer):

--- a/openapi/serializer/gateway_serializer.py
+++ b/openapi/serializer/gateway_serializer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import json
+from typing import Any
 
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
@@ -15,7 +16,7 @@ class HTTPGatewayRuleSerializer(serializers.ModelSerializer):
         exclude = ["create_time"]
 
     @swagger_serializer_method(serializer_or_field=serializers.ListField)
-    def get_rule_extensions(self, instance):
+    def get_rule_extensions(self, instance: Any) -> Any:
         try:
             return json.loads(instance.rule_extensions)
         except Exception:

--- a/openapi/serializer/groupapp_serializer.py
+++ b/openapi/serializer/groupapp_serializer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # create by: panda-zxs
+from typing import Any
 
 from openapi.serializer.app_serializer import ServiceBaseInfoSerializer
 from openapi.serializer.utils import DateCharField
@@ -47,14 +48,14 @@ class AppCopyLSerializer(serializers.Serializer):
     app_name = serializers.CharField(max_length=64, allow_null=True, help_text="应用名称")
     min_memory = serializers.CharField(max_length=32, allow_null=True, help_text="组件运行内存")
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
-    def get_build_source(self, instance):
+    def get_build_source(self, instance: Any) -> Any:
         build_source = instance.get("build_source")
         service_source = build_source.get("service_source")
         if service_source == "docker_image":
-            serializer = CompomentDockerImageBuildSourceSerializer(data=build_source)
+            serializer: CompomentBuildSourceSerializer = CompomentDockerImageBuildSourceSerializer(data=build_source)
             serializer.is_valid(raise_exception=True)
         elif service_source == "market":
             serializer = CompomentMarketBuildSourceSerializer(data=build_source)
@@ -76,7 +77,7 @@ class AppModifyInfoSerializer(serializers.Serializer):
     build_source = serializers.SerializerMethodField()
     envs = serializers.DictField(default=dict())
 
-    def get_build_source(self, instance):
+    def get_build_source(self, instance: Any) -> Any:
         default_build_source = {"version": None}
         build_source = instance.get("build_source")
         if not build_source:
@@ -86,7 +87,7 @@ class AppModifyInfoSerializer(serializers.Serializer):
             serializer.is_valid(raise_exception=True)
             return serializer.data
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
 
@@ -94,7 +95,7 @@ class AppCopyModifySerializer(serializers.Serializer):
     service_id = serializers.CharField(max_length=32, help_text="id")
     change = serializers.SerializerMethodField()
 
-    def get_change(self, instance):
+    def get_change(self, instance: Any) -> Any:
         default_change = {"build_source": {"version": None}, "envs": {}}
         change = instance.get("change")
         if not change:
@@ -111,12 +112,12 @@ class AppCopyCSerializer(serializers.Serializer):
     target_region_name = serializers.CharField(max_length=32, help_text="数据中心名称")
     target_app_id = serializers.IntegerField(help_text="应用id")
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data
 
 
 class AppCopyCResSerializer(serializers.Serializer):
     services = ServiceBaseInfoSerializer(many=True)
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         return data

--- a/openapi/serializer/region_serializer.py
+++ b/openapi/serializer/region_serializer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
+from typing import Any
+
 from rest_framework import serializers
 
 from console.enum.region_enum import RegionStatusEnum
@@ -9,27 +11,27 @@ from openapi.serializer.utils import urlregex
 
 
 class RegionReqValidate(object):
-    def validate_url(self, url):
+    def validate_url(self, url: Any) -> Any:
         if not urlregex.match(url):
             raise serializers.ValidationError("集群API地址非法")
         return url
 
-    def validate_wsurl(self, wsurl):
+    def validate_wsurl(self, wsurl: Any) -> Any:
         if not urlregex.match(wsurl):
             raise serializers.ValidationError("集群Websocket地址非法")
         return wsurl
 
-    def validate_tcpdomain(self, tcpdomain):
+    def validate_tcpdomain(self, tcpdomain: Any) -> Any:
         if not ipregex.match(tcpdomain):
             raise serializers.ValidationError("TCP访问地址非法")
         return tcpdomain
 
-    def validate_status(self, status):
+    def validate_status(self, status: Any) -> Any:
         if status not in ['0', '1', '2', '3']:
             raise serializers.ValidationError("集群状态值不正确")
         return status
 
-    def validate_scope(self, scope):
+    def validate_scope(self, scope: Any) -> Any:
         if scope not in ["private", "public"]:
             raise serializers.ValidationError("集群开放类型不正确")
         return scope
@@ -105,7 +107,7 @@ class ListRegionsRespSerializer(serializers.Serializer):
 class UpdateRegionStatusReqSerializer(serializers.Serializer):
     status = serializers.CharField(help_text="需要设置的集群状态, 可选值为: 'ONLINE', 'OFFLINE', 'MAINTAIN'(大小写不敏感)")
 
-    def validate_status(self, status):
+    def validate_status(self, status: Any) -> Any:
         status = status.upper()
         names = RegionStatusEnum.names()
         if status not in names:

--- a/openapi/serializer/team_serializer.py
+++ b/openapi/serializer/team_serializer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
+from typing import Any
+
 from openapi.serializer.role_serializer import RoleInfoSerializer
 from openapi.serializer.utils import DateCharField
 from rest_framework import serializers
@@ -66,7 +68,7 @@ class RoleInfoRespSerializer(serializers.Serializer):
 class CreateTeamUserReqSerializer(serializers.Serializer):
     role_ids = serializers.CharField(max_length=255, help_text="角色ID列表")
 
-    def validate_role_ids(self, role_ids):
+    def validate_role_ids(self, role_ids: Any) -> Any:
         role_ids = role_ids.replace(" ", "")
         for role_id in role_ids.split(","):
             try:

--- a/openapi/serializer/utils.py
+++ b/openapi/serializer/utils.py
@@ -3,6 +3,7 @@
 import re
 import six
 import datetime
+from typing import Any
 from zoneinfo import ZoneInfo
 from django.conf import settings
 from rest_framework.fields import CharField
@@ -18,7 +19,7 @@ urlregex = re.compile(
 ipregex = re.compile(r'((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}', re.IGNORECASE)
 
 
-def pagination(data, total, page=1, page_size=10):
+def pagination(data: Any, total: int, page: int = 1, page_size: int = 10) -> dict:
     return {"list": data, "total": total, "page": page, "page_size": page_size}
 
 
@@ -27,7 +28,7 @@ utc_tz = ZoneInfo('UTC')
 
 
 class DateCharField(CharField):
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Any:
         if isinstance(data, bool) or not isinstance(data, six.string_types + six.integer_types + (float, datetime.datetime)):
             self.fail('invalid')
         if isinstance(data, datetime.datetime):

--- a/openapi/services/ai_engine_proxy_service.py
+++ b/openapi/services/ai_engine_proxy_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import time
+from typing import Any, List, Optional
 
 from console.exception.main import ServiceHandleException
 
@@ -15,11 +16,11 @@ class AIEngineProxyService(object):
         ("POST", "v1/embeddings"),
     }
 
-    def __init__(self, cache_ttl_seconds=30):
+    def __init__(self, cache_ttl_seconds: int = 30) -> None:
         self.cache_ttl_seconds = cache_ttl_seconds
-        self._region_cache = {}
+        self._region_cache: dict = {}
 
-    def extract_bearer_token(self, authorization):
+    def extract_bearer_token(self, authorization: Any) -> str:
         authorization = str(authorization or "").strip()
         if not authorization:
             raise ServiceHandleException("missing Authorization header", status_code=401)
@@ -29,7 +30,7 @@ class AIEngineProxyService(object):
             raise ServiceHandleException("invalid Authorization format, expected Bearer <api-key>", status_code=401)
         return parts[1].strip()
 
-    def validate_proxy_target(self, method, proxy_path):
+    def validate_proxy_target(self, method: Any, proxy_path: Any) -> str:
         normalized_path = str(proxy_path or "").strip().strip("/")
         normalized_method = str(method or "").upper()
         if (normalized_method, normalized_path) not in self.ALLOWED_TARGETS:
@@ -38,7 +39,7 @@ class AIEngineProxyService(object):
                 status_code=405)
         return normalized_path
 
-    def resolve_unique_region(self, team_name):
+    def resolve_unique_region(self, team_name: str) -> Any:
         normalized_team = str(team_name or "").strip()
         if not normalized_team:
             raise ServiceHandleException("team not found", status_code=404)
@@ -55,8 +56,8 @@ class AIEngineProxyService(object):
         if not candidate_regions:
             raise ServiceHandleException("team {} has no active regions".format(normalized_team), status_code=404)
 
-        matched_regions = []
-        lookup_failures = []
+        matched_regions: list = []
+        lookup_failures: list = []
         for region_name in candidate_regions:
             try:
                 if self._region_has_ai_engine(team.enterprise_id, region_name):
@@ -86,20 +87,20 @@ class AIEngineProxyService(object):
 
         raise ServiceHandleException("team {} has no available ai-engine cluster".format(normalized_team), status_code=404)
 
-    def build_region_proxy_path(self, proxy_path, query_string=""):
+    def build_region_proxy_path(self, proxy_path: Any, query_string: str = "") -> str:
         normalized_path = str(proxy_path or "").strip().lstrip("/")
         path = "/v2/platform/backend/plugins/rainbond-ai-engine/{}".format(normalized_path)
         if query_string:
             return "{}?{}".format(path, query_string)
         return path
 
-    def proxy_request(self, request, region_name, proxy_path, query_string=""):
+    def proxy_request(self, request: Any, region_name: str, proxy_path: Any, query_string: str = "") -> Any:
         from www.apiclient.regionapi import RegionInvokeApi
 
         region_api = RegionInvokeApi()
         return region_api.proxy(request, self.build_region_proxy_path(proxy_path, query_string), region_name)
 
-    def _get_cached_region(self, team_name):
+    def _get_cached_region(self, team_name: str) -> Optional[str]:
         cache_item = self._region_cache.get(team_name)
         if not cache_item:
             return None
@@ -108,29 +109,32 @@ class AIEngineProxyService(object):
             return None
         return cache_item["region_name"]
 
-    def _cache_region(self, team_name, region_name):
+    def _cache_region(self, team_name: str, region_name: str) -> None:
         self._region_cache[team_name] = {
             "region_name": region_name,
             "expires_at": time.time() + self.cache_ttl_seconds,
         }
 
-    def _get_team(self, team_name):
+    def _get_team(self, team_name: str) -> Any:
         from console.repositories.team_repo import team_repo
 
         return team_repo.get_team_by_team_name(team_name)
 
-    def _get_candidate_regions(self, team):
+    def _get_candidate_regions(self, team: Any) -> List[Any]:
         from www.models.main import TenantRegionInfo
 
-        region_infos = TenantRegionInfo.objects.filter(tenant_id=team.tenant_id, is_active=1, is_init=1)
+        # NOTE: legacy int (1/0) used for BooleanField lookups; stubs expect bool.
+        region_infos = TenantRegionInfo.objects.filter(
+            tenant_id=team.tenant_id, is_active=1, is_init=1)  # type: ignore[misc]
         return [item.region_name for item in region_infos]
 
-    def _region_has_ai_engine(self, enterprise_id, region_name):
+    def _region_has_ai_engine(self, enterprise_id: str, region_name: str) -> bool:
         from www.apiclient.regionapi import RegionInvokeApi
 
         region_api = RegionInvokeApi()
         _, body = region_api.list_plugins(enterprise_id, region_name, False)
-        plugins = body.get("list") or []
+        # NOTE: region api body may be None per stubs; backlog null-safety.
+        plugins = body.get("list") or []  # type: ignore[union-attr]
         for plugin in plugins:
             if isinstance(plugin, dict) and plugin.get("name") == "rainbond-ai-engine":
                 return True

--- a/openapi/services/api_user_service.py
+++ b/openapi/services/api_user_service.py
@@ -1,35 +1,37 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 
+from typing import Any, Optional
 from console.services.user_services import user_services
 from www.models.main import Users
 
 
 class ErrorUser(Exception):
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         self.message = message
 
 
 class APIUserService(object):
-    def get_token(self, user):
+    def get_token(self, user: Any) -> Any:
         if not isinstance(user, Users):
             raise ErrorUser("user is not rainbond user")
         return user_services.get_administrator_user_token(user)
 
-    def get_user_by_token(self, token):
+    def get_user_by_token(self, token: str) -> Any:
         return user_services.get_user_by_openapi_token(token)
 
-    def login_api_user(self, username, password):
+    def login_api_user(self, username: str, password: str) -> Optional[Any]:
         user = user_services.get_user_by_username(username)
         if not user:
             return None
         if not user.check_password(password):
             return None
-        if user_services.is_user_admin_in_current_enterprise(user, user.enterprise_id):
+        # NOTE: enterprise_id typed str|None by stubs; runtime always str.
+        if user_services.is_user_admin_in_current_enterprise(user, user.enterprise_id):  # type: ignore[arg-type]
             return self.get_token(user)
         return None
 
-    def get_permissions_by_user(self, user, enterprise_id):
+    def get_permissions_by_user(self, user: Any, enterprise_id: str) -> list:
         if not isinstance(user, Users):
             raise ErrorUser("user is not rainbond user")
         # TODO:impl rbac

--- a/openapi/services/app_service.py
+++ b/openapi/services/app_service.py
@@ -2,6 +2,7 @@
 # creater by: barnett
 import copy
 import logging
+from typing import Any, Optional
 
 from django.forms.models import model_to_dict
 
@@ -16,12 +17,14 @@ logger = logging.getLogger("default")
 
 
 class AppService(object):
-    def get_app_services_and_status(self, app):
+    def get_app_services_and_status(self, app: Any) -> list:
         services = group_service.get_group_services(app.ID)
         service_ids = [service.service_id for service in services]
         team = team_services.get_team_by_team_id(app.tenant_id)
+        # NOTE: enterprise_id typed str|None by stubs; runtime always str.
         status_list = base_service.status_multi_service(
-            region=app.region_name, tenant_name=team.tenant_name, service_ids=service_ids, enterprise_id=team.enterprise_id)
+            region=app.region_name, tenant_name=team.tenant_name, service_ids=service_ids,
+            enterprise_id=team.enterprise_id)  # type: ignore[arg-type]
         status_map = {}
         if status_list:
             for status in status_list:
@@ -33,7 +36,7 @@ class AppService(object):
             re_services.append(s)
         return re_services
 
-    def get_group_services_by_id(self, app_id):
+    def get_group_services_by_id(self, app_id: str) -> list:
         services = group_service_relation_repo.get_services_by_group(app_id)
         if not services:
             return []
@@ -45,10 +48,10 @@ class AppService(object):
                 service_ids.remove(service_id)
         return service_ids
 
-    def get_services_by_group_id(self, group_id):
+    def get_services_by_group_id(self, group_id: str) -> Any:
         return group_service_relation_repo.get_services_by_group(group_id)
 
-    def get_service_by_service_key_and_group_id(self, service_key, group_id):
+    def get_service_by_service_key_and_group_id(self, service_key: str, group_id: str) -> Any:
         rst = None
         services = group_service_relation_repo.get_services_by_group(group_id)
         if not services:
@@ -63,7 +66,7 @@ class AppService(object):
             break
         return rst
 
-    def get_tenant_by_group_id(self, group_id):
+    def get_tenant_by_group_id(self, group_id: str) -> Optional[Any]:
         service_group = group_repo.get_group_by_id(group_id)
         if not service_group:
             return None
@@ -73,20 +76,20 @@ class AppService(object):
         except Exception:
             return None
 
-    def get_app_service_count(self, group_id):
+    def get_app_service_count(self, group_id: str) -> int:
         services = group_service_relation_repo.get_services_by_group(group_id)
         if not services:
             return 0
         return len(services)
 
-    def get_app_running_service_count(self, tenant, services):
+    def get_app_running_service_count(self, tenant: Any, services: list) -> int:
         count = 0
         for service in services:
             if service["status"] == "running":
                 count += 1
         return count
 
-    def get_app_memory_and_cpu_used(self, services):
+    def get_app_memory_and_cpu_used(self, services: list) -> tuple:
         memory = 0
         cpu = 0
         for service in services:

--- a/openapi/services/component_action.py
+++ b/openapi/services/component_action.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
+from typing import Any
+
 from console.constants import AppConstants
 from console.exception.main import ServiceHandleException
 from console.repositories.app import service_source_repo
@@ -8,10 +10,13 @@ from www.models.main import Tenants, TenantServiceInfo, Users
 
 
 class ComponnetActionService(object):
-    def component_build(self, tenant: Tenants, component: TenantServiceInfo, user: Users, build_info):
+    def component_build(self, tenant: Tenants, component: TenantServiceInfo, user: Users, build_info: dict) -> Any:
         if component.create_status != "complete":
             raise ServiceHandleException(
-                msg="component create status is " + component.create_status, msg_show="组件未完成创建，禁止构建", status_code=400)
+                # NOTE: create_status is str|None per model; legacy concat, behavior unchanged.
+                msg="component create status is " + component.create_status,  # type: ignore[operator]
+                msg_show="组件未完成创建，禁止构建",
+                status_code=400)
         # if build_info.server_type:
         # change component server type
 
@@ -24,7 +29,7 @@ class ComponnetActionService(object):
             if component.service_source == AppConstants.DOCKER_RUN \
                     or component.service_source == AppConstants.DOCKER_COMPOSE \
                     or component.service_source == AppConstants.DOCKER_IMAGE:
-                component.image = build_info.get("repo_url")
+                component.image = build_info.get("repo_url")  # type: ignore[assignment]
             service_source = service_source_repo.get_service_source(component.tenant_id, component.service_id)
             if service_source:
                 service_source.user_name = build_info.get("username")

--- a/openapi/v2/auth/authentication.py
+++ b/openapi/v2/auth/authentication.py
@@ -2,10 +2,12 @@
 # creater by: barnett
 
 import logging
+from typing import Any
 from www.models.main import Users
 from openapi.services.api_user_service import apiUserService
 from rest_framework import authentication
 from rest_framework import exceptions
+from rest_framework.request import Request
 import os
 
 logger = logging.getLogger("default")
@@ -13,7 +15,7 @@ logger = logging.getLogger("default")
 
 class OpenAPIAuthentication(authentication.TokenAuthentication):
     # TODO only use user open api
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> Any:
         token = request.META.get('HTTP_AUTHORIZATION')
         if not token:
             raise exceptions.AuthenticationFailed('No token')
@@ -28,7 +30,7 @@ class OpenAPIAuthentication(authentication.TokenAuthentication):
 
 
 class OpenAPIManageAuthentication(authentication.TokenAuthentication):
-    def authenticate(self, request):
+    def authenticate(self, request: Request) -> Any:
         token = request.META.get('HTTP_AUTHORIZATION')
         if not token:
             raise exceptions.AuthenticationFailed('No token')
@@ -36,5 +38,6 @@ class OpenAPIManageAuthentication(authentication.TokenAuthentication):
         if not manage_token or manage_token != token:
             raise exceptions.AuthenticationFailed('token is invalid')
         user = Users(nick_name="ManageOpenAPI")
-        user.is_administrator = True
+        # NOTE: legacy dynamic attribute assignment not declared on Users model.
+        user.is_administrator = True  # type: ignore[attr-defined]
         return (user, None)

--- a/openapi/v2/auth/permissions.py
+++ b/openapi/v2/auth/permissions.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any, List
 from www.models.main import AnonymousUser
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
 
 logger = logging.getLogger("default")
 
 
 class OpenAPIPermissions(BasePermission):
-    def has_perms(self, user, perms):
+    def has_perms(self, user: Any, perms: List[str]) -> bool:
         if isinstance(user, AnonymousUser):
             return False
         return True
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: Any) -> bool:
         '''
         check permission
         '''

--- a/openapi/v2/auth/views.py
+++ b/openapi/v2/auth/views.py
@@ -3,6 +3,7 @@
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -32,7 +33,7 @@ class TokenInfoView(APIView):
         ),
         tags=['openapi-auth'],
         operation_description="企业管理员账号密码获取API-Token")
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         username = request.data.get("username", None)
         password = request.data.get("password", None)
         if not username or not password:

--- a/openapi/v2/models/main.py
+++ b/openapi/v2/models/main.py
@@ -10,9 +10,9 @@ class BaseModel(models.Model):
 
     ID = models.AutoField(primary_key=True, max_length=10)
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         opts = self._meta
-        data = {}
+        data: dict = {}
         for f in opts.concrete_fields:
             value = f.value_from_object(self)
             if isinstance(value, datetime):

--- a/openapi/v2/serializer/ent_serializers.py
+++ b/openapi/v2/serializer/ent_serializers.py
@@ -16,7 +16,8 @@ class EnterpriseListInfoSerializer(serializers.Serializer):
 
 class ListEntsRespSerializer(serializers.Serializer):
     total = serializers.IntegerField(help_text="总数")
-    data = EnterpriseListInfoSerializer(many=True)
+    # NOTE: `data` shadows Serializer.data property; legacy field name, behavior unchanged.
+    data = EnterpriseListInfoSerializer(many=True)  # type: ignore[assignment]
 
 
 class UpdEntReqSerializer(serializers.Serializer):

--- a/openapi/v2/serializer/region_serializer.py
+++ b/openapi/v2/serializer/region_serializer.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
+from typing import Any
+
 from rest_framework import serializers
 
 from console.enum.region_enum import RegionStatusEnum
@@ -8,27 +10,27 @@ from openapi.serializer.utils import ipregex, urlregex
 
 
 class RegionReqValidate(object):
-    def validate_url(self, url):
+    def validate_url(self, url: Any) -> Any:
         if not urlregex.match(url):
             raise serializers.ValidationError("集群API地址非法")
         return url
 
-    def validate_wsurl(self, wsurl):
+    def validate_wsurl(self, wsurl: Any) -> Any:
         if not urlregex.match(wsurl):
             raise serializers.ValidationError("集群Websocket地址非法")
         return wsurl
 
-    def validate_tcpdomain(self, tcpdomain):
+    def validate_tcpdomain(self, tcpdomain: Any) -> Any:
         if not ipregex.match(tcpdomain):
             raise serializers.ValidationError("TCP访问地址非法")
         return tcpdomain
 
-    def validate_status(self, status):
+    def validate_status(self, status: Any) -> Any:
         if status not in ['0', '1', '2', '3']:
             raise serializers.ValidationError("集群状态值不正确")
         return status
 
-    def validate_scope(self, scope):
+    def validate_scope(self, scope: Any) -> Any:
         if scope not in ["private", "public"]:
             raise serializers.ValidationError("集群开放类型不正确")
         return scope
@@ -84,13 +86,14 @@ class RegionInfoAndStatusRespSerializer(serializers.Serializer):
 
 class ListRegionsRespSerializer(serializers.Serializer):
     total = serializers.IntegerField(help_text="总数")
-    data = RegionInfoAndStatusRespSerializer(many=True)
+    # NOTE: `data` shadows Serializer.data property; legacy field name, behavior unchanged.
+    data = RegionInfoAndStatusRespSerializer(many=True)  # type: ignore[assignment]
 
 
 class UpdateRegionStatusReqSerializer(serializers.Serializer):
     status = serializers.CharField(help_text="需要设置的集群状态, 可选值为: 'ONLINE', 'OFFLINE', 'MAINTAIN'(大小写不敏感)")
 
-    def validate_status(self, status):
+    def validate_status(self, status: Any) -> Any:
         status = status.upper()
         names = RegionStatusEnum.names()
         if status not in names:

--- a/openapi/v2/serializer/utils.py
+++ b/openapi/v2/serializer/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import re
+from typing import Any
 
 urlregex = re.compile(
     r'^(?:http|ftp|ws)s?://'  # http:// or https://
@@ -13,5 +14,5 @@ urlregex = re.compile(
 ipregex = re.compile(r'((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}', re.IGNORECASE)
 
 
-def pagination(data, total, page=1, page_size=10):
+def pagination(data: Any, total: int, page: int = 1, page_size: int = 10) -> dict:
     return {"list": data, "total": total, "page": page, "page_size": page_size}

--- a/openapi/v2/views/base.py
+++ b/openapi/v2/views/base.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
+from typing import Any
+
+from rest_framework.request import Request
 from rest_framework.views import APIView
 from openapi.v2.auth.authentication import OpenAPIManageAuthentication
 from openapi.v2.auth.permissions import OpenAPIPermissions
@@ -10,10 +13,10 @@ class BaseOpenAPIView(APIView):
     authentication_classes = [OpenAPIManageAuthentication]
     permission_classes = [OpenAPIPermissions]
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(BaseOpenAPIView, self).__init__()
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(BaseOpenAPIView, self).initial(request, *args, **kwargs)
 
 

--- a/openapi/v2/views/enterprise_view.py
+++ b/openapi/v2/views/enterprise_view.py
@@ -5,9 +5,11 @@ import json
 import time
 
 from django.db import connection
+from typing import Any
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.main import ServiceHandleException
@@ -38,7 +40,7 @@ class ListEnterpriseInfoView(ListAPIView):
         responses={status.HTTP_200_OK: ListEntsRespSerializer()},
         tags=['openapi-entreprise'],
     )
-    def get(self, req):
+    def get(self, req: Request) -> Response:
         try:
             page = int(req.GET.get("current", 1))
         except ValueError:
@@ -60,7 +62,7 @@ class EnterpriseInfoView(BaseOpenAPIView):
         responses={},
         tags=['openapi-entreprise'],
     )
-    def put(self, req, eid):
+    def put(self, req: Request, eid: str) -> Response:
         enterprise_services.update(eid, req.data)
         return Response(None, status=status.HTTP_200_OK)
 
@@ -69,7 +71,7 @@ class EnterpriseInfoView(BaseOpenAPIView):
         responses={200: EnterpriseInfoSerializer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, eid):
+    def get(self, req: Request, eid: str) -> Response:
         ent = enterprise_services.get_enterprise_by_id(eid)
         if ent is None:
             return Response({"msg": "企业不存在"}, status=status.HTTP_404_NOT_FOUND)
@@ -84,9 +86,10 @@ class EnterpriseSourceView(ListAPIView):
         responses={200: EnterpriseSourceSerializer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, eid):
+    def get(self, req: Request, eid: str) -> Response:
         data = {"enterprise_id": eid, "used_cpu": 0, "used_memory": 0, "used_disk": 0}
-        if not req.user.is_administrator:
+        # NOTE: request.user typed User|AnonymousUser by stubs; runtime is User.
+        if not req.user.is_administrator:  # type: ignore[union-attr]
             raise ServiceHandleException(status_code=401, error_code=401, msg="Permission denied")
         ent = enterprise_services.get_enterprise_by_id(eid)
         if ent is None:
@@ -95,11 +98,13 @@ class EnterpriseSourceView(ListAPIView):
         for region in regions:
             try:
                 # Exclude development clusters
-                if "development" in region.region_type:
+                # NOTE: region_type typed str|None by stubs; runtime always str.
+                if "development" in region.region_type:  # type: ignore[operator]
                     logger.debug("{0} region type is development in enterprise {1}".format(region.region_name, eid))
                     continue
                 res, body = region_api.get_region_resources(eid, region=region.region_name)
-                rst = body.get("bean")
+                # NOTE: regionapi return body typed dict|None by stubs; may be None (backlog).
+                rst = body.get("bean")  # type: ignore[union-attr]
                 if res.get("status") == 200 and rst:
                     data["used_cpu"] += rst.get("req_cpu", 0)
                     data["used_memory"] += rst.get("req_mem", 0)
@@ -113,7 +118,7 @@ class EnterpriseSourceView(ListAPIView):
 
 
 class EntUserInfoView(BaseOpenAPIView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page_num", 1))
         page_size = int(request.GET.get("page_size", 10))
         enterprise_id = request.GET.get("eid", None)
@@ -139,7 +144,8 @@ class EntUserInfoView(BaseOpenAPIView):
                 bean["phone"] = user.phone
                 bean["email"] = user.email
                 bean["create_time"] = time_to_str(user.create_time, "%Y-%m-%d %H:%M:%S")
-                bean["user_id"] = user.user_id
+                # NOTE: bean values inferred str|None; user_id is int (legacy).
+                bean["user_id"] = user.user_id  # type: ignore[assignment]
             admin_list.append(bean)
 
         result = {"list": admin_list, "total": admins_num}

--- a/openapi/v2/views/region_view.py
+++ b/openapi/v2/views/region_view.py
@@ -5,6 +5,7 @@ import logging
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.exceptions import RegionUnreachableError
@@ -31,7 +32,7 @@ class ListRegionInfo(ListAPIView):
         responses={200: ListRegionsRespSerializer()},
         tags=['openapi-region'],
         operation_description="获取全部数据中心列表")
-    def get(self, req):
+    def get(self, req: Request) -> Response:
         query = req.GET.get("query", "")
         try:
             page = int(req.GET.get("current", 1))
@@ -74,13 +75,14 @@ class ListRegionInfo(ListAPIView):
         },
         tags=['openapi-region'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             serializer = RegionInfoSerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
             region_data = serializer.data
             region_data["region_id"] = make_uuid()
-            region = region_services.add_region(region_data, request.user)
+            # NOTE: request.user typed as User|AnonymousUser per stubs.
+            region = region_services.add_region(region_data, request.user)  # type: ignore[arg-type]
             serializer = RegionInfoSerializer(region)
             if region:
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -100,7 +102,7 @@ class RegionInfo(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def get(self, request, region_id):
+    def get(self, request: Request, region_id: str) -> Response:
         try:
             queryset = region_services.get_region_by_region_id(region_id)
             serializer = RegionInfoSerializer(queryset)
@@ -118,7 +120,7 @@ class RegionInfo(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def put(self, request, region_id):
+    def put(self, request: Request, region_id: str) -> Response:
         serializer = UpdateRegionReqSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         region_data = serializer.data
@@ -142,7 +144,7 @@ class RegionInfo(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def delete(self, request, region_id):
+    def delete(self, request: Request, region_id: str) -> Response:
         try:
             region = region_services.del_by_region_id(region_id)
             serializer = RegionInfoSerializer(data=region)
@@ -164,17 +166,18 @@ class RegionStatusView(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def put(self, req, region_id):
+    def put(self, req: Request, region_id: str) -> Response:
         serializer = UpdateRegionStatusReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
         try:
             region = region_services.update_region_status(region_id, req.data["status"])
-            serializer = RegionInfoSerializer(region)
-            return Response(serializer.data, status.HTTP_200_OK)
+            resp_serializer = RegionInfoSerializer(region)
+            return Response(resp_serializer.data, status.HTTP_200_OK)
         except RegionConfig.DoesNotExist:
             fs = FailSerializer({"msg": "数据中心不存在"})
             return Response(fs.data, status.HTTP_404_NOT_FOUND)
         except RegionUnreachableError as e:
-            fs = FailSerializer({"msg": e.message})
+            # NOTE: py2-style Exception.message attribute, absent in py3.
+            fs = FailSerializer({"msg": e.message})  # type: ignore[attr-defined]
             return Response(fs.data, status.HTTP_400_BAD_REQUEST)

--- a/openapi/views/admin_view.py
+++ b/openapi/views/admin_view.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any
 
 from console.enum.enterprise_enum import EnterpriseRolesEnum
 from console.exception.exceptions import UserNotExistError
@@ -13,6 +14,7 @@ from openapi.serializer.base_serializer import FailSerializer
 from openapi.serializer.user_serializer import (CreateAdminUserReqSerializer, ListUsersRespView, UserInfoSerializer)
 from openapi.views.base import BaseOpenAPIView
 from rest_framework import exceptions, serializers, status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 logger = logging.getLogger("default")
@@ -29,7 +31,7 @@ class ListAdminsView(BaseOpenAPIView):
         responses={200: ListUsersRespView()},
         tags=['openapi-user'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             page = int(req.GET.get("page", 1))
         except ValueError:
@@ -54,7 +56,7 @@ class ListAdminsView(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def post(self, req, *args, **kwargs):
+    def post(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = CreateAdminUserReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
@@ -64,7 +66,10 @@ class ListAdminsView(BaseOpenAPIView):
             raise exceptions.NotFound("用户'{}'不存在".format(req.data["user_id"]))
         ent = enterprise_services.get_enterprise_by_enterprise_id(req.data["eid"])
         if ent is None:
-            raise serializers.ValidationError("企业'{}'不存在".format(req.data["eid"]), status.HTTP_404_NOT_FOUND)
+            # NOTE: legacy bug — ValidationError 2nd arg is `code` (str), not HTTP status;
+            # passing an int status here does not set the response status code.
+            raise serializers.ValidationError(
+                "企业'{}'不存在".format(req.data["eid"]), status.HTTP_404_NOT_FOUND)  # type: ignore[arg-type]
 
         user_services.create_admin_user(user, ent, [EnterpriseRolesEnum.admin.name])
 
@@ -80,13 +85,18 @@ class AdminInfoView(BaseOpenAPIView):
         },
         tags=['openapi-user'],
     )
-    def delete(self, req, user_id, *args, **kwargs):
-        if str(req.user.user_id) == user_id:
-            raise serializers.ValidationError({"msg": "不能删除自己"}, status.HTTP_400_BAD_REQUEST)
+    def delete(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: request.user typed as User|AnonymousUser per stubs; user_id present at runtime.
+        if str(req.user.user_id) == user_id:  # type: ignore[union-attr]
+            raise serializers.ValidationError(
+                {"msg": "不能删除自己"}, status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
         try:
             user_services.delete_admin_user(user_id)
             return Response(None, status.HTTP_200_OK)
         except ErrAdminUserDoesNotExist:
             raise exceptions.NotFound(detail="用户'{}'不是企业管理员".format(user_id))
         except ErrCannotDelLastAdminUser as e:
-            raise serializers.ValidationError({"msg": e.message}, status.HTTP_400_BAD_REQUEST)
+            # NOTE: py2-style Exception.message attribute, absent in py3.
+            raise serializers.ValidationError(
+                {"msg": e.message},  # type: ignore[attr-defined]
+                status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]

--- a/openapi/views/ai_engine_proxy.py
+++ b/openapi/views/ai_engine_proxy.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Any
 
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -11,7 +13,7 @@ from openapi.services.ai_engine_proxy_service import ai_engine_proxy_service
 logger = logging.getLogger("default")
 
 
-def build_openai_error_response(message, status_code):
+def build_openai_error_response(message: Any, status_code: int) -> Response:
     error_type = "authentication_error" if status_code == 401 else "invalid_request_error"
     return Response(
         {
@@ -28,13 +30,13 @@ class AIEnginePublicProxyView(APIView):
     authentication_classes = ()
     permission_classes = (AllowAny, )
 
-    def get(self, request, team_name, proxy_path="", *args, **kwargs):
+    def get(self, request: Request, team_name: str, proxy_path: str = "", *args: Any, **kwargs: Any) -> Response:
         return self._handle_proxy(request, team_name, proxy_path)
 
-    def post(self, request, team_name, proxy_path="", *args, **kwargs):
+    def post(self, request: Request, team_name: str, proxy_path: str = "", *args: Any, **kwargs: Any) -> Response:
         return self._handle_proxy(request, team_name, proxy_path)
 
-    def _handle_proxy(self, request, team_name, proxy_path):
+    def _handle_proxy(self, request: Request, team_name: str, proxy_path: str) -> Response:
         try:
             ai_engine_proxy_service.extract_bearer_token(request.META.get("HTTP_AUTHORIZATION"))
             normalized_path = ai_engine_proxy_service.validate_proxy_target(request.method, proxy_path)

--- a/openapi/views/announcement_view.py
+++ b/openapi/views/announcement_view.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.announcement_service import announcement_service
@@ -26,7 +28,7 @@ class ListAnnouncementView(BaseOpenAPIView):
         responses={200: ListAnnouncementRespSerializer()},
         tags=['openapi-announcement'],
     )
-    def get(self, req):
+    def get(self, req: Request) -> Response:
         try:
             page = int(req.GET.get("page", 1))
         except ValueError:
@@ -45,7 +47,7 @@ class ListAnnouncementView(BaseOpenAPIView):
         responses={},
         tags=['openapi-announcement'],
     )
-    def post(self, request, **kwargs):
+    def post(self, request: Request, **kwargs: Any) -> Response:
         announcement_service.create(request.data)
         return Response(None, status.HTTP_201_CREATED)
 
@@ -57,7 +59,7 @@ class AnnouncementView(BaseOpenAPIView):
         responses={},
         tags=['openapi-announcement'],
     )
-    def put(self, req, aid, *args, **kwargs):
+    def put(self, req: Request, aid: str, *args: Any, **kwargs: Any) -> Response:
         serializer = UpdateAncmReqSerilizer(data=req.data)
         serializer.is_valid(raise_exception=True)
         announcement_service.update(aid, req.data)
@@ -68,6 +70,6 @@ class AnnouncementView(BaseOpenAPIView):
         responses={},
         tags=['openapi-announcement'],
     )
-    def delete(self, request, aid, *args, **kwargs):
+    def delete(self, request: Request, aid: str, *args: Any, **kwargs: Any) -> Response:
         announcement_service.delete(aid)
         return Response(None, status.HTTP_200_OK)

--- a/openapi/views/apps/apps.py
+++ b/openapi/views/apps/apps.py
@@ -8,6 +8,7 @@ import pickle
 import re
 import time
 import uuid
+from typing import Any
 
 from django.db import transaction
 
@@ -61,6 +62,7 @@ from openapi.views.base import (EnterpriseServiceOauthView, TeamAPIView, TeamApp
                                 BaseOpenAPIView)
 from openapi.views.exceptions import ErrAppNotFound
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.crypt import make_uuid, make_uuid3
@@ -88,14 +90,14 @@ class AppsPortView(TeamAPIView):
         operation_description="团队端口列表",
         tags=['openapi-apps'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         ports = port_repo.get_tenant_services(self.team.tenant_id)
         component_list = service_repo.get_tenant_region_services(self.region_name, self.team.tenant_id)
         component_dict = {component.service_id: component.service_cname for component in component_list}
         port_list = list()
         if ports:
             for port in ports:
-                port_dict = dict()
+                port_dict: dict = dict()
                 if not port.is_inner_service:
                     continue
                 port_dict["port"] = port.container_port
@@ -117,7 +119,7 @@ class ListAppsView(TeamAPIView):
         responses={200: AppBaseInfoSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         query = req.GET.get("query", None)
         apps = group_service.get_apps_list(team_id=self.team.tenant_id, region_name=self.region_name, query=query)
         re = AppBaseInfoSerializer(apps, many=True)
@@ -129,7 +131,7 @@ class ListAppsView(TeamAPIView):
         responses={200: AppBaseInfoSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = AppPostInfoSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.data
@@ -138,7 +140,7 @@ class ListAppsView(TeamAPIView):
             self.team,
             self.region_name,
             data["app_name"],
-            data.get("app_note"),
+            data.get("app_note"),  # type: ignore[arg-type]
             self.user.get_username(),
             k8s_app=k8s_app if k8s_app else "app-" + make_uuid()[:6],
         )
@@ -155,7 +157,7 @@ class AppInfoView(TeamAppAPIView):
         responses={200: AppInfoSerializer()},
         tags=['openapi-apps'],
     )
-    def get(self, req, app_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
         if not app:
             raise ErrAppNotFound
@@ -189,7 +191,7 @@ class AppInfoView(TeamAppAPIView):
         responses={},
         tags=['openapi-apps'],
     )
-    def delete(self, req, app_id, *args, **kwargs):
+    def delete(self, req: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         msg_list = []
         try:
             force = int(req.GET.get("force", 0))
@@ -202,7 +204,7 @@ class AppInfoView(TeamAppAPIView):
                 region=self.app.region_name,
                 tenant_name=self.team.tenant_name,
                 service_ids=service_ids,
-                enterprise_id=self.team.enterprise_id)
+                enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]
             status_list = [x for x in [x["status"] for x in status_list] if x not in ["closed", "undeploy"]]
             if len(status_list) > 0:
                 raise ServiceHandleException(
@@ -211,7 +213,7 @@ class AppInfoView(TeamAppAPIView):
                 code_status = 200
                 for service in services:
                     code, msg = app_manage_service.batch_delete(self.user, self.team, service, is_force=True)
-                    msg_dict = dict()
+                    msg_dict: dict = dict()
                     msg_dict['status'] = code
                     msg_dict['msg'] = msg
                     msg_dict['service_id'] = service.service_id
@@ -242,7 +244,7 @@ class APPOperationsView(TeamAppAPIView):
         },
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         sos = ServiceGroupOperationsSerializer(data=request.data)
         sos.is_valid(raise_exception=True)
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
@@ -261,7 +263,8 @@ class APPOperationsView(TeamAppAPIView):
             self.has_perms([300007])
         if action == "deploy":
             self.has_perms([300008])
-        app_manage_service.batch_operations(self.team, self.region_name, request.user, action, service_ids, None)
+        app_manage_service.batch_operations(
+            self.team, self.region_name, request.user, action, service_ids, None)  # type: ignore[arg-type]
         result = {"msg": "操作成功"}
         rst_serializer = SuccessSerializer(data=result)
         rst_serializer.is_valid()
@@ -277,7 +280,7 @@ class ListAppServicesView(TeamAppAPIView):
         responses={200: ServiceBaseInfoSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, req, app_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         services = app_service.get_app_services_and_status(self.app)
         serializer = ServiceBaseInfoSerializer(data=services, many=True)
         serializer.is_valid()
@@ -290,7 +293,7 @@ class ListAppServicesView(TeamAppAPIView):
         ],
         tags=['openapi-apps'],
     )
-    def post(self, request, region_name, app_id, *args, **kwargs):
+    def post(self, request: Request, region_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         group_id = request.data.get("group_id", -1)
         service_cname = request.data.get("service_cname", None)
         image = request.data.get("image", "")
@@ -308,31 +311,37 @@ class ListAppServicesView(TeamAppAPIView):
             tenant = app_service.get_tenant_by_group_id(group_id)
 
             code, msg_show, new_service = console_app_service.create_docker_run_app(
-                region_name, tenant, self.user, service_cname, "", image_type, k8s_component_name, image)
+                region_name, tenant, self.user, service_cname, "",  # type: ignore[arg-type]
+                image_type, k8s_component_name, image)
             if code != 200:
                 return Response(general_message(code, "service create fail", msg_show), status=code)
 
             # 添加username,password信息
             if docker_password or docker_user_name:
-                console_app_service.create_service_source_info(tenant, new_service, docker_user_name, docker_password)
+                console_app_service.create_service_source_info(
+                    tenant, new_service, docker_user_name, docker_password)  # type: ignore[arg-type]
 
-            code, msg_show = group_service.add_service_to_group(tenant, region_name, group_id, new_service.service_id)
+            code, msg_show = group_service.add_service_to_group(
+                tenant, region_name, group_id, new_service.service_id)  # type: ignore[union-attr]
             if code != 200:
                 logger.debug("service.create", msg_show)
 
         except AccountOverdueException as re:
             logger.exception(re)
-            return Response(general_message(10410, "resource is not enough", re.message), status=412)
+            # NOTE: py2 Exception.message attribute; absent on py3 Exception (backlog).
+            return Response(
+                general_message(10410, "resource is not enough", re.message), status=412)  # type: ignore[attr-defined]
 
         # 创建成功后是否构建
         is_deploy = request.data.get("is_deploy", True)
         try:
             # 数据中心创建组件
-            region_new_service = console_app_service.create_region_service(tenant, new_service, self.user.nick_name)
+            region_new_service = console_app_service.create_region_service(
+                tenant, new_service, self.user.nick_name)  # type: ignore[arg-type]
 
             if is_deploy:
                 try:
-                    app_manage_service.deploy(tenant, region_new_service, self.user)
+                    app_manage_service.deploy(tenant, region_new_service, self.user)  # type: ignore[arg-type]
                 except Exception as e:
                     logger.exception(e)
                     err = ErrComponentBuildFailed()
@@ -357,7 +366,7 @@ class CreateThirdComponentView(TeamAppAPIView):
         responses={200: CreateThirdComponentResponseSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         ctcs = CreateThirdComponentSerializer(data=request.data)
         ctcs.is_valid(raise_exception=True)
         req_date = ctcs.data
@@ -374,14 +383,16 @@ class CreateThirdComponentView(TeamAppAPIView):
         bean = new_component.to_dict()
         if endpoints_type == "api":
             # 生成秘钥
-            deploy = deploy_repo.get_deploy_relation_by_service_id(service_id=new_component.service_id)
+            # NOTE: BUG—deploy_repo imported as module; singleton method on deploy_repo.deploy_repo.
+            deploy = deploy_repo.get_deploy_relation_by_service_id(  # type: ignore[attr-defined]
+                service_id=new_component.service_id)
             api_secret_key = pickle.loads(base64.b64decode(deploy)).get("secret_key")
             # 从环境变量中获取域名，没有在从请求中获取
             host = os.environ.get('DEFAULT_DOMAIN', "http://" + request.get_host())
             api_url = host + "/console/" + "third_party/{0}".format(new_component.service_id)
             bean["api_service_key"] = api_secret_key
             bean["url"] = api_url
-        console_app_service.create_third_party_service(self.team, new_component, self.user.nick_name)
+        console_app_service.create_third_party_service(self.team, new_component, self.user.nick_name)  # type: ignore[arg-type]
         return Response(bean, status=status.HTTP_200_OK)
 
 
@@ -394,12 +405,12 @@ class AppServicesView(TeamAppServiceAPIView):
         responses={200: ServiceBaseInfoSerializer()},
         tags=['openapi-apps'],
     )
-    def get(self, req, app_id, service_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, service_id: str, *args: Any, **kwargs: Any) -> Response:
         status_list = base_service.status_multi_service(
             region=self.app.region_name,
             tenant_name=self.team.tenant_name,
             service_ids=[self.service.service_id],
-            enterprise_id=self.team.enterprise_id)
+            enterprise_id=self.team.enterprise_id)  # type: ignore[arg-type]
         data = self.service.to_dict()
         data["status"] = status_list[0]["status"]
         data["access_infos"] = domain_service.get_component_access_infos(self.region_name, self.service.service_id)
@@ -416,7 +427,7 @@ class AppServicesView(TeamAppServiceAPIView):
         responses={},
         tags=['openapi-apps'],
     )
-    def delete(self, req, app_id, service_id, *args, **kwargs):
+    def delete(self, req: Request, app_id: str, service_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             force = int(req.GET.get("force", 0))
         except ValueError:
@@ -424,7 +435,7 @@ class AppServicesView(TeamAppServiceAPIView):
         code, msg = app_manage_service.delete(self.user, self.team, self.service, True)
         if code != 200 and force:
             app_manage_service.delete_again(self.user, self.team, self.service, is_force=True)
-        msg_dict = dict()
+        msg_dict: dict = dict()
         msg_dict['status'] = code
         msg_dict['msg'] = msg
         msg_dict['service_id'] = self.service.service_id
@@ -445,7 +456,7 @@ class AppServiceEventsView(TeamAppServiceAPIView):
         responses={200: ListServiceEventsResponse()},
         tags=['openapi-apps'],
     )
-    def get(self, req, app_id, service_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, service_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(req.GET.get("page", 1))
         page_size = int(req.GET.get("page_size", 10))
         events, total, has_next = event_service.get_target_events("service", self.service.service_id, self.team,
@@ -468,7 +479,7 @@ class AppServiceTelescopicVerticalView(TeamAppServiceAPIView, EnterpriseServiceO
         responses={},
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = AppServiceTelescopicVerticalSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         new_memory = serializer.data.get("new_memory")
@@ -478,7 +489,7 @@ class AppServiceTelescopicVerticalView(TeamAppServiceAPIView, EnterpriseServiceO
             self.team,
             self.service,
             self.user,
-            int(new_memory),
+            int(new_memory),  # type: ignore[arg-type]
             oauth_instance=self.oauth_instance,
             new_gpu=new_gpu,
             new_cpu=new_cpu)
@@ -497,12 +508,12 @@ class AppServiceTelescopicHorizontalView(TeamAppServiceAPIView, EnterpriseServic
         responses={},
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = AppServiceTelescopicHorizontalSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         new_node = serializer.data.get("new_node")
         app_manage_service.horizontal_upgrade(
-            self.team, self.service, self.user, int(new_node), oauth_instance=self.oauth_instance)
+            self.team, self.service, self.user, int(new_node), oauth_instance=self.oauth_instance)  # type: ignore[arg-type]
         return Response(None, status=200)
 
 
@@ -513,18 +524,19 @@ class TeamAppsCloseView(TeamAPIView, EnterpriseServiceOauthView):
         responses={},
         tags=['openapi-apps'],
     )
-    def post(self, request, team_id, region_name, *args, **kwargs):
+    def post(self, request: Request, team_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         serializers = TeamAppsCloseSerializers(data=request.data)
         serializers.is_valid(raise_exception=True)
         service_id_list = serializers.data.get("service_ids", None)
         services = service_repo.get_tenant_region_services(self.region_name, self.team.tenant_id)
         if not services:
             return Response(None, status=200)
-        service_ids = services.values_list("service_id", flat=True)
+        service_ids: Any = services.values_list("service_id", flat=True)
         if service_id_list:
             service_ids = list(set(service_ids) & set(service_id_list))
-        code, msg = app_manage_service.batch_action(self.region_name, self.team, self.user, "stop", service_ids, None,
-                                                    self.oauth_instance)
+        # NOTE: BUG—batch_action returns 3 values (code, msg, services); only 2 unpacked here.
+        code, msg = app_manage_service.batch_action(self.region_name, self.team, self.user, "stop",  # type: ignore[misc]
+                                                    service_ids, None, self.oauth_instance)
         if code != 200:
             raise ServiceHandleException(status_code=code, msg="batch manage error", msg_show=msg)
         return Response(None, status=200)
@@ -541,7 +553,7 @@ class TeamAppsMonitorQueryView(TeamAppAPIView):
         responses={200: ComponentMonitorSerializers(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, request, team_id, region_name, app_id, *args, **kwargs):
+    def get(self, request: Request, team_id: str, region_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         is_outer = request.GET.get("is_outer", False)
         if is_outer == "true":
             is_outer = True
@@ -565,7 +577,7 @@ class TeamAppsMonitorQueryView(TeamAppAPIView):
                             is_outer_service = True
                             break
                 if has_plugin and is_outer_service:
-                    dt = {
+                    dt: dict = {
                         "service_id": service.service_id,
                         "service_cname": service.service_cname,
                         "service_alias": service.service_alias,
@@ -574,14 +586,15 @@ class TeamAppsMonitorQueryView(TeamAppAPIView):
                     for k, v in list(monitor_query_items.items()):
                         monitor = {"monitor_item": k}
                         res, body = region_api.get_query_data(self.region_name, self.team.tenant_name, v % service.service_id)
-                        if body.get("data"):
-                            if body["data"]["result"]:
+                        # NOTE: regionapi result may be None; legacy assumes dict (backlog).
+                        if body.get("data"):  # type: ignore[union-attr]
+                            if body["data"]["result"]:  # type: ignore[index]
                                 result_list = []
-                                for result in body["data"]["result"]:
+                                for result in body["data"]["result"]:  # type: ignore[index]
                                     result["value"] = [str(value) for value in result["value"]]
                                     result_list.append(result)
-                                body["data"]["result"] = result_list
-                                monitor.update(body)
+                                body["data"]["result"] = result_list  # type: ignore[index]
+                                monitor.update(body)  # type: ignore[arg-type]
                                 dt["monitors"].append(monitor)
                     data.append(dt)
         serializers = ComponentMonitorSerializers(data=data, many=True)
@@ -605,7 +618,7 @@ class TeamAppsMonitorQueryRangeView(TeamAppAPIView):
         responses={200: ComponentMonitorSerializers(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, request, team_id, region_name, app_id, *args, **kwargs):
+    def get(self, request: Request, team_id: str, region_name: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         is_outer = request.GET.get("is_outer", False)
         if is_outer == "true":
             is_outer = True
@@ -634,7 +647,7 @@ class TeamAppsMonitorQueryRangeView(TeamAppAPIView):
                             is_outer_service = True
                             break
                 if has_plugin and is_outer_service:
-                    dt = {
+                    dt: dict = {
                         "service_id": service.service_id,
                         "service_cname": service.service_cname,
                         "service_alias": service.service_alias,
@@ -642,10 +655,12 @@ class TeamAppsMonitorQueryRangeView(TeamAppAPIView):
                     }
                     for k, v in list(monitor_query_range_items.items()):
                         monitor = {"monitor_item": k}
-                        body = {}
+                        body: dict = {}
                         try:
-                            res, body = region_api.get_query_range_data(self.region_name, self.team.tenant_name,
-                                                                        v % (service.service_id, start, end, step))
+                            # NOTE: regionapi result may be None; legacy assumes dict (backlog).
+                            res, body = region_api.get_query_range_data(  # type: ignore[assignment]
+                                self.region_name, self.team.tenant_name,
+                                v % (service.service_id, start, end, step))
                         except Exception as e:
                             logger.debug(e)
                         if body.get("data"):
@@ -678,7 +693,7 @@ class ComponentEnvsUView(TeamAppServiceAPIView):
         },
         tags=['openapi-apps'],
     )
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializers = ComponentEnvsSerializers(data=request.data)
         serializers.is_valid(raise_exception=True)
         envs = serializers.data.get("envs")
@@ -700,11 +715,12 @@ class ComponentPortsChangeView(TeamAppServiceAPIView):
         responses={200: ServicePortSerializer()},
         tags=['openapi-apps'],
     )
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         container_port = kwargs.get("port")
         if not container_port:
             raise AbortRequest("container_port not specify", "端口变量名未指定")
-        data = port_service.delete_port_by_container_port(self.team, self.service, int(container_port), self.user.nick_name)
+        data = port_service.delete_port_by_container_port(
+            self.team, self.service, int(container_port), self.user.nick_name)  # type: ignore[arg-type]
         re = ServicePortSerializer(data)
         result = general_message(200, "success", "删除成功", bean=re.data)
         return Response(result, status=status.HTTP_200_OK)
@@ -721,7 +737,7 @@ class ComponentPortsChangeView(TeamAppServiceAPIView):
         responses={200: ServicePortSerializer()},
         tags=['openapi-apps'],
     )
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         port_update = ComponentUpdatePortReqSerializers(data=request.data)
         port_update.is_valid(raise_exception=True)
         container_port = kwargs.get("port")
@@ -732,14 +748,15 @@ class ComponentPortsChangeView(TeamAppServiceAPIView):
         if not container_port:
             raise AbortRequest("container_port not specify", "端口变量名未指定")
 
-        if self.service.service_source == "third_party" and ("outer" in action):
+        if self.service.service_source == "third_party" and ("outer" in action):  # type: ignore[operator]
             msg, msg_show, code = port_service.check_domain_thirdpart(self.team, self.service)
             if code != 200:
                 logger.exception(msg, msg_show)
                 return Response(general_message(code, msg, msg_show), status=code)
 
-        code, msg, data = port_service.manage_port(self.team, self.service, self.region_name, int(container_port), action,
-                                                   protocol, port_alias, k8s_service_name, self.user.nick_name)
+        code, msg, data = port_service.manage_port(
+            self.team, self.service, self.region_name, int(container_port), action,  # type: ignore[arg-type]
+            protocol, port_alias, k8s_service_name, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "change port fail", msg), status=code)
 
@@ -760,7 +777,7 @@ class ComponentPortsShowView(TeamAppServiceAPIView):
         responses={200: ServicePortSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         ports = port_repo.get_service_ports(self.team.tenant_id, self.service.service_id)
         re = ServicePortSerializer(ports, many=True)
         result = general_message(200, "success", "查询成功", list=re.data)
@@ -778,7 +795,7 @@ class ComponentPortsShowView(TeamAppServiceAPIView):
         responses={200: ServicePortSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         port_info = ComponentPortReqSerializers(data=request.data)
         port_info.is_valid(raise_exception=True)
         port = port_info.data.get("port")
@@ -791,8 +808,9 @@ class ComponentPortsShowView(TeamAppServiceAPIView):
             return Response(general_message(400, "params error", "缺少协议参数"), status=400)
         if not port_alias:
             port_alias = self.service.service_alias.upper().replace("-", "_") + str(port)
-        code, msg, port_info = port_service.add_service_port(self.team, self.service, port, protocol, port_alias,
-                                                             is_inner_service, False, None, self.user.nick_name)
+        code, msg, port_info = port_service.add_service_port(
+            self.team, self.service, port, protocol, port_alias,
+            is_inner_service, False, None, self.user.nick_name)  # type: ignore[arg-type]
         if code != 200:
             return Response(general_message(code, "add port error", msg), status=code)
         re = ServicePortSerializer(port_info)
@@ -812,14 +830,14 @@ class ServiceVolumeView(TeamAppServiceAPIView):
         request_body=ServiceVolumeSerializer,
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
 
         ServiceVolumeSerializerRequest = ServiceVolumeSerializer(data=request.data)
         ServiceVolumeSerializerRequest.is_valid(raise_exception=True)
 
         req = ServiceVolumeSerializerRequest.data
         r = re.compile('(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$')
-        if not r.match(req.get("volume_name")):
+        if not r.match(req.get("volume_name")):  # type: ignore[arg-type]
             raise AbortRequest(msg="volume name illegal", msg_show="持久化名称只支持数字字母下划线")
 
         file_content = request.data.get("file_content", None)
@@ -845,12 +863,12 @@ class ServiceVolumeView(TeamAppServiceAPIView):
         data = volume_service.add_service_volume(
             self.team,
             self.service,
-            req.get("volume_path"),
-            req.get("volume_type"),
-            req.get("volume_name"),
+            req.get("volume_path"),  # type: ignore[arg-type]
+            req.get("volume_type"),  # type: ignore[arg-type]
+            req.get("volume_name"),  # type: ignore[arg-type]
             file_content,
             settings,
-            self.user.nick_name,
+            self.user.nick_name,  # type: ignore[arg-type]
             mode=mode)
         result = general_message(200, "success", "持久化路径添加成功", bean=data.to_dict())
 
@@ -869,7 +887,7 @@ class ChangeDeploySourceView(TeamAppServiceAPIView):
         request_body=ChangeDeploySourceSerializer,
         tags=['openapi-apps'],
     )
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         image = request.data.get("image", None)
         if image:
             version = image.split(':')[-1]
@@ -895,7 +913,8 @@ class ComponentBuildView(TeamAppServiceAPIView):
         responses={200: ComponentEventSerializers()},
         tags=['openapi-apps'],
     )
-    def post(self, request, team_id, region_name, app_id, service_id, *args, **kwargs):
+    def post(self, request: Request, team_id: str, region_name: str, app_id: str, service_id: str, *args: Any,
+             **kwargs: Any) -> Response:
         build_info = ComponentBuildReqSerializers(data=request.data)
         build_info.is_valid(raise_exception=True)
         event_id = component_action_service.component_build(self.team, self.service, self.user, build_info.data)
@@ -909,7 +928,7 @@ class AppModelImportEvent(TeamAPIView):
         operation_description="创建应用导入记录",
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # 查询导入记录，如果有未完成的记录返回未完成的记录，如果没有，创建新的导入记录
         unfinished_records = import_service.get_user_not_finish_import_record_in_enterprise(
             self.enterprise.enterprise_id, self.user)
@@ -925,15 +944,16 @@ class AppModelImportEvent(TeamAPIView):
             new = True
         if new:
             try:
-                r = import_service.create_app_import_record_2_enterprise(self.enterprise.enterprise_id, self.user.nick_name)
+                r = import_service.create_app_import_record_2_enterprise(
+                    self.enterprise.enterprise_id, self.user.nick_name)  # type: ignore[arg-type]
             except RegionNotFound:
                 return Response(general_message(200, "success", "查询成功", bean={"region_name": ''}), status=200)
-        upload_url = import_service.get_upload_url(r.region, r.event_id)
-        region = region_services.get_region_by_region_name(r.region)
+        upload_url = import_service.get_upload_url(r.region, r.event_id)  # type: ignore[union-attr]
+        region = region_services.get_region_by_region_name(r.region)  # type: ignore[union-attr]
         data = {
-            "status": r.status,
-            "source_dir": r.source_dir,
-            "event_id": r.event_id,
+            "status": r.status,  # type: ignore[union-attr]
+            "source_dir": r.source_dir,  # type: ignore[union-attr]
+            "event_id": r.event_id,  # type: ignore[union-attr]
             "upload_url": upload_url,
             "region_name": region.region_alias if region else '',
         }
@@ -945,7 +965,7 @@ class AppTarballDirView(TeamAPIView):
         operation_description="应用包目录查询",
         tags=['openapi-apps'],
     )
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         查询应用包目录
         """
@@ -957,7 +977,7 @@ class AppTarballDirView(TeamAPIView):
         result = general_message(200, "success", "查询成功", list=apps)
         return Response(result, status=result["code"])
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         批量导入时创建一个目录
         """
@@ -966,7 +986,7 @@ class AppTarballDirView(TeamAPIView):
         result = general_message(200, "success", "查询成功", bean=import_record.to_dict())
         return Response(result, status=result["code"])
 
-    def delete(self, request, *args, **kwargs):
+    def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         删除导入
         """
@@ -974,7 +994,9 @@ class AppTarballDirView(TeamAPIView):
         if not event_id:
             return Response(general_message(400, "event id is null", "请指明需要查询的event id"), status=400)
 
-        import_record = import_service.delete_import_app_dir(self, self.region_name)
+        # NOTE: BUG—delete_import_app_dir(tenant, region, event_id) needs 3 args & returns None.
+        import_record = import_service.delete_import_app_dir(  # type: ignore[call-arg,func-returns-value]
+            self, self.region_name)
 
         result = general_message(200, "success", "查询成功", bean=import_record.to_dict())
         return Response(result, status=result["code"])
@@ -985,7 +1007,7 @@ class AppImportView(TeamAPIView):
         operation_description="应用导入",
         tags=['openapi-apps'],
     )
-    def post(self, request, event_id, *args, **kwargs):
+    def post(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         导入应用包
         """
@@ -1000,7 +1022,7 @@ class AppImportView(TeamAPIView):
         result = general_message(200, 'success', "操作成功，正在导入")
         return Response(result, status=result["code"])
 
-    def get(self, request, event_id, *args, **kwargs):
+    def get(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         查询应用包导入状态
         """
@@ -1016,7 +1038,7 @@ class AppImportView(TeamAPIView):
             raise e
         return Response(result, status=result["code"])
 
-    def delete(self, request, event_id, *args, **kwargs):
+    def delete(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         放弃导入
         """
@@ -1035,7 +1057,7 @@ class AppDeployView(TeamAPIView):
         request_body=DeployAppSerializer(),
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer_data = DeployAppSerializer(data=request.data)
         serializer_data.is_valid(raise_exception=True)
         req_date = serializer_data.data
@@ -1061,7 +1083,8 @@ class AppDeployView(TeamAPIView):
                 try:
                     group = group_service.get_app_by_id(
                         tenant=self.team, region=self.region.region_name, app_id=req_date["app_id"])
-                    apps = market_app_service.get_market_apps_in_app(self.region_name, self.team, group)
+                    apps = market_app_service.get_market_apps_in_app(
+                        self.region_name, self.team, group)  # type: ignore[arg-type]
                     app_enable_upgrade_map = {app["app_model_id"]: app["can_upgrade"] for app in apps}
                     app_upgrade_group_id_map = {app["app_model_id"]: app["upgrade_group_id"] for app in apps}
 
@@ -1072,16 +1095,17 @@ class AppDeployView(TeamAPIView):
                     if enable_upgrade:
                         # 升级
                         rainbond_app = rainbond_app_repo.get_rainbond_app_by_key_version(group_key=app_key, version=app_version)
-                        ram_model_info = json.loads(rainbond_app.app_template)
+                        ram_model_info = json.loads(rainbond_app.app_template)  # type: ignore[union-attr]
                         component_keys = [cpt["service_key"] for cpt in ram_model_info["apps"]]
-                        record = upgrade_service.create_upgrade_record(self.user.enterprise_id, self.team, group,
-                                                                       app_upgrade_group_id)
+                        record = upgrade_service.create_upgrade_record(
+                            self.user.enterprise_id, self.team, group,  # type: ignore[arg-type]
+                            app_upgrade_group_id)
                         app_upgrade_record = upgrade_repo.get_by_record_id(record["ID"])
                         record, _ = upgrade_service.upgrade(
                             self.team,
                             self.region,
                             self.user,
-                            group,
+                            group,  # type: ignore[arg-type]
                             app_version,
                             app_upgrade_record,
                             component_keys,
@@ -1113,7 +1137,8 @@ class AppDeployView(TeamAPIView):
                 return Response(general_message(code, "parse yaml error", msg), status=code)
             # 创建组
             group_info = group_service.create_app(
-                self.team, self.region_name, group_name, group_note, self.user.get_username(), k8s_app=k8s_app)
+                self.team, self.region_name, group_name, group_note,
+                self.user.get_username(), k8s_app=k8s_app)  # type: ignore[arg-type]
             code, msg, group_compose = compose_service.create_group_compose(self.team, self.region_name, group_info["group_id"],
                                                                             yaml_content, hub_user, hub_pass)
             if code != 200:
@@ -1125,7 +1150,7 @@ class AppDeployView(TeamAPIView):
             while True:
                 sid = None
                 try:
-                    group_compose = compose_service.get_group_compose_by_compose_id(compose_id)
+                    group_compose = compose_service.get_group_compose_by_compose_id(compose_id)  # type: ignore[assignment]
                     code, msg, data = app_check_service.get_service_check_info(self.team, self.region_name,
                                                                                compose_bean["check_uuid"])
                     logger.debug("start save compose info ! {0}".format(group_compose.create_status))
@@ -1135,7 +1160,7 @@ class AppDeployView(TeamAPIView):
                         data["check_status"] = "failure"
                         return Response(general_message(code, "check docker compose error", msg), status=code)
                     else:
-                        transaction.savepoint_commit(sid)
+                        transaction.savepoint_commit(sid)  # type: ignore[arg-type]
                 except Exception as e:
                     logger.exception(e)
                     return Response(general_message(10410, "resource is not enough", e), status=412)
@@ -1145,12 +1170,13 @@ class AppDeployView(TeamAPIView):
             # build
             services = None
             try:
-                group_compose = compose_service.get_group_compose_by_compose_id(compose_id)
+                group_compose = compose_service.get_group_compose_by_compose_id(compose_id)  # type: ignore[assignment]
                 services = compose_service.get_compose_services(compose_id)
                 # 数据中心创建组件
                 new_app_list = []
                 for service in services:
-                    new_service = console_app_service.create_region_service(self.team, service, self.user.nick_name)
+                    new_service = console_app_service.create_region_service(
+                        self.team, service, self.user.nick_name)  # type: ignore[arg-type]
                     new_app_list.append(new_service)
                 group_compose.create_status = "complete"
                 group_compose.save()
@@ -1183,7 +1209,7 @@ class AppChartInfo(TeamAPIView):
         operation_description="chart包部署应用",
         tags=['openapi-apps'],
     )
-    def post(self, request, event_id, *args, **kwargs):
+    def post(self, request: Request, event_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         chart包部署应用
         """
@@ -1211,8 +1237,9 @@ class AppChartInfo(TeamAPIView):
 
             helm_center_app = helm_app_service.create_center_app_by_chart(self.enterprise.enterprise_id, name)
 
-            helm_app_service.generate_template(cvdata, helm_center_app, version, self.team, name, self.region_name,
-                                               self.enterprise.enterprise_id, self.user.user_id, "", group_id)
+            helm_app_service.generate_template(
+                cvdata, helm_center_app, version, self.team, name, self.region_name,  # type: ignore[arg-type]
+                self.enterprise.enterprise_id, self.user.user_id, "", group_id)
             helm_app_service.parse_chart_record(event_id)
         except Exception as e:
             logger.error(e)
@@ -1225,7 +1252,7 @@ class AppChartInfo(TeamAPIView):
                 self.region,
                 self.user,
                 group_id,
-                helm_center_app.app_id,
+                helm_center_app.app_id,  # type: ignore[union-attr]
                 version,
                 "",
                 False,
@@ -1236,27 +1263,28 @@ class AppChartInfo(TeamAPIView):
             # 更新应用
             try:
                 group = group_service.get_app_by_id(tenant=self.team, region=self.region.region_name, app_id=group_id)
-                apps = market_app_service.get_market_apps_in_app(self.region_name, self.team, group)
+                apps = market_app_service.get_market_apps_in_app(self.region_name, self.team, group)  # type: ignore[arg-type]
                 app_enable_upgrade_map = {app["app_model_id"]: app["can_upgrade"] for app in apps}
                 app_upgrade_group_id_map = {app["app_model_id"]: app["upgrade_group_id"] for app in apps}
 
                 app_version = version
-                app_key = helm_center_app.app_id
+                app_key = helm_center_app.app_id  # type: ignore[union-attr]
                 enable_upgrade = app_enable_upgrade_map[app_key]
                 app_upgrade_group_id = app_upgrade_group_id_map[app_key]
                 if enable_upgrade:
                     # 升级
                     rainbond_app = rainbond_app_repo.get_rainbond_app_by_key_version(group_key=app_key, version=app_version)
-                    ram_model_info = json.loads(rainbond_app.app_template)
+                    ram_model_info = json.loads(rainbond_app.app_template)  # type: ignore[union-attr]
                     component_keys = [cpt["service_key"] for cpt in ram_model_info["apps"]]
-                    record = upgrade_service.create_upgrade_record(self.user.enterprise_id, self.team, group,
-                                                                   app_upgrade_group_id)
+                    record = upgrade_service.create_upgrade_record(
+                        self.user.enterprise_id, self.team, group,  # type: ignore[arg-type]
+                        app_upgrade_group_id)
                     app_upgrade_record = upgrade_repo.get_by_record_id(record["ID"])
                     record, _ = upgrade_service.upgrade(
                         self.team,
                         self.region,
                         self.user,
-                        group,
+                        group,  # type: ignore[arg-type]
                         app_version,
                         app_upgrade_record,
                         component_keys,
@@ -1276,7 +1304,7 @@ class DeleteApp(TeamAPIView):
         operation_description="一键删除应用",
         tags=['openapi-apps'],
     )
-    def delete(self, request, app_id, *args, **kwargs):
+    def delete(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         删除应用及所有资源
         """
@@ -1285,15 +1313,16 @@ class DeleteApp(TeamAPIView):
         # delete k8s resource
         k8s_resources = k8s_resource_service.list_by_app_id(str(app_id))
         resource_ids = [k8s_resource.ID for k8s_resource in k8s_resources]
-        k8s_resource_service.batch_delete_k8s_resource(self.user.enterprise_id, self.team.tenant_name, str(app_id),
-                                                       self.region_name, resource_ids)
+        k8s_resource_service.batch_delete_k8s_resource(
+            self.user.enterprise_id, self.team.tenant_name, str(app_id),  # type: ignore[arg-type]
+            self.region_name, resource_ids)
         # delete configs
         app_config_group_service.batch_delete_config_group(self.region_name, self.team.tenant_name, app_id)
         # delete records
         group_service.delete_app_share_records(self.team.tenant_name, app_id)
         # delete app
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
-        group_service.delete_app(self.team, self.region_name, app)
+        group_service.delete_app(self.team, self.region_name, app)  # type: ignore[arg-type]
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
@@ -1307,11 +1336,12 @@ class GetServiceInfoView(BaseOpenAPIView):
         ],
         tags=['openapi-service-scan'],
     )
-    def get(self, request, enterprise_id, region_name, *args, **kwargs):
+    def get(self, request: Request, enterprise_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         res = []
         services = service_repo.get_service_by_region(enterprise_id, region_name)
         service_team_map = {service.service_id: service.tenant_id for service in services}
-        teams = team_repo.get_team_by_enterprise_id(enterprise_id).all()
+        # NOTE: BUG—team_repo is not imported/defined in this module; runtime NameError.
+        teams = team_repo.get_team_by_enterprise_id(enterprise_id).all()  # type: ignore[name-defined]
         team_map = {team.tenant_id: team.tenant_alias for team in teams}
         for service in services:
             tenant_id = service_team_map[service.service_id]
@@ -1329,8 +1359,10 @@ class AppPeerAuthentications(TeamAppAPIView):
         ],
         tags=['openapi-apps'],
     )
-    def get(self, request, app_id, *args, **kwargs):
-        operating_mode = group_service.get_app_peer_authentications(self.region_name, self.tenant, app_id, self.app.k8s_app)
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: BUG—self.tenant unset (base sets self.team) & GroupService lacks this method.
+        operating_mode = group_service.get_app_peer_authentications(  # type: ignore[attr-defined]
+            self.region_name, self.tenant, app_id, self.app.k8s_app)  # type: ignore[attr-defined]
         result = general_message(200, "success", "查询成功", bean=operating_mode)
         return Response(result, status=200)
 
@@ -1342,11 +1374,12 @@ class AppPeerAuthentications(TeamAppAPIView):
         request_body=UpdateAppPeerAuthentications(),
         tags=['openapi-apps'],
     )
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         pa = UpdateAppPeerAuthentications(data=request.data)
         pa.is_valid(raise_exception=True)
         operating_mode = pa.data.get("operating_mode", "close")
-        group_service.update_app_peer_authentications(self.region_name, self.tenant, app_id, operating_mode, self.app.k8s_app)
+        group_service.update_app_peer_authentications(  # type: ignore[attr-defined]
+            self.region_name, self.tenant, app_id, operating_mode, self.app.k8s_app)  # type: ignore[attr-defined]
         result = general_message(200, "success", "更新成功", bean={"operating_mode": operating_mode})
         return Response(result, status=200)
 
@@ -1359,8 +1392,9 @@ class AppAuthorizationPolicy(TeamAppAPIView):
         ],
         tags=['openapi-apps'],
     )
-    def get(self, request, app_id, *args, **kwargs):
-        operating_mode = group_service.get_app_authorization_policy(self.region_name, self.tenant, app_id, self.app.k8s_app)
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
+        operating_mode = group_service.get_app_authorization_policy(  # type: ignore[attr-defined]
+            self.region_name, self.tenant, app_id, self.app.k8s_app)  # type: ignore[attr-defined]
         result = general_message(200, "success", "查询成功", bean=operating_mode)
         return Response(result, status=200)
 
@@ -1372,12 +1406,13 @@ class AppAuthorizationPolicy(TeamAppAPIView):
         request_body=UpdateAppAuthorizationPolicy(),
         tags=['openapi-apps'],
     )
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         ap = UpdateAppAuthorizationPolicy(data=request.data)
         ap.is_valid(raise_exception=True)
         operating_mode = ap.data.get("operating_mode", "close")
 
-        group_service.update_app_authorization_policy(self.region_name, self.tenant, app_id, operating_mode, self.app.k8s_app)
+        group_service.update_app_authorization_policy(  # type: ignore[attr-defined]
+            self.region_name, self.tenant, app_id, operating_mode, self.app.k8s_app)  # type: ignore[attr-defined]
         result = general_message(200, "success", "更新成功", bean={"operating_mode": operating_mode})
         return Response(result, status=200)
 
@@ -1392,21 +1427,22 @@ class HelmChart(TeamAPIView):
         request_body=HelmChartSerializer,
         tags=['openapi-apps'],
     )
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         chart_info = HelmChartSerializer(data=request.GET)
         chart_info.is_valid(raise_exception=True)
         name = chart_info.data.get("chart_name")
         repo_name = chart_info.data.get("repo_name")
         chart_name = chart_info.data.get("chart_name")
         version = chart_info.data.get("version")
-        overrides = []
+        overrides: list = []
         print(name, chart_name, repo_name, version)
-        _, data = helm_app_service.check_helm_app(name, repo_name, chart_name, version, overrides, self.region_name,
-                                                  self.team.tenant_name, self.team)
+        _, data = helm_app_service.check_helm_app(
+            name, repo_name, chart_name, version, overrides, self.region_name,  # type: ignore[arg-type]
+            self.team.tenant_name, self.team)
         result = general_message(200, "success", "获取成功", bean=data)
         return Response(result, status=result["code"])
 
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         chart_info = HelmChartSerializer(data=request.data)
         chart_info.is_valid(raise_exception=True)
         repo_name = chart_info.data.get("repo_name")
@@ -1414,7 +1450,7 @@ class HelmChart(TeamAPIView):
         version = chart_info.data.get("version")
         chart_name = chart_info.data.get("chart_name")
         name = chart_name
-        app_model_id = make_uuid3(repo_name + "/" + chart_name)
+        app_model_id = make_uuid3(repo_name + "/" + chart_name)  # type: ignore[operator]
         helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)
         data = {"exist": True, "app_model_id": app_id}
         if not helm_center_app:
@@ -1422,7 +1458,7 @@ class HelmChart(TeamAPIView):
                 "app_id": app_id,
                 "app_name": chart_name,
                 "create_team": "",
-                "source": "helm:" + repo_name,
+                "source": "helm:" + repo_name,  # type: ignore[operator]
                 "scope": "enterprise",
                 "pic": "",
                 "describe": "",
@@ -1433,21 +1469,25 @@ class HelmChart(TeamAPIView):
             data["exist"] = False
             data["app_model_id"] = app_model_id
         overrides_list = overrides.split(",")
-        cvdata = helm_app_service.yaml_conversion(name, repo_name, chart_name, version, overrides_list, self.region_name,
-                                                  self.team.tenant_name, self.team, self.enterprise.enterprise_id,
+        cvdata = helm_app_service.yaml_conversion(
+            name, repo_name, chart_name, version, overrides_list, self.region_name,  # type: ignore[arg-type]
+            self.team.tenant_name, self.team, self.enterprise.enterprise_id,
                                                   self.region.region_id)
         helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)
-        chart = repo_name + "/" + chart_name
-        helm_app_service.generate_template(cvdata, helm_center_app, version, self.team, chart, self.region_name,
-                                           self.enterprise.enterprise_id, self.user.user_id, overrides_list, app_id)
+        chart = repo_name + "/" + chart_name  # type: ignore[operator]
+        helm_app_service.generate_template(
+            cvdata, helm_center_app, version, self.team, chart, self.region_name,  # type: ignore[arg-type]
+            self.enterprise.enterprise_id, self.user.user_id, overrides_list, app_id)
 
-        market_app_service.install_app(self.team, self.region, self.user, app_id, app_model_id, version, "localApplication",
-                                       False, True, False)
+        market_app_service.install_app(
+            self.team, self.region, self.user, app_id, app_model_id, version, "localApplication",  # type: ignore[arg-type]
+            False, True, False)
 
         result = general_message(200, "success", "成功")
         return Response(result, status=result["code"])
 
-class HelmChart(TeamAPIView):
+# NOTE: BUG—HelmChart is defined twice; this redefinition shadows the earlier class.
+class HelmChart(TeamAPIView):  # type: ignore[no-redef]
     @swagger_auto_schema(
         operation_description="安装helm应用",
         manual_parameters=[
@@ -1458,21 +1498,23 @@ class HelmChart(TeamAPIView):
         request_body=HelmChartSerializer,
         tags=['openapi-apps'],
     )
-    def get(self, request, app_id, *args, **kwargs):
+    def get(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         chart_info = HelmChartSerializer(data=request.GET)
         chart_info.is_valid(raise_exception=True)
         name = chart_info.data.get("chart_name")
         repo_name = chart_info.data.get("repo_name")
         chart_name = chart_info.data.get("chart_name")
         version = chart_info.data.get("version")
-        overrides = []
+        overrides: list = []
         print(name, chart_name, repo_name, version)
-        _, data = helm_app_service.check_helm_app(name, repo_name, chart_name, version, overrides, self.region_name,
-                                                  self.team.tenant_name, self.team)
+        _, data = helm_app_service.check_helm_app(
+            name, repo_name, chart_name, version, overrides, self.region_name,  # type: ignore[arg-type]
+            self.team.tenant_name, self.team)
         result = general_message(200, "success", "获取成功", bean=data)
         return Response(result, status=result["code"])
 
-    def post(self, request, app_id, *args, **kwargs):
+    # NOTE: BUG—this post handler has no return statement; declared -> Response but returns None.
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:  # type: ignore[return]
         chart_info = HelmChartSerializer(data=request.data)
         chart_info.is_valid(raise_exception=True)
         repo_name = chart_info.data.get("repo_name")
@@ -1480,7 +1522,7 @@ class HelmChart(TeamAPIView):
         version = chart_info.data.get("version")
         chart_name = chart_info.data.get("chart_name")
         name = chart_name
-        app_model_id = make_uuid3(repo_name + "/" + chart_name)
+        app_model_id = make_uuid3(repo_name + "/" + chart_name)  # type: ignore[operator]
         helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)
         data = {"exist": True, "app_model_id": app_id}
         if not helm_center_app:
@@ -1488,7 +1530,7 @@ class HelmChart(TeamAPIView):
                 "app_id": app_id,
                 "app_name": chart_name,
                 "create_team": "",
-                "source": "helm:" + repo_name,
+                "source": "helm:" + repo_name,  # type: ignore[operator]
                 "scope": "enterprise",
                 "pic": "",
                 "describe": "",
@@ -1499,13 +1541,15 @@ class HelmChart(TeamAPIView):
             data["exist"] = False
             data["app_model_id"] = app_model_id
         overrides_list = overrides.split(",")
-        cvdata = helm_app_service.yaml_conversion(name, repo_name, chart_name, version, overrides_list, self.region_name,
-                                                  self.team.tenant_name, self.team, self.enterprise.enterprise_id,
+        cvdata = helm_app_service.yaml_conversion(
+            name, repo_name, chart_name, version, overrides_list, self.region_name,  # type: ignore[arg-type]
+            self.team.tenant_name, self.team, self.enterprise.enterprise_id,
                                                   self.region.region_id)
         helm_center_app = rainbond_app_repo.get_rainbond_app_by_app_id(app_model_id)
-        chart = repo_name + "/" + chart_name
-        helm_app_service.generate_template(cvdata, helm_center_app, version, self.team, chart, self.region_name,
-                                           self.enterprise.enterprise_id, self.user.user_id, overrides_list, app_id)
+        chart = repo_name + "/" + chart_name  # type: ignore[operator]
+        helm_app_service.generate_template(
+            cvdata, helm_center_app, version, self.team, chart, self.region_name,  # type: ignore[arg-type]
+            self.enterprise.enterprise_id, self.user.user_id, overrides_list, app_id)
 
     @swagger_auto_schema(
         operation_description="更新授权认证",
@@ -1515,7 +1559,7 @@ class HelmChart(TeamAPIView):
         request_body=UpdateAppAuthorizationPolicy(),
         tags=['openapi-apps'],
     )
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         ap = UpdateAppAuthorizationPolicy(data=request.data)
         ap.is_valid(raise_exception=True)
 
@@ -1561,7 +1605,7 @@ class SmartDeployTemplateView(TeamAPIView):
         },
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         智能部署应用模板（使用最新版本）
         """
@@ -1618,7 +1662,7 @@ class SmartDeployTemplateView(TeamAPIView):
                 # 未安装，在现有应用中安装
                 logger.info("Template not installed in app, installing: template_id={}".format(template_id))
                 return self._install_template(
-                    app_id,
+                    app_id,  # type: ignore[arg-type]
                     app_name,
                     template_id,
                     market_name,
@@ -1642,9 +1686,11 @@ class SmartDeployTemplateView(TeamAPIView):
                 # 使用已存在的应用
                 app_id = existing_app.ID
                 # 如果应用已删除，恢复它
-                if existing_app.status == "deleted":
+                # NOTE: BUG—ServiceGroup has no `status` field; runtime AttributeError.
+                if existing_app.status == "deleted":  # type: ignore[attr-defined]
                     try:
-                        group_service.recover_app(
+                        # NOTE: BUG—GroupService has no recover_app method; runtime AttributeError.
+                        group_service.recover_app(  # type: ignore[attr-defined]
                             tenant=self.team,
                             region_name=self.region.region_name,
                             app=existing_app,
@@ -1661,7 +1707,7 @@ class SmartDeployTemplateView(TeamAPIView):
                         region_name=self.region.region_name,
                         app_name=app_name,
                         note="通过智能部署模板创建",
-                        username=self.user.nick_name,
+                        username=self.user.nick_name,  # type: ignore[arg-type]
                         k8s_app=app_name
                     )
                     app_id = app_data["app_id"]
@@ -1679,7 +1725,7 @@ class SmartDeployTemplateView(TeamAPIView):
                                     region_name=self.region.region_name,
                                     app_name=new_app_name,
                                     note="通过智能部署模板创建",
-                                    username=self.user.nick_name,
+                                    username=self.user.nick_name,  # type: ignore[arg-type]
                                     k8s_app=new_app_name
                                 )
                                 app_id = app_data["app_id"]
@@ -1710,7 +1756,7 @@ class SmartDeployTemplateView(TeamAPIView):
 
             # 安装模板
             return self._install_template(
-                app_id,
+                app_id,  # type: ignore[arg-type]
                 app_name,
                 template_id,
                 market_name,
@@ -1718,7 +1764,7 @@ class SmartDeployTemplateView(TeamAPIView):
                 is_deploy
             )
 
-    def _get_latest_version(self, template_id, install_from_cloud, market_name):
+    def _get_latest_version(self, template_id: str, install_from_cloud: bool, market_name: str) -> Any:
         """
         获取模板的最新版本
         """
@@ -1726,12 +1772,13 @@ class SmartDeployTemplateView(TeamAPIView):
             if install_from_cloud and market_name:
                 # 从云端市场获取最新版本
                 market = app_market_service.get_app_market_by_name(
-                    self.team.enterprise_id, market_name, raise_exception=True
+                    self.team.enterprise_id, market_name, raise_exception=True  # type: ignore[arg-type]
                 )
                 versions = app_market_service.get_market_app_model_versions(market, template_id)
             else:
                 # 从本地获取最新版本
-                versions = rainbond_app_repo.get_rainbond_app_versions(template_id).order_by('-update_time')
+                versions = rainbond_app_repo.get_rainbond_app_versions(
+                    template_id).order_by('-update_time')  # type: ignore[assignment]
 
             if not versions:
                 return None
@@ -1742,7 +1789,8 @@ class SmartDeployTemplateView(TeamAPIView):
             logger.exception("Failed to get latest version: {}".format(e))
             return None
 
-    def _install_template(self, app_id, app_name, template_id, market_name, install_from_cloud, is_deploy):
+    def _install_template(self, app_id: str, app_name: str, template_id: str, market_name: str,
+                          install_from_cloud: bool, is_deploy: bool) -> Response:
         """
         安装模板到应用（使用最新版本）
         """
@@ -1790,7 +1838,8 @@ class SmartDeployTemplateView(TeamAPIView):
                 status=500
             )
 
-    def _upgrade_template(self, app, template_id, template_info, install_from_cloud, market_name):
+    def _upgrade_template(self, app: Any, template_id: str, template_info: dict, install_from_cloud: bool,
+                          market_name: str) -> Response:
         """
         升级应用中的模板（使用最新版本）
         """
@@ -1833,15 +1882,15 @@ class SmartDeployTemplateView(TeamAPIView):
                 group_key=template_id,
                 version=latest_version
             )
-            ram_model_info = json.loads(rainbond_app.app_template)
+            ram_model_info = json.loads(rainbond_app.app_template)  # type: ignore[union-attr]
             component_keys = [cpt["service_key"] for cpt in ram_model_info["apps"]]
 
             # 创建升级记录
             record = upgrade_service.create_upgrade_record(
-                self.user.enterprise_id,
+                self.user.enterprise_id,  # type: ignore[arg-type]
                 self.team,
                 app,
-                app_upgrade_group_id
+                app_upgrade_group_id  # type: ignore[arg-type]
             )
             app_upgrade_record = upgrade_repo.get_by_record_id(record["ID"])
 

--- a/openapi/views/apps/gray_release.py
+++ b/openapi/views/apps/gray_release.py
@@ -3,6 +3,7 @@
 Gray release view for application-level canary deployments
 """
 import logging
+from typing import Any
 
 from console.exception.main import ServiceHandleException
 from console.services.gray_release_service import gray_release_service
@@ -18,6 +19,7 @@ from openapi.serializer.app_serializer import (
 )
 from openapi.views.base import TeamAPIView, TeamAppAPIView
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from www.utils.return_message import general_message
@@ -37,7 +39,7 @@ class GrayReleaseView(TeamAppAPIView):
         responses={200: GrayReleaseResponseSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         Create a gray release for an application
 
@@ -71,9 +73,10 @@ class GrayReleaseView(TeamAppAPIView):
                 region_name=self.region_name,
                 user=self.user,
                 app=self.app,
-                template_id=template_id,
-                domain_name=domain_name,
-                gray_ratio=gray_ratio,
+                # NOTE: serializer .get() yields Any|None; service params are non-Optional.
+                template_id=template_id,  # type: ignore[arg-type]
+                domain_name=domain_name,  # type: ignore[arg-type]
+                gray_ratio=gray_ratio,  # type: ignore[arg-type]
                 market_name=market_name,
                 install_from_cloud=install_from_cloud
             )
@@ -127,7 +130,7 @@ class UpdateGrayRatioView(TeamAppAPIView):
         responses={200: UpdateGrayRatioResponseSerializer()},
         tags=['openapi-apps'],
     )
-    def put(self, request, app_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         Update gray ratio for an existing gray release
 
@@ -154,7 +157,7 @@ class UpdateGrayRatioView(TeamAppAPIView):
 
             # Find active gray release record by app_id and template_id
             record = gray_release_repo.get_active_record_by_app_and_template(
-                self.team.tenant_id, app_id, template_id
+                self.team.tenant_id, app_id, template_id  # type: ignore[arg-type]
             )
 
             if not record:
@@ -181,7 +184,7 @@ class UpdateGrayRatioView(TeamAppAPIView):
                 user=self.user,
                 app=self.app,
                 record=record,
-                new_gray_ratio=gray_ratio,
+                new_gray_ratio=gray_ratio,  # type: ignore[arg-type]
                 is_full_release=is_full_release
             )
 
@@ -280,7 +283,7 @@ class GrayRollbackView(TeamAppAPIView):
         responses={200: GrayRollbackResponseSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         Rollback gray release: switch all traffic to original services and delete new services
 
@@ -306,7 +309,7 @@ class GrayRollbackView(TeamAppAPIView):
                 region_name=self.region_name,
                 user=self.user,
                 app=self.app,
-                template_id=template_id
+                template_id=template_id  # type: ignore[arg-type]
             )
 
             logger.info("Gray release rollback completed successfully: {0}".format(result))
@@ -352,7 +355,7 @@ class GrayReleaseListView(APIView):
         responses={200: GrayReleaseListItemSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         Get gray release list for the whole platform
 

--- a/openapi/views/apps/market.py
+++ b/openapi/views/apps/market.py
@@ -2,6 +2,7 @@
 # creater by: barnett
 
 import logging
+from typing import Any
 
 from console.exception.main import ServiceHandleException
 from console.services.app import app_market_service
@@ -15,6 +16,7 @@ from openapi.serializer.app_serializer import (InstallSerializer, ListUpgradeSer
                                                UpgradeSerializer)
 from openapi.views.base import EnterpriseServiceOauthView, TeamAppAPIView
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.utils.crypt import make_uuid
 
@@ -35,7 +37,7 @@ class AppInstallView(TeamAppAPIView):
         responses={200: MarketInstallSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         is_deploy = request.GET.get("is_deploy", False)
         if is_deploy == "true":
             is_deploy = True
@@ -47,7 +49,9 @@ class AppInstallView(TeamAppAPIView):
         market_access_key = serializer.data.get("market_access_key")
         app_model_id = serializer.data.get("app_model_id")
         app_model_version = serializer.data.get("app_model_version")
-        market = app_market_service.get_app_market_by_domain_url(self.team.enterprise_id, market_domain, market_url)
+        # NOTE: serializer.data.get(...) yields Optional; legacy passes to str params (backlog).
+        market = app_market_service.get_app_market_by_domain_url(
+            self.team.enterprise_id, market_domain, market_url)  # type: ignore[arg-type]
         if not market:
             market_name = make_uuid()
             dt = {
@@ -59,16 +63,18 @@ class AppInstallView(TeamAppAPIView):
                 "domain": market_domain,
             }
             app_market_service.create_app_market(dt)
-            dt, market = app_market_service.get_app_market(self.team.enterprise_id, market_name, raise_exception=True)
+            dt, market = app_market_service.get_app_market(
+                self.team.enterprise_id, market_name, raise_exception=True)  # type: ignore[arg-type]
         market_name = market.name
         app, app_version_info = app_market_service.cloud_app_model_to_db_model(
-            market, app_model_id, app_model_version, for_install=True)
+            market, app_model_id, app_model_version, for_install=True)  # type: ignore[arg-type]
         if not app:
             raise ServiceHandleException(status_code=404, msg="not found", msg_show="云端应用不存在")
         if not app_version_info:
             raise ServiceHandleException(status_code=404, msg="not found", msg_show="云端应用版本不存在")
         market_app_service.install_service(
-            self.team, self.region_name, self.user, app_id, app, app_version_info, is_deploy, True, market_name=market_name)
+            self.team, self.region_name, self.user, app_id, app, app_version_info,
+            is_deploy, True, market_name=market_name)  # type: ignore[arg-type]
         services = group_service.get_group_services(app_id)
         app_info = model_to_dict(self.app)
         app_info["app_name"] = app_info["group_name"]
@@ -90,7 +96,7 @@ class AppUpgradeView(TeamAppAPIView, EnterpriseServiceOauthView):
         responses={200: ListUpgradeSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         app_models = market_app_service.get_market_apps_in_app(self.region_name, self.team, self.app)
         serializer = ListUpgradeSerializer(data=app_models, many=True)
         serializer.is_valid(raise_exception=True)
@@ -105,7 +111,7 @@ class AppUpgradeView(TeamAppAPIView, EnterpriseServiceOauthView):
         responses={200: ListUpgradeSerializer(many=True)},
         tags=['openapi-apps'],
     )
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = UpgradeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         upgrade_service.openapi_upgrade_app_models(self.user, self.team, self.region_name, self.oauth_instance, self.app.ID,

--- a/openapi/views/appstore_view.py
+++ b/openapi/views/appstore_view.py
@@ -6,6 +6,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import exceptions
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.enterprise_services import enterprise_services
@@ -30,7 +31,7 @@ class ListAppStoresView(BaseOpenAPIView):
         responses={status.HTTP_200_OK: ListAppStoreInfosRespSerializer()},
         tags=['openapi-appstore'],
     )
-    def get(self, req):
+    def get(self, req: Request) -> Response:
         try:
             page = int(req.GET.get("page", 1))
         except ValueError:
@@ -56,7 +57,7 @@ class AppStoreInfoView(BaseOpenAPIView):
         },
         tags=['openapi-appstore'],
     )
-    def put(self, req, eid):
+    def put(self, req: Request, eid: str) -> Response:
         serializer = UpdAppStoreInfoReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
@@ -65,7 +66,8 @@ class AppStoreInfoView(BaseOpenAPIView):
 
         try:
             res = enterprise_services.update_appstore_info(eid, req.data)
-        except TenantEnterpriseToken:
+        # NOTE: BUG—TenantEnterpriseToken is a Django model, not an exception; except can never match.
+        except TenantEnterpriseToken:  # type: ignore[misc]
             raise exceptions.NotFound({"msg": "应用市场信息不存在 {}".format(eid)})
         serializer = AppStoreInfoSerializer(res)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/openapi/views/base.py
+++ b/openapi/views/base.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import os
+from typing import Any
 
 from rest_framework import generics
+from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from console.services.user_services import user_services
 from console.exception.main import NoPermissionsError, ServiceHandleException
-from console.models.main import (EnterpriseUserPerm, OAuthServices, PermsInfo, RoleInfo, RolePerms, UserOAuthServices, UserRole)
+from console.models.main import (EnterpriseUserPerm, OAuthServices, PermsInfo, RoleInfo, RolePerms, UserOAuthServices, UserRole,
+                                 RegionConfig)
 from console.repositories.group import group_service_relation_repo
 from console.repositories.region_repo import region_repo
 from console.services.enterprise_services import enterprise_services
@@ -18,7 +21,7 @@ from console.utils.oauth.oauth_types import get_oauth_instance
 from openapi.auth.authentication import (OpenAPIAuthentication, OpenAPIManageAuthentication)
 from openapi.auth.permissions import OpenAPIPermissions
 from openapi.views.exceptions import ErrEnterpriseNotFound, ErrRegionNotFound
-from www.models.main import TenantEnterprise, TenantServiceInfo
+from www.models.main import TenantEnterprise, TenantServiceInfo, Tenants, Users
 from console.utils import perms
 
 
@@ -31,28 +34,39 @@ class BaseOpenAPIView(APIView):
     authentication_classes = [OpenAPIAuthentication]
     permission_classes = [OpenAPIPermissions]
 
-    def __init__(self):
-        super(BaseOpenAPIView, self).__init__()
-        self.enterprise = None
-        self.region_name = None
-        self.regions = None
-        self.user = None
+    # Context attributes populated in initial() before any handler runs; typed to the
+    # runtime contract so subclass views get clean self.<attr> access (see P5 convention).
+    enterprise: TenantEnterprise
+    region_name: str
+    regions: Any
+    region: RegionConfig
+    user: Users
+    user_perms: Any
+    is_enterprise_admin: bool
 
-    def check_perms(self, request, *args, **kwargs):
+    def __init__(self) -> None:
+        super(BaseOpenAPIView, self).__init__()
+        self.enterprise = None  # type: ignore[assignment]
+        self.region_name = None  # type: ignore[assignment]
+        self.regions = None
+        self.user = None  # type: ignore[assignment]
+
+    def check_perms(self, request: Request, *args: Any, **kwargs: Any) -> None:
         if kwargs.get("__message"):
             if kwargs.get("app_id"):
                 pass
-            request_perms = kwargs["__message"][request.META.get("REQUEST_METHOD").lower()]["perms"]
+            request_perms = kwargs["__message"][request.META.get("REQUEST_METHOD").lower()]["perms"]  # type: ignore[union-attr]
             if request_perms and (len(set(request_perms) & set(self.user_perms)) != len(set(request_perms))):
                 raise NoPermissionsError
 
-    def has_perms(self, request_perms):
+    def has_perms(self, request_perms: Any) -> None:
         if request_perms and (len(set(request_perms) & set(self.user_perms)) != len(set(request_perms))):
             raise NoPermissionsError
 
-    def get_perms(self):
+    def get_perms(self) -> None:
         self.user_perms = []
-        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)
+        # NOTE: systemic int-as-str / nullable enterprise_id mismatch (backlog).
+        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         self.user_perms = list(perms.list_enterprise_perm_codes_by_roles(admin_roles))
 
         roles = RoleInfo.objects.filter(kind="enterprise", kind_id=self.user.enterprise_id)
@@ -66,38 +80,44 @@ class BaseOpenAPIView(APIView):
                     self.user_perms = role_perms.values_list("perm_code", flat=True)
         self.user_perms = list(set(self.user_perms))
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(BaseOpenAPIView, self).initial(request, *args, **kwargs)
-        request.user.is_ = False
+        request.user.is_ = False  # type: ignore[union-attr]
+        # NOTE: request.user is User|AnonymousUser per stubs; runtime carries enterprise_id etc.
         if hasattr(request.user, "enterprise_id"):
-            self.enterprise = enterprise_services.get_enterprise_by_id(request.user.enterprise_id)
+            self.enterprise = enterprise_services.get_enterprise_by_id(request.user.enterprise_id)  # type: ignore[assignment,union-attr]
         if not self.enterprise:
             raise ErrEnterpriseNotFound
-        self.region_name = kwargs.get("region_name")
+        self.region_name = kwargs.get("region_name")  # type: ignore[assignment]
         if not self.region_name:
-            self.region_name = kwargs.get("region_id")
+            self.region_name = kwargs.get("region_id")  # type: ignore[assignment]
         if self.region_name:
-            self.region = region_services.get_enterprise_region_by_region_name(
+            self.region = region_services.get_enterprise_region_by_region_name(  # type: ignore[assignment]
                 enterprise_id=self.enterprise.enterprise_id, region_name=self.region_name)
             if not self.region:
-                self.region = region_repo.get_region_by_id(self.enterprise.enterprise_id, self.region_name)
+                self.region = region_repo.get_region_by_id(self.enterprise.enterprise_id, self.region_name)  # type: ignore[assignment]
         # Temporary logic
         if self.enterprise.ID == 1:
-            request.user.is_administrator = True
-        self.user = request.user
+            request.user.is_administrator = True  # type: ignore[union-attr]
+        self.user = request.user  # type: ignore[assignment]
         self.get_perms()
         self.check_perms(request, *args, **kwargs)
 
 
 class TeamNoRegionAPIView(BaseOpenAPIView):
-    def __init__(self):
+    team: Tenants
+    is_team_owner: bool
+    team_regions: Any
+
+    def __init__(self) -> None:
         super(TeamNoRegionAPIView, self).__init__()
-        self.team = None
+        self.team = None  # type: ignore[assignment]
         self.is_team_owner = False
 
-    def get_perms(self):
+    def get_perms(self) -> None:
         self.user_perms = []
-        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)
+        # NOTE: systemic int-as-str / nullable enterprise_id mismatch (backlog).
+        admin_roles = user_services.list_roles(self.user.enterprise_id, self.user.user_id)  # type: ignore[arg-type]
         self.user_perms = list(perms.list_enterprise_perm_codes_by_roles(admin_roles))
 
         if self.is_team_owner:
@@ -116,27 +136,27 @@ class TeamNoRegionAPIView(BaseOpenAPIView):
                         self.user_perms.extend(list(team_role_perms.values_list("perm_code", flat=True)))
         self.user_perms = list(set(self.user_perms))
 
-    def initial(self, request, *args, **kwargs):
-        request.user.is_administrator = False
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
+        request.user.is_administrator = False  # type: ignore[union-attr]
         if hasattr(request.user, "enterprise_id"):
-            self.enterprise = enterprise_services.get_enterprise_by_id(request.user.enterprise_id)
+            self.enterprise = enterprise_services.get_enterprise_by_id(request.user.enterprise_id)  # type: ignore[assignment,union-attr]
         if not self.enterprise:
             raise ErrEnterpriseNotFound
         if self.enterprise.ID == 1:
-            request.user.is_administrator = True
-        self.user = request.user
+            request.user.is_administrator = True  # type: ignore[union-attr]
+        self.user = request.user  # type: ignore[assignment]
         self.is_team_owner = False
         team_id = kwargs.get("team_id")
         if team_id:
-            self.team = team_services.get_team_by_team_id_and_eid(team_id, self.enterprise.enterprise_id)
+            self.team = team_services.get_team_by_team_id_and_eid(team_id, self.enterprise.enterprise_id)  # type: ignore[assignment]
         if not self.team:
-            self.team = team_services.get_enterprise_tenant_by_tenant_name(self.enterprise.enterprise_id, team_id)
+            self.team = team_services.get_enterprise_tenant_by_tenant_name(self.enterprise.enterprise_id, team_id)  # type: ignore[assignment,arg-type]
         if not self.team:
             raise ServiceHandleException(msg_show="团队不存在", msg="no found team", status_code=404)
         self.team_regions = region_services.get_team_usable_regions(self.team.tenant_name, self.enterprise.enterprise_id)
         if self.user.user_id == self.team.creater:
             self.is_team_owner = True
-        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.team.enterprise_id).first()
+        self.enterprise = TenantEnterprise.objects.filter(enterprise_id=self.team.enterprise_id).first()  # type: ignore[assignment]
         self.is_enterprise_admin = False
         enterprise_user_perms = EnterpriseUserPerm.objects.filter(
             enterprise_id=self.team.enterprise_id, user_id=self.user.user_id).first()
@@ -147,16 +167,16 @@ class TeamNoRegionAPIView(BaseOpenAPIView):
 
 
 class TeamAPIView(TeamNoRegionAPIView):
-    def __init__(self):
+    def __init__(self) -> None:
         super(TeamAPIView, self).__init__()
-        self.region_name = None
-        self.region = None
+        self.region_name = None  # type: ignore[assignment]
+        self.region = None  # type: ignore[assignment]
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(TeamAPIView, self).initial(request, *args, **kwargs)
-        self.region_name = kwargs.get("region_name")
+        self.region_name = kwargs.get("region_name")  # type: ignore[assignment]
         if self.region_name:
-            self.region = region_services.get_enterprise_region_by_region_name(
+            self.region = region_services.get_enterprise_region_by_region_name(  # type: ignore[assignment]
                 enterprise_id=self.enterprise.enterprise_id, region_name=self.region_name)
         else:
             raise ErrRegionNotFound
@@ -165,11 +185,13 @@ class TeamAPIView(TeamNoRegionAPIView):
 
 
 class TeamAppAPIView(TeamAPIView):
-    def __init__(self):
+    app: Any
+
+    def __init__(self) -> None:
         super(TeamAppAPIView, self).__init__()
         self.app = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(TeamAppAPIView, self).initial(request, *args, **kwargs)
         app_id = kwargs.get("app_id")
         if app_id:
@@ -179,18 +201,20 @@ class TeamAppAPIView(TeamAPIView):
 
 
 class TeamAppServiceAPIView(TeamAppAPIView):
-    def __init__(self):
-        super(TeamAppServiceAPIView, self).__init__()
-        self.service = None
+    service: TenantServiceInfo
 
-    def initial(self, request, *args, **kwargs):
+    def __init__(self) -> None:
+        super(TeamAppServiceAPIView, self).__init__()
+        self.service = None  # type: ignore[assignment]
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(TeamAppServiceAPIView, self).initial(request, *args, **kwargs)
         service_id = kwargs.get("service_id")
         self.service = TenantServiceInfo.objects.filter(
-            tenant_id=self.team.tenant_id, service_region=self.region_name, service_id=service_id).first()
+            tenant_id=self.team.tenant_id, service_region=self.region_name, service_id=service_id).first()  # type: ignore[assignment]
         if not self.service:
             self.service = TenantServiceInfo.objects.filter(
-                tenant_id=self.team.tenant_id, service_region=self.region_name, service_alias=service_id).first()
+                tenant_id=self.team.tenant_id, service_region=self.region_name, service_alias=service_id).first()  # type: ignore[assignment]
         if not self.service:
             raise ServiceHandleException(msg_show="组件不存在", msg="no found component", status_code=404)
         gsr = group_service_relation_repo.get_services_by_group(self.app.ID)
@@ -201,20 +225,20 @@ class TeamAppServiceAPIView(TeamAppAPIView):
 
 
 class EnterpriseServiceOauthView(APIView):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(EnterpriseServiceOauthView, self).__init__(*args, **kwargs)
         self.oauth_instance = None
         self.oauth = None
         self.oauth_user = None
 
-    def initial(self, request, *args, **kwargs):
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
         super(EnterpriseServiceOauthView, self).initial(request, *args, **kwargs)
         try:
-            oauth_service = OAuthServices.objects.get(oauth_type="enterprisecenter", ID=1, user_id=request.user.user_id)
+            oauth_service = OAuthServices.objects.get(oauth_type="enterprisecenter", ID=1, user_id=request.user.user_id)  # type: ignore[union-attr]
             pre_enterprise_center = os.getenv("PRE_ENTERPRISE_CENTER", None)
             if pre_enterprise_center:
-                oauth_service = OAuthServices.objects.get(name=pre_enterprise_center, oauth_type="enterprisecenter", user_id=request.user.user_id)
-            oauth_user = UserOAuthServices.objects.get(service_id=oauth_service.ID, user_id=request.user.user_id)
+                oauth_service = OAuthServices.objects.get(name=pre_enterprise_center, oauth_type="enterprisecenter", user_id=request.user.user_id)  # type: ignore[union-attr]
+            oauth_user = UserOAuthServices.objects.get(service_id=oauth_service.ID, user_id=request.user.user_id)  # type: ignore[union-attr]
         except OAuthServices.DoesNotExist:
             raise ServiceHandleException(
                 msg="not found enterprise center oauth server config", msg_show="未找到企业中心OAuth配置", status_code=404)

--- a/openapi/views/enterprise_view.py
+++ b/openapi/views/enterprise_view.py
@@ -2,6 +2,8 @@
 # creater by: barnett
 import logging
 import os
+from typing import Any
+
 from drf_yasg import openapi
 
 from console.exception.main import ServiceHandleException
@@ -24,6 +26,7 @@ from openapi.serializer.ent_serializers import (EnterpriseInfoSerializer, Enterp
                                                 UpdEntReqSerializer)
 from openapi.views.base import BaseOpenAPIView
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 from console.services.team_services import team_services
@@ -41,7 +44,7 @@ class EnterpriseInfoView(BaseOpenAPIView):
         responses={},
         tags=['openapi-entreprise'],
     )
-    def put(self, req, eid):
+    def put(self, req: Request, eid: str) -> Response:
         enterprise_services.update(eid, req.data)
         return Response(None, status=status.HTTP_200_OK)
 
@@ -50,7 +53,7 @@ class EnterpriseInfoView(BaseOpenAPIView):
         responses={200: EnterpriseInfoSerializer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, eid):
+    def get(self, req: Request, eid: str) -> Response:
         ent = enterprise_services.get_enterprise_by_id(eid)
         if ent is None:
             return Response({"msg": "企业不存在"}, status=status.HTTP_404_NOT_FOUND)
@@ -65,9 +68,10 @@ class EnterpriseSourceView(BaseOpenAPIView):
         responses={200: EnterpriseSourceSerializer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, eid):
+    def get(self, req: Request, eid: str) -> Response:
         data = {"enterprise_id": eid, "used_cpu": 0, "used_memory": 0, "used_disk": 0}
-        if not req.user.is_administrator:
+        # NOTE: request.user is User|AnonymousUser per stubs; runtime carries these attrs.
+        if not req.user.is_administrator:  # type: ignore[union-attr]
             raise ServiceHandleException(status_code=401, error_code=401, msg="Permission denied")
         ent = enterprise_services.get_enterprise_by_id(eid)
         if ent is None:
@@ -76,11 +80,13 @@ class EnterpriseSourceView(BaseOpenAPIView):
         for region in regions:
             try:
                 # Exclude development clusters
-                if "development" in region.region_type:
+                # NOTE: region_type is str|None per model; legacy membership test (backlog).
+                if "development" in region.region_type:  # type: ignore[operator]
                     logger.debug("{0} region type is development in enterprise {1}".format(region.region_name, eid))
                     continue
                 res, body = region_api.get_region_resources(eid, region=region.region_name)
-                rst = body.get("bean")
+                # NOTE: regionapi result may be None; legacy assumes dict (backlog).
+                rst = body.get("bean")  # type: ignore[union-attr]
                 if res.get("status") == 200 and rst:
                     data["used_cpu"] += rst.get("req_cpu", 0)
                     data["used_memory"] += rst.get("req_mem", 0)
@@ -94,7 +100,7 @@ class EnterpriseSourceView(BaseOpenAPIView):
 
 
 class EntUserInfoView(BaseOpenAPIView):
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page_num", 1))
         page_size = int(request.GET.get("page_size", 10))
         enterprise_id = request.GET.get("eid", None)
@@ -114,7 +120,7 @@ class EntUserInfoView(BaseOpenAPIView):
         admin_tuples = cursor.fetchall()
         for admin in admin_tuples:
             user = user_repo.get_by_user_id(user_id=admin[0])
-            bean = dict()
+            bean: dict = dict()
             if user:
                 bean["nick_name"] = user.nick_name
                 bean["phone"] = user.phone
@@ -133,12 +139,14 @@ class EnterpriseConfigView(BaseOpenAPIView):
         responses={200: EnterpriseConfigSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         key = req.GET.get("key", None)
         ent = enterprise_services.get_enterprise_by_id(self.enterprise.enterprise_id)
         if ent is None:
             return Response({"msg": "企业不存在"}, status=status.HTTP_404_NOT_FOUND)
-        ent_config = EnterpriseConfigService(self.enterprise.enterprise_id, self.user.user_id).initialization_or_get_config
+        # NOTE: user_id is int AutoField; service expects str|None (backlog).
+        ent_config = EnterpriseConfigService(
+            self.enterprise.enterprise_id, self.user.user_id).initialization_or_get_config  # type: ignore[arg-type]
         if key is None:
             serializer = EnterpriseConfigSeralizer(data=ent_config)
         elif key in list(ent_config.keys()):
@@ -156,7 +164,7 @@ class ResourceOverview(BaseOpenAPIView):
         responses={200: ResourceOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         handle = Global_resource_processing()
         handle.region_obtain_handle(self.enterprise.enterprise_id)
         handle.tenant_obtain_handle(self.enterprise.enterprise_id)
@@ -174,8 +182,9 @@ class EnterpriseOverview(BaseOpenAPIView):
         responses={200: EnterpriseOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
-        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="")
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: enterprise_id is str|None per model; service expects str (backlog).
+        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="")  # type: ignore[arg-type]
         nodes = 0
         instances = 0
         for region in regions:
@@ -187,11 +196,11 @@ class EnterpriseOverview(BaseOpenAPIView):
                 instances += region.get("run_pod_number", 0)
             elif isinstance(pods_data, (int, float)):
                 # 如果pods是数字，直接相加
-                instances += pods_data
+                instances += pods_data  # type: ignore[assignment]
             else:
                 # 其他情况使用run_pod_number作为备选
                 instances += region.get("run_pod_number", 0)
-        teams = team_services.count_teams(self.user.enterprise_id)
+        teams = team_services.count_teams(self.user.enterprise_id)  # type: ignore[arg-type]
         apps = group_repo.count_apps()
         components = service_repo.count_components()
         visual_monitor = {
@@ -225,11 +234,14 @@ class AppRankOverview(BaseOpenAPIView):
         responses={200: AppRankOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         team_name = req.GET.get("team_name", "")
-        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="", check_status="no")
-        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)
-        result = enterprise_services.get_app_ranking(regions, tenants, team_name)
+        # NOTE: enterprise_id is str|None; service expects str (backlog).
+        regions = region_services.get_enterprise_regions(
+            self.user.enterprise_id, level="", check_status="no")  # type: ignore[arg-type]
+        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)  # type: ignore[arg-type]
+        # NOTE: BUG—EnterpriseServices has no get_app_ranking; runtime AttributeError.
+        result = enterprise_services.get_app_ranking(regions, tenants, team_name)  # type: ignore[attr-defined]
         serializer = AppRankOverviewSeralizer(data=result, many=True)
         serializer.is_valid()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -241,12 +253,15 @@ class MonitorMessageOverview(BaseOpenAPIView):
         responses={200: MonitorMessageOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         team_name = req.GET.get("team_name", "")
         interval = req.GET.get("interval", 60)
-        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="", check_status="no")
-        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)
-        result = enterprise_services.get_monitor_message(regions, tenants, team_name, interval)
+        regions = region_services.get_enterprise_regions(
+            self.user.enterprise_id, level="", check_status="no")  # type: ignore[arg-type]
+        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)  # type: ignore[arg-type]
+        # NOTE: BUG—EnterpriseServices has no get_monitor_message; runtime AttributeError.
+        result = enterprise_services.get_monitor_message(regions, tenants, team_name,  # type: ignore[attr-defined]
+                                                         interval)
         serializer = MonitorMessageOverviewSeralizer(data=result, many=True)
         serializer.is_valid()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -258,7 +273,7 @@ class Performance_overview(BaseOpenAPIView):
         responses={200: PerformanceOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         result = performance_overview.get_performance_overview(self.enterprise.enterprise_id)
         serializer = PerformanceOverviewSeralizer(data=result)
         serializer.is_valid()
@@ -271,9 +286,10 @@ class ServiceOverview(BaseOpenAPIView):
         responses={200: ServieOveriewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name")
-        run_count, abnormal_count, closed_count = service_overview.get_service_overview(
+        # NOTE: BUG—service_overview is not imported/defined; runtime NameError.
+        run_count, abnormal_count, closed_count = service_overview.get_service_overview(  # type: ignore[name-defined]
             enterprise_id=self.enterprise.enterprise_id,
             region_name=region_name)
         result = {"abnormal_service_num": abnormal_count, "closed_service_num": closed_count,
@@ -283,13 +299,14 @@ class ServiceOverview(BaseOpenAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class ResourceOverview(BaseOpenAPIView):
+# NOTE: BUG—ResourceOverview is defined twice; this redefinition shadows the earlier one.
+class ResourceOverview(BaseOpenAPIView):  # type: ignore[no-redef]
     @swagger_auto_schema(
         operation_description="资源信息总览",
         responses={200: ResourceOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         handle = Global_resource_processing()
         handle.region_obtain_handle(self.enterprise.enterprise_id)
         handle.tenant_obtain_handle(self.enterprise.enterprise_id)
@@ -312,7 +329,7 @@ class MonitorQueryOverview(BaseOpenAPIView):
         responses={200: MonitorQueryOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         query = req.GET.get("query", "")
         _, body = region_api.get_query_data(region_name, "", "?query={}".format(query))
@@ -334,7 +351,7 @@ class MonitorQueryRangeOverview(BaseOpenAPIView):
         responses={200: MonitorQueryOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         query = req.GET.get("query", "")
         start = req.GET.get("start")
@@ -359,7 +376,7 @@ class MonitorSeriesOverview(BaseOpenAPIView):
         responses={200: MonitorQueryOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         match = req.GET.get("match[]")
         start = req.GET.get("start")
@@ -369,7 +386,8 @@ class MonitorSeriesOverview(BaseOpenAPIView):
             query = "{}&start={}".format(query, start)
         if end:
             query = "{}&end={}".format(query, end)
-        _, body = region_api.get_query_series(region_name, "", query)
+        # NOTE: BUG—RegionInvokeApi has no get_query_series; runtime AttributeError.
+        _, body = region_api.get_query_series(region_name, "", query)  # type: ignore[attr-defined]
         serializer = MonitorQueryOverviewSeralizer(data=body)
         serializer.is_valid()
         return Response(body, status=status.HTTP_200_OK)
@@ -381,9 +399,11 @@ class RegionsMonitorOverview(BaseOpenAPIView):
         responses={200: RegionMonitorOverviewSeralizer(many=True)},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
-        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="", check_status="no")
-        data = enterprise_services.get_exception_nodes_info(regions)
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
+        regions = region_services.get_enterprise_regions(
+            self.user.enterprise_id, level="", check_status="no")  # type: ignore[arg-type]
+        # NOTE: BUG—EnterpriseServices has no get_exception_nodes_info; runtime AttributeError.
+        data = enterprise_services.get_exception_nodes_info(regions)  # type: ignore[attr-defined]
         serializer = RegionMonitorOverviewSeralizer(data=data, many=True)
         serializer.is_valid()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -401,13 +421,16 @@ class InstancesMonitorOverview(BaseOpenAPIView):
         responses={200: InstancesMonitorOverviewSeralizer(many=True)},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         region_name = req.GET.get("region_name", "")
         node_name = req.GET.get("node_name", "")
         query = req.GET.get("query", "")
-        regions = region_services.get_enterprise_regions(self.user.enterprise_id, level="", check_status="no")
-        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)
-        result = enterprise_services.get_instances_monitor(regions, tenants, region_name, node_name, query)
+        regions = region_services.get_enterprise_regions(
+            self.user.enterprise_id, level="", check_status="no")  # type: ignore[arg-type]
+        tenants, _ = team_services.get_enterprise_teams(self.user.enterprise_id)  # type: ignore[arg-type]
+        # NOTE: BUG—EnterpriseServices has no get_instances_monitor; runtime AttributeError.
+        result = enterprise_services.get_instances_monitor(regions, tenants,  # type: ignore[attr-defined]
+                                                           region_name, node_name, query)
         serializer = InstancesMonitorOverviewSeralizer(data=result, many=True)
         serializer.is_valid()
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -419,7 +442,7 @@ class ComponentMemoryOverview(BaseOpenAPIView):
         responses={200: ComponentMemoryOverviewSeralizer},
         tags=['openapi-entreprise'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         from console.services.component_memory_processing import Component_memory_processing
         handle = Component_memory_processing()
         handle.region_obtain_handle(self.enterprise.enterprise_id)

--- a/openapi/views/gateway/gateway.py
+++ b/openapi/views/gateway/gateway.py
@@ -5,6 +5,7 @@
 # creater by: barnett
 
 import logging
+from typing import Any
 
 from console.constants import DomainType
 from console.exception.main import ServiceHandleException
@@ -21,6 +22,7 @@ from openapi.serializer.gateway_serializer import (EnterpriseHTTPGatewayRuleSeri
 from openapi.views.base import BaseOpenAPIView, TeamAppAPIView
 from openapi.views.exceptions import ErrAppNotFound
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.apiclient.regionapi import RegionInvokeApi
 
@@ -37,7 +39,7 @@ class ListAppGatewayHTTPRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer(many=True)},
         tags=['openapi-gateway'],
     )
-    def get(self, req, app_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
         if not app:
             raise ErrAppNotFound
@@ -54,7 +56,7 @@ class ListAppGatewayHTTPRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         ads = PostHTTPGatewayRuleSerializer(data=request.data)
         ads.is_valid(raise_exception=True)
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
@@ -120,7 +122,7 @@ class ListEnterpriseAppGatewayHTTPRuleView(BaseOpenAPIView):
         responses={200: EnterpriseHTTPGatewayRuleSerializer(many=True)},
         tags=['openapi-gateway'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         auto_ssl = req.GET.get("auto_ssl", None)
         is_auto_ssl = None
         if auto_ssl is not None:
@@ -144,7 +146,7 @@ class UpdateAppGatewayHTTPRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def get(self, req, app_id, rule_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         rule = domain_service.get_http_rules_by_app_id(self.app.ID).filter(http_rule_id=rule_id).first()
         re = HTTPGatewayRuleSerializer(rule)
         return Response(re.data, status=status.HTTP_200_OK)
@@ -159,7 +161,7 @@ class UpdateAppGatewayHTTPRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def put(self, request, app_id, rule_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         ads = UpdatePostHTTPGatewayRuleSerializer(data=request.data)
         ads.is_valid(raise_exception=True)
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
@@ -182,7 +184,7 @@ class UpdateAppGatewayHTTPRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def delete(self, request, app_id, rule_id, *args, **kwargs):
+    def delete(self, request: Request, app_id: str, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         rule = domain_service.get_http_rule_by_id(self.team.tenant_id, rule_id)
         if not rule:
             raise ErrNotFoundDomain
@@ -201,7 +203,7 @@ class ListAppGatewayRuleView(TeamAppAPIView):
         responses={200: GatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def get(self, req, app_id, *args, **kwargs):
+    def get(self, req: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         query = req.GET.get("query", None)
         data = {}
         if query == "http":
@@ -225,7 +227,7 @@ class ListAppGatewayRuleView(TeamAppAPIView):
         responses={200: GatewayRuleSerializer()},
         tags=['openapi-apps'],
     )
-    def post(self, request, app_id, *args, **kwargs):
+    def post(self, request: Request, app_id: str, *args: Any, **kwargs: Any) -> Response:
         ads = PostGatewayRuleSerializer(data=request.data)
         ads.is_valid(raise_exception=True)
         if ads.data.get("protocol") == "tcp":
@@ -255,9 +257,9 @@ class ListAppGatewayRuleView(TeamAppAPIView):
             try:
                 tenant_service_port = port_service.get_service_port_by_port(service, container_port)
                 # 仅打开对外端口
-                code, msg, data = port_service.manage_port(self.team, service, service.service_region,
-                                                           int(tenant_service_port.container_port), "only_open_outer",
-                                                           tenant_service_port.protocol, tenant_service_port.port_alias)
+                code, msg, port_data = port_service.manage_port(self.team, service, service.service_region,
+                                                               int(tenant_service_port.container_port), "only_open_outer",
+                                                               tenant_service_port.protocol, tenant_service_port.port_alias)
                 if code != 200:
                     raise ServiceHandleException(status_code=code, msg="change port fail", msg_show=msg)
             except Exception as e:
@@ -295,9 +297,9 @@ class ListAppGatewayRuleView(TeamAppAPIView):
             if httpdomain.get("whether_open", True):
                 tenant_service_port = port_service.get_service_port_by_port(service, httpdomain["container_port"])
                 # 仅开启对外端口
-                code, msg, data = port_service.manage_port(self.team, service, service.service_region,
-                                                           int(tenant_service_port.container_port), "only_open_outer",
-                                                           tenant_service_port.protocol, tenant_service_port.port_alias)
+                code, msg, port_data = port_service.manage_port(self.team, service, service.service_region,
+                                                               int(tenant_service_port.container_port), "only_open_outer",
+                                                               tenant_service_port.protocol, tenant_service_port.port_alias)
                 if code != 200:
                     return Response({"msg": "change port fail"}, status=code)
             tenant_service_port = port_service.get_service_port_by_port(service, httpdomain["container_port"])
@@ -327,7 +329,7 @@ class UpdateAppGatewayRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def put(self, request, app_id, rule_id, *args, **kwargs):
+    def put(self, request: Request, app_id: str, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         ads = UpdatePostHTTPGatewayRuleSerializer(data=request.data)
         ads.is_valid(raise_exception=True)
         app = group_service.get_app_by_id(self.team, self.region_name, app_id)
@@ -350,7 +352,7 @@ class UpdateAppGatewayRuleView(TeamAppAPIView):
         responses={200: HTTPGatewayRuleSerializer()},
         tags=['openapi-gateway'],
     )
-    def delete(self, request, app_id, rule_id, *args, **kwargs):
+    def delete(self, request: Request, app_id: str, rule_id: str, *args: Any, **kwargs: Any) -> Response:
         rule = domain_service.get_http_rule_by_id(self.team.tenant_id, rule_id)
         if not rule:
             raise ErrNotFoundDomain

--- a/openapi/views/groupapp.py
+++ b/openapi/views/groupapp.py
@@ -3,10 +3,12 @@
   Created on 18/5/23.
 """
 import logging
+from typing import Any
 
 from console.utils.cache_decorators import never_cache
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.app_config.domain_service import domain_service
@@ -25,7 +27,7 @@ class GroupAppsCopyView(TeamAPIView):
         tags=['openapi-apps'],
     )
     @never_cache
-    def get(self, request, team_id, app_id, **kwargs):
+    def get(self, request: Request, team_id: str, app_id: str, **kwargs: Any) -> Response:
         group_services = groupapp_copy_service.get_group_services_with_build_source(
             self.team, self.region_name, group_id=app_id)
         serializer = AppCopyLSerializer(data=group_services, many=True)
@@ -43,7 +45,7 @@ class GroupAppsCopyView(TeamAPIView):
         tags=['openapi-apps'],
     )
     @never_cache
-    def post(self, request, team_id, app_id, *args, **kwargs):
+    def post(self, request: Request, team_id: str, app_id: str, *args: Any, **kwargs: Any) -> Response:
         """
         应用复制
         ---
@@ -65,11 +67,14 @@ class GroupAppsCopyView(TeamAPIView):
         tar_team_name = request.data.get("target_team_name")
         tar_region_name = request.data.get("target_region_name")
         tar_app_id = request.data.get("target_app_id")
-        tar_team, tar_group = groupapp_copy_service.check_and_get_team_group(request.user, tar_team_name, tar_region_name,
-                                                                             tar_app_id)
-        services = groupapp_copy_service.copy_group_services(request.user, self.team, self.region_name, tar_team,
-                                                             tar_region_name, tar_group, app_id, services)
-        services = domain_service.get_components_that_contains_gateway_rules(tar_region_name, services)
+        # NOTE: request.data.get(...) yields Optional; legacy passes to str params (backlog).
+        tar_team, tar_group = groupapp_copy_service.check_and_get_team_group(
+            request.user, tar_team_name, tar_region_name, tar_app_id)  # type: ignore[arg-type]
+        services = groupapp_copy_service.copy_group_services(
+            request.user, self.team, self.region_name, tar_team,
+            tar_region_name, tar_group, app_id, services)  # type: ignore[arg-type]
+        services = domain_service.get_components_that_contains_gateway_rules(
+            tar_region_name, services)  # type: ignore[arg-type]
         services = ServiceBaseInfoSerializer(data=services, many=True)
         services.is_valid()
         serializers = AppCopyCResSerializer(data={"services": services.data})

--- a/openapi/views/region_view.py
+++ b/openapi/views/region_view.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.exception.exceptions import RegionUnreachableError
@@ -29,7 +31,7 @@ class ListRegionInfo(BaseOpenAPIView):
 
     @swagger_auto_schema(
         responses={200: RegionInfoRespSerializer(many=True)}, tags=['openapi-region'], operation_description="获取全部数据中心列表")
-    def get(self, req):
+    def get(self, req: Request) -> Response:
         regions = region_services.get_enterprise_regions(self.enterprise.enterprise_id, level="")
         serializer = RegionInfoRespSerializer(data=regions, many=True)
         serializer.is_valid(raise_exception=True)
@@ -63,13 +65,14 @@ class ListRegionInfo(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             serializer = RegionInfoSerializer(data=request.data)
             serializer.is_valid(raise_exception=True)
             region_data = serializer.data
             region_data["region_id"] = make_uuid()
-            region = region_services.add_region(region_data, request.user)
+            # NOTE: request.user typed as User|AnonymousUser per stubs.
+            region = region_services.add_region(region_data, request.user)  # type: ignore[arg-type]
             serializer = RegionInfoSerializer(region)
             if region:
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -93,7 +96,7 @@ class RegionInfo(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def get(self, request, region_id, *args, **kwargs):
+    def get(self, request: Request, region_id: str, *args: Any, **kwargs: Any) -> Response:
         extend_info = request.GET.get("extend_info", False)
         if extend_info == "true":
             extend_info = True
@@ -104,8 +107,9 @@ class RegionInfo(BaseOpenAPIView):
         if not self.region:
             raise ServiceHandleException(msg="no found region", msg_show="数据中心不存在", status_code=404)
 
+        # NOTE: legacy — extend_info is reused as both bool and str ("yes"); param typed bool.
         data = region_services.get_enterprise_region(
-            self.enterprise.enterprise_id, self.region.region_id, check_status=extend_info)
+            self.enterprise.enterprise_id, self.region.region_id, check_status=extend_info)  # type: ignore[arg-type]
         serializers = RegionInfoRSerializer(data=data)
         serializers.is_valid(raise_exception=True)
         return Response(serializers.data, status=200)
@@ -166,19 +170,20 @@ class RegionStatusView(BaseOpenAPIView):
         },
         tags=['openapi-region'],
     )
-    def put(self, req, region_id):
+    def put(self, req: Request, region_id: str) -> Response:
         serializer = UpdateRegionStatusReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
         try:
             region = region_services.update_region_status(region_id, req.data["status"])
-            serializer = RegionInfoSerializer(region)
-            return Response(serializer.data, status.HTTP_200_OK)
+            resp_serializer = RegionInfoSerializer(region)
+            return Response(resp_serializer.data, status.HTTP_200_OK)
         except RegionConfig.DoesNotExist:
             fs = FailSerializer({"msg": "数据中心不存在"})
             return Response(fs.data, status.HTTP_404_NOT_FOUND)
         except RegionUnreachableError as e:
-            fs = FailSerializer({"msg": e.message})
+            # NOTE: py2-style Exception.message attribute, absent in py3.
+            fs = FailSerializer({"msg": e.message})  # type: ignore[attr-defined]
             return Response(fs.data, status.HTTP_400_BAD_REQUEST)
 
 
@@ -187,7 +192,7 @@ class ReplaceRegionIP(BaseOpenAPIView):
         operation_description="通过grctl修改region ip",
         tags=['openapi-region'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         region_name = request.data.get("region_name", "")
         region_info = region_services.get_by_region_name(region_name)
         region_id = region_info.region_id

--- a/openapi/views/team_view.py
+++ b/openapi/views/team_view.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import time
+from typing import Any
 
 from console.exception.exceptions import UserNotExistError
 from console.exception.main import ServiceHandleException
@@ -29,6 +30,7 @@ from openapi.serializer.utils import pagination
 from openapi.views.base import (BaseOpenAPIView, TeamAPIView, TeamNoRegionAPIView)
 from openapi.views.exceptions import ErrRegionNotFound, ErrTeamNotFound
 from rest_framework import exceptions, serializers, status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.models.main import PermRelTenant, TenantRegionInfo, Tenants
 from www.utils.crypt import make_uuid, make_uuid3
@@ -42,7 +44,7 @@ class EntAppModelView(BaseOpenAPIView):
         responses={200: None},
         tags=['openapi-entreprise'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         try:
             # 获取请求参数
             app_name = request.data.get("app_name")
@@ -97,7 +99,8 @@ class EntAppModelView(BaseOpenAPIView):
                 app_version.app_version_info = app_version_info
                 app_version.app_template = json.dumps(app_template)
                 app_version.arch = arch
-                app_version.upgrade_time = time.time()
+                # NOTE: legacy stores epoch float into a str/int upgrade_time field.
+                app_version.upgrade_time = time.time()  # type: ignore[assignment]
                 app_version.save()
                 msg = "版本已更新"
             except RainbondCenterAppVersion.DoesNotExist:
@@ -118,7 +121,7 @@ class EntAppModelView(BaseOpenAPIView):
                     enterprise_id=enterprise_id,
                     arch=arch,
                     is_complete=True,
-                    upgrade_time=time.time()
+                    upgrade_time=time.time()  # type: ignore[misc]
                 )
                 app_version.save()
                 msg = "版本已创建"
@@ -141,7 +144,7 @@ class ListTeamInfo(BaseOpenAPIView):
         responses={200: ListTeamRespSerializer()},
         tags=['openapi-team'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         query = req.GET.get("query", "")
         try:
             page = int(req.GET.get("page", 1))
@@ -151,8 +154,11 @@ class ListTeamInfo(BaseOpenAPIView):
             page_size = int(req.GET.get("page_size", 10))
         except ValueError:
             page_size = 10
+        # NOTE: request.user typed as User|AnonymousUser per stubs.
         tenants, total = team_services.list_teams_by_user_id(
-            eid=self.enterprise.enterprise_id, user_id=req.user.user_id, query=query, page=page, page_size=page_size)
+            eid=self.enterprise.enterprise_id,
+            user_id=req.user.user_id,  # type: ignore[union-attr]
+            query=query, page=page, page_size=page_size)
         result = {"tenants": tenants, "total": total, "page": page, "page_size": page_size}
         serializer = ListTeamRespSerializer(data=result)
         return Response(serializer.initial_data, status.HTTP_200_OK)
@@ -165,7 +171,7 @@ class ListTeamInfo(BaseOpenAPIView):
         },
         tags=['openapi-team'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         serializer = CreateTeamReqSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         team_data = serializer.data
@@ -177,13 +183,14 @@ class ListTeamInfo(BaseOpenAPIView):
             raise serializers.ValidationError("指定企业不存在")
         region = None
         if team_data.get("region", None):
-            region = region_services.get_region_by_region_name(team_data.get("region"))
+            # NOTE: serializer .get() yields Any|None; region name param is non-Optional.
+            region = region_services.get_region_by_region_name(team_data.get("region"))  # type: ignore[arg-type]
             if not region:
                 raise ErrRegionNotFound
         try:
             user = user_services.get_user_by_user_id(team_data.get("creater", 0))
         except UserNotExistError:
-            user = request.user
+            user = request.user  # type: ignore[assignment]
         team = team_services.create_team(user, en, team_alias=team_data["tenant_name"])
         if region:
             region_services.create_tenant_on_region(self.enterprise.enterprise_id, team.tenant_name, region.region_name,
@@ -200,7 +207,7 @@ class TeamInfo(TeamNoRegionAPIView):
         },
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, *args, **kwargs):
+    def get(self, request: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             queryset = team_services.get_team_by_team_id(team_id.strip())
             serializer = TeamInfoSerializer(queryset)
@@ -213,15 +220,18 @@ class TeamInfo(TeamNoRegionAPIView):
         responses={},
         tags=['openapi-team'],
     )
-    def delete(self, req, team_id, *args, **kwargs):
+    def delete(self, req: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             team_services.delete_by_tenant_id(self.user, self.team)
             return Response(None, status.HTTP_200_OK)
         except Tenants.DoesNotExist as e:
-            logger.exception("failed to delete tenant: {}".format(e.message))
+            # NOTE: py2-style Exception.message attribute, absent in py3.
+            logger.exception("failed to delete tenant: {}".format(e.message))  # type: ignore[attr-defined]
             return Response(None, status=status.HTTP_404_NOT_FOUND)
-        except PermRelTenant as e:
-            logger.exception("failed to delete tenant: {}".format(e.message))
+        # NOTE: legacy bug — PermRelTenant is a Django model, not an exception class;
+        # this except clause can never match. Behavior preserved.
+        except PermRelTenant as e:  # type: ignore[misc]
+            logger.exception("failed to delete tenant: {}".format(e.message))  # type: ignore[attr-defined]
             return Response(None, status=status.HTTP_404_NOT_FOUND)
 
     @swagger_auto_schema(
@@ -230,19 +240,23 @@ class TeamInfo(TeamNoRegionAPIView):
         responses={},
         tags=['openapi-team'],
     )
-    def put(self, req, team_id, *args, **kwargs):
+    def put(self, req: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = UpdateTeamInfoReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
         if req.data.get("enterprise_id", ""):
             ent = enterprise_services.get_enterprise_by_enterprise_id(req.data["enterprise_id"])
             if not ent:
-                raise serializers.ValidationError("指定企业不存在", status.HTTP_404_NOT_FOUND)
+                # NOTE: legacy bug — ValidationError 2nd arg is `code` (str), not HTTP status.
+                raise serializers.ValidationError(
+                    "指定企业不存在", status.HTTP_404_NOT_FOUND)  # type: ignore[arg-type]
         if req.data.get("creator", 0):
             try:
-                ent = user_services.get_user_by_user_id(req.data.get("creator"))
+                # NOTE: legacy reuses `ent` for both enterprise and user objects; .get() yields Any|None.
+                ent = user_services.get_user_by_user_id(req.data.get("creator"))  # type: ignore[assignment,arg-type]
             except UserNotExistError:
-                raise serializers.ValidationError("指定用户不存在", status.HTTP_404_NOT_FOUND)
+                raise serializers.ValidationError(
+                    "指定用户不存在", status.HTTP_404_NOT_FOUND)  # type: ignore[arg-type]
 
         try:
             team_services.update(team_id, req.data)
@@ -259,16 +273,17 @@ class TeamUserInfoView(TeamAPIView):
         },
         tags=['openapi-team'],
     )
-    def delete(self, req, team_id, user_id):
-        if req.user.user_id == user_id:
-            raise serializers.ValidationError("不能删除自己", status.HTTP_400_BAD_REQUEST)
+    def delete(self, req: Request, team_id: str, user_id: str) -> Response:
+        if req.user.user_id == user_id:  # type: ignore[union-attr]
+            raise serializers.ValidationError(
+                "不能删除自己", status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
 
         try:
             user_services.get_user_by_tenant_id(team_id, user_id)
             user_services.batch_delete_users(team_id, [user_id])
             return Response(None, status.HTTP_200_OK)
         except UserNotExistError as e:
-            return Response({"msg": e.message}, status.HTTP_404_NOT_FOUND)
+            return Response({"msg": e.message}, status.HTTP_404_NOT_FOUND)  # type: ignore[attr-defined]
         except Tenants.DoesNotExist:
             return Response({"msg": "团队不存在"}, status.HTTP_404_NOT_FOUND)
 
@@ -278,7 +293,7 @@ class TeamUserInfoView(TeamAPIView):
         responses={},
         tags=['openapi-team'],
     )
-    def post(self, req, team_id, user_id):
+    def post(self, req: Request, team_id: str, user_id: str) -> Response:
         serializer = CreateTeamUserReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
         role_ids = req.data["role_ids"].replace(" ", "").split(",")
@@ -294,9 +309,10 @@ class TeamUserInfoView(TeamAPIView):
         tags=['openapi-team'],
     )
     # TODO 修改权限控制
-    def put(self, req, team_id, user_id):
-        if req.user.user_id == user_id:
-            raise serializers.ValidationError("您不能修改自己的权限!", status.HTTP_400_BAD_REQUEST)
+    def put(self, req: Request, team_id: str, user_id: str) -> Response:
+        if req.user.user_id == user_id:  # type: ignore[union-attr]
+            raise serializers.ValidationError(
+                "您不能修改自己的权限!", status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
 
         serializer = CreateTeamUserReqSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
@@ -318,7 +334,7 @@ class ListRegionsView(TeamNoRegionAPIView):
         responses={200: ListTeamRegionsRespSerializer()},
         tags=['openapi-team-region'],
     )
-    def get(self, req, team_id, *args, **kwargs):
+    def get(self, req: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         query = req.GET.get("query", "")
         try:
             page = int(req.GET.get("page", 1))
@@ -345,19 +361,22 @@ class ListRegionsView(TeamNoRegionAPIView):
         },
         tags=['openapi-team-region'],
     )
-    def post(self, request, team_id, *args, **kwargs):
+    def post(self, request: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = TeamRegionReqSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         team_data = serializer.data
 
         region = None
         if team_data.get("region", None):
-            region = region_services.get_region_by_region_name(team_data.get("region"))
+            region = region_services.get_region_by_region_name(team_data.get("region"))  # type: ignore[arg-type]
             if not region:
                 raise ErrRegionNotFound
         team = team_services.get_team_by_team_id(team_id)
-        region_services.create_tenant_on_region(self.enterprise.enterprise_id, team.tenant_name, region.region_name,
-                                                team.namespace)
+        # NOTE: legacy — region may be None when payload omits region; backlog null-safety.
+        region_services.create_tenant_on_region(
+            self.enterprise.enterprise_id, team.tenant_name,
+            region.region_name,  # type: ignore[union-attr]
+            team.namespace)
         re = TeamBaseInfoSerializer(team)
         return Response(re.data, status=status.HTTP_201_CREATED)
 
@@ -368,7 +387,7 @@ class TeamRegionView(TeamNoRegionAPIView):
         responses={},
         tags=['openapi-team-region'],
     )
-    def delete(self, request, team_id):
+    def delete(self, request: Request, team_id: str) -> Response:
         serializer = TeamRegionReqSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         team_data = serializer.data
@@ -377,7 +396,10 @@ class TeamRegionView(TeamNoRegionAPIView):
             region = region_services.get_region_by_region_name(region)
             if not region:
                 raise serializers.ValidationError("指定数据中心不存在")
-        code, msg, team = team_services.delete_team_region(self.team.tenant_id, region)
+        # NOTE: latent bug — delete_team_region returns None, so this tuple-unpack
+        # would raise at runtime; arg also typed str. Behavior preserved.
+        code, msg, team = team_services.delete_team_region(  # type: ignore[func-returns-value]
+            self.team.tenant_id, region)  # type: ignore[arg-type]
         if code == 200:
             re = TeamBaseInfoSerializer(team)
             return Response(re.data, status=status.HTTP_200_OK)
@@ -395,7 +417,7 @@ class ListRegionTeamServicesView(BaseOpenAPIView):
         responses={200: ListRegionTeamServicesSerializer()},
         tags=['openapi-team'],
     )
-    def get(self, req, team_id, region_name, *args, **kwargs):
+    def get(self, req: Request, team_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         services = region_services.list_services_by_tenant_name(region_name, team_id)
         total = len(services)
         data = {"services": services, "total": total}
@@ -403,7 +425,7 @@ class ListRegionTeamServicesView(BaseOpenAPIView):
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data, status.HTTP_200_OK)
 
-    def delete(self, request, team_id, region_name):
+    def delete(self, request: Request, team_id: str, region_name: str) -> Response:
         try:
             team_services.delete_team_region(team_id, region_name)
         except (Tenants.DoesNotExist, RegionConfig.DoesNotExist, ErrTenantRegionNotFound):
@@ -422,7 +444,7 @@ class TeamCertificatesLCView(TeamNoRegionAPIView):
         responses={200: TeamCertificatesLSerializer()},
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, *args, **kwargs):
+    def get(self, request: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         certificates, nums = domain_service.get_certificate(self.team, page, page_size)
@@ -439,7 +461,7 @@ class TeamCertificatesLCView(TeamNoRegionAPIView):
         },
         tags=['openapi-team'],
     )
-    def post(self, request, team_id, *args, **kwargs):
+    def post(self, request: Request, team_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = TeamCertificatesCSerializer(data=request.data)
         serializer.is_valid()
         data = serializer.data
@@ -460,8 +482,9 @@ class TeamCertificatesRUDView(TeamNoRegionAPIView):
         responses={200: TeamCertificatesRSerializer()},
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, certificate_id, *args, **kwargs):
-        code, msg, certificate = domain_service.get_certificate_by_pk(certificate_id)
+    def get(self, request: Request, team_id: str, certificate_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: certificate_id arrives as str path param; service param typed int.
+        code, msg, certificate = domain_service.get_certificate_by_pk(certificate_id)  # type: ignore[arg-type]
         if code != 200:
             raise ServiceHandleException(msg=None, status_code=code, msg_show=msg)
         serializer = TeamCertificatesRSerializer(data=certificate)
@@ -476,7 +499,7 @@ class TeamCertificatesRUDView(TeamNoRegionAPIView):
         },
         tags=['openapi-team'],
     )
-    def put(self, request, team_id, certificate_id, *args, **kwargs):
+    def put(self, request: Request, team_id: str, certificate_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = TeamCertificatesCSerializer(data=request.data)
 
         serializer.is_valid()
@@ -496,8 +519,10 @@ class TeamCertificatesRUDView(TeamNoRegionAPIView):
         responses={},
         tags=['openapi-team'],
     )
-    def delete(self, request, team_id, certificate_id, *args, **kwargs):
-        domain_service.delete_certificate_by_pk(None, self.team, certificate_id)
+    def delete(self, request: Request, team_id: str, certificate_id: str, *args: Any, **kwargs: Any) -> Response:
+        # NOTE: legacy passes None for region and str certificate_id; params typed str/int.
+        domain_service.delete_certificate_by_pk(
+            None, self.team, certificate_id)  # type: ignore[arg-type]
         return Response(data=None, status=status.HTTP_200_OK)
 
 
@@ -509,7 +534,7 @@ class TeamAppsResourceView(TeamAPIView):
         },
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, region_name, *args, **kwargs):
+    def get(self, request: Request, team_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         data = team_services.get_tenant_resource(self.team, self.region_name)
         serializer = TeamAppsResourceSerializer(data=data)
         serializer.is_valid(raise_exception=True)
@@ -524,7 +549,7 @@ class TeamOverviewView(TeamAPIView):
         },
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, region_name, *args, **kwargs):
+    def get(self, request: Request, team_id: str, region_name: str, *args: Any, **kwargs: Any) -> Response:
         data = team_services.overview(self.team, self.region_name)
         serializer = TeamOverviewSerializer(data=data)
         serializer.is_valid(raise_exception=True)
@@ -540,8 +565,8 @@ class TeamsResourceView(BaseOpenAPIView):
         },
         tags=['openapi-team'],
     )
-    def post(self, request, *args, **kwargs):
-        resources = []
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        resources: list = []
         serializer = TenantRegionListSerializer(data=request.data, many=True)
         serializer.is_valid(raise_exception=True)
         for tenant in serializer.data:
@@ -552,7 +577,8 @@ class TeamsResourceView(BaseOpenAPIView):
                 tenant_id=tenant_id, enterprise_id=self.enterprise.enterprise_id, region_name=region_name).first()
             if team_region:
                 team = team_services.get_team_by_team_id(tenant_id)
-            data = team_services.get_tenant_resource(team, region_name)
+            # NOTE: team may be None when team_region missing; param typed non-Optional.
+            data = team_services.get_tenant_resource(team, region_name)  # type: ignore[arg-type]
             if data:
                 resources.append(data)
         serializer = TeamAppsResourceSerializer(data=resources, many=True)
@@ -573,7 +599,7 @@ class TeamEventLogView(TeamAPIView):
         },
         tags=['openapi-team'],
     )
-    def get(self, request, team_id, region_name, event_id, *args, **kwargs):
+    def get(self, request: Request, team_id: str, region_name: str, event_id: str, *args: Any, **kwargs: Any) -> Response:
         log_content = event_service.get_event_log(self.team, region_name, event_id)
         re = TeamEventLogSerializer(data={"logs": log_content})
         re.is_valid(raise_exception=True)

--- a/openapi/views/upload_view.py
+++ b/openapi/views/upload_view.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
 from rest_framework import status
 from rest_framework.parsers import MultiPartParser
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from console.services.file_upload_service import upload_service
@@ -29,20 +31,21 @@ class UploadView(BaseOpenAPIView):
         responses={status.HTTP_200_OK: UploadFileRespSerializer()},
         tags=['openapi-upload'],
     )
-    def post(self, request):
+    def post(self, request: Request) -> Response:
         req = UploadFileReqSerializer(data=request.FILES)
         req.is_valid(raise_exception=True)
 
         if not request.FILES or not request.FILES.get('file'):
-            raise serializers.ValidationError("请指定需要上传的文件", status.HTTP_400_BAD_REQUEST)
+            # NOTE: DRF ValidationError 2nd arg is `code` (str|None); legacy passes status int.
+            raise serializers.ValidationError("请指定需要上传的文件", status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
         upload_file = request.FILES.get('file')
         if upload_file.size > 1048576 * 2:
-            raise serializers.ValidationError("图片大小不能超过2M", status.HTTP_400_BAD_REQUEST)
+            raise serializers.ValidationError("图片大小不能超过2M", status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
 
         suffix = upload_file.name.split('.')[-1]
         file_url = upload_service.upload_file(upload_file, suffix)
         if not file_url:
-            raise serializers.ValidationError("上传失败", status.HTTP_400_BAD_REQUEST)
+            raise serializers.ValidationError("上传失败", status.HTTP_400_BAD_REQUEST)  # type: ignore[arg-type]
 
         serializer = UploadFileRespSerializer(data={"file_url": file_url})
         serializer.is_valid(raise_exception=True)

--- a/openapi/views/user_view.py
+++ b/openapi/views/user_view.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # creater by: barnett
 import logging
+from typing import Any
 
 from console.exception.exceptions import (EmailExistError, PhoneExistError, UserExistError, UserNotExistError)
 from console.exception.main import ServiceHandleException
@@ -17,6 +18,7 @@ from openapi.serializer.user_serializer import (ChangePassWdSerializer, ChangePa
                                                 ListUsersRespView, UpdateUserSerializer, UserInfoSerializer)
 from openapi.views.base import BaseOpenAPIView
 from rest_framework import serializers, status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from www.models.main import Users, Tenants
 from www.utils.return_message import general_message
@@ -35,7 +37,7 @@ class ListUsersView(BaseOpenAPIView):
         responses={200: ListUsersRespView()},
         tags=['openapi-user'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         try:
             page = int(req.GET.get("page", 1))
         except ValueError:
@@ -59,7 +61,7 @@ class ListUsersView(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def post(self, req, *args, **kwargs):
+    def post(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = CreateUserSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
 
@@ -70,7 +72,8 @@ class ListUsersView(BaseOpenAPIView):
             user_services.create(req.data)
             return Response(None, status.HTTP_201_CREATED)
         except (UserExistError, EmailExistError, PhoneExistError) as e:
-            return Response(e.message, status.HTTP_400_BAD_REQUEST)
+            # NOTE: py2-style Exception.message attr not in stubs.
+            return Response(e.message, status.HTTP_400_BAD_REQUEST)  # type: ignore[union-attr]
 
 
 class UserInfoView(BaseOpenAPIView):
@@ -79,13 +82,15 @@ class UserInfoView(BaseOpenAPIView):
         responses={200: UserInfoSerializer()},
         tags=['openapi-user'],
     )
-    def get(self, req, user_id, *args, **kwargs):
+    def get(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             uid = int(user_id)
-            user = user_services.get_user_by_user_id(uid)
+            user = user_services.get_user_by_user_id(uid)  # type: ignore[arg-type]
         except (ValueError, UserNotExistError):
             try:
-                user = user_services.get_user_by_user_name(req.user.enterprise_id, user_id)
+                # NOTE: get_user_by_user_name may return None; user later used unguarded (assignment).
+                user = user_services.get_user_by_user_name(
+                    req.user.enterprise_id, user_id)  # type: ignore[union-attr, assignment]
             except UserNotExistError:
                 return Response(None, status.HTTP_404_NOT_FOUND)
         serializer = UserInfoSerializer(user)
@@ -96,7 +101,7 @@ class UserInfoView(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def delete(self, req, user_id, *args, **kwargs):
+    def delete(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
         try:
             user_services.delete_user(user_id)
             return Response()
@@ -109,7 +114,7 @@ class UserInfoView(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def put(self, req, user_id, *args, **kwargs):
+    def put(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
         serializer = UpdateUserSerializer(data=req.data)
         serializer.is_valid(raise_exception=True)
         try:
@@ -126,7 +131,7 @@ class ChangePassword(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改密码
         ---
@@ -148,14 +153,19 @@ class ChangePassword(BaseOpenAPIView):
         new_password1 = serializer.data.get("password1", None)
         info = "缺少参数"
         if new_password and new_password == new_password1:
-            status, info = user_services.update_password(user_id=request.user.user_id, new_password=new_password)
-            oauth_instance, _ = user_services.check_user_is_enterprise_center_user(request.user.user_id)
+            status, info = user_services.update_password(
+                user_id=request.user.user_id, new_password=new_password)  # type: ignore[union-attr]
+            oauth_instance, _ = user_services.check_user_is_enterprise_center_user(
+                request.user.user_id)  # type: ignore[union-attr]
             if oauth_instance:
                 data = {
                     "password": new_password,
-                    "real_name": request.user.real_name,
+                    # NOTE: request.user typed User|AnonymousUser by stubs; runtime is User.
+                    "real_name": request.user.real_name,  # type: ignore[union-attr]
                 }
-                oauth_instance.update_user(request.user.enterprise_id, request.user.enterprise_center_user_id, data)
+                oauth_instance.update_user(
+                    request.user.enterprise_id,  # type: ignore[union-attr]
+                    request.user.enterprise_center_user_id, data)  # type: ignore[union-attr]
             if status:
                 return Response(None, status=200)
         logger.debug(info)
@@ -169,7 +179,7 @@ class ChangeUserPassword(BaseOpenAPIView):
         responses={},
         tags=['openapi-user'],
     )
-    def put(self, request, *args, **kwargs):
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         修改密码
         ---
@@ -196,18 +206,24 @@ class ChangeUserPassword(BaseOpenAPIView):
         new_password = serializer.data.get("password", None)
         new_password1 = serializer.data.get("password1", None)
         info = "缺少参数"
-        user = user_repo.get_enterprise_user_by_id(request.user.enterprise_id, user_id)
+        # NOTE: serializer.data values typed Any|None; runtime str (arg-type).
+        user = user_repo.get_enterprise_user_by_id(
+            request.user.enterprise_id, user_id)  # type: ignore[union-attr, arg-type]
         if not user:
             raise ServiceHandleException(msg="no found user", msg_show="用户不存在", status_code=404)
         if new_password and new_password == new_password1:
-            status, info = user_services.update_password(user_id=user_id, new_password=new_password)
-            oauth_instance, _ = user_services.check_user_is_enterprise_center_user(user_id)
+            status, info = user_services.update_password(
+                user_id=user_id, new_password=new_password)  # type: ignore[arg-type]
+            oauth_instance, _ = user_services.check_user_is_enterprise_center_user(user_id)  # type: ignore[arg-type]
             if oauth_instance:
                 data = {
                     "password": new_password,
                     "real_name": user.real_name,
                 }
-                oauth_instance.update_user(request.user.enterprise_id, user.enterprise_center_user_id, data)
+                # NOTE: Users model has no enterprise_center_user_id attr (latent bug; backlog).
+                oauth_instance.update_user(
+                    request.user.enterprise_id,  # type: ignore[union-attr]
+                    user.enterprise_center_user_id, data)  # type: ignore[attr-defined]
             if status:
                 return Response(None, status=200)
         logger.debug(info)
@@ -220,9 +236,9 @@ class CurrentUsersView(BaseOpenAPIView):
         manual_parameters=[],
         tags=['openapi-user'],
     )
-    def get(self, req, *args, **kwargs):
+    def get(self, req: Request, *args: Any, **kwargs: Any) -> Response:
         if req.user:
-            user_info = req.user.to_dict()
+            user_info = req.user.to_dict()  # type: ignore[union-attr]
             res = {
                 "user_id": user_info.get("user_id", ""),
                 "email": user_info.get("email", ""),
@@ -242,9 +258,10 @@ class UserTenantClose(BaseOpenAPIView):
         operation_description="根据用户ID关闭所有团队",
         tags=['openapi-user'],
     )
-    def get(self, req, user_id, *args, **kwargs):
+    def get(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
         uid = int(user_id)
-        user = user_services.get_user_by_user_id(uid)
+        # NOTE: get_user_by_user_id typed to expect str; runtime accepts int (arg-type).
+        user = user_services.get_user_by_user_id(uid)  # type: ignore[arg-type]
         tenants = Tenants.objects.filter(creater=uid)
         user.nick_name = "系统（余额不足）"
         for tenant in tenants:
@@ -257,10 +274,10 @@ class UserTenantDelete(BaseOpenAPIView):
         operation_description="根据用户ID删除团队下所有应用",
         tags=['openapi-user'],
     )
-    def get(self, req, user_id, *args, **kwargs):
+    def get(self, req: Request, user_id: str, *args: Any, **kwargs: Any) -> Response:
         uid = int(user_id)
         tenants = Tenants.objects.filter(creater=uid)
-        user = user_services.get_user_by_user_id(uid)
+        user = user_services.get_user_by_user_id(uid)  # type: ignore[arg-type]
         for tenant in tenants:
             apps = group_repo.get_groups_by_tenant_id(tenant.tenant_id)
             for app in apps:
@@ -269,13 +286,16 @@ class UserTenantDelete(BaseOpenAPIView):
                 # delete k8s resource
                 k8s_resources = k8s_resource_service.list_by_app_id(str(app_id))
                 resource_ids = [k8s_resource.ID for k8s_resource in k8s_resources]
-                k8s_resource_service.batch_delete_k8s_resource(user.enterprise_id, tenant.tenant_name, str(app_id),
-                                                               app.region_name, resource_ids)
+                # NOTE: enterprise_id typed str|None by stubs; runtime always str.
+                k8s_resource_service.batch_delete_k8s_resource(
+                    user.enterprise_id, tenant.tenant_name, str(app_id),  # type: ignore[arg-type]
+                    app.region_name, resource_ids)
                 # delete configs
                 app_config_group_service.batch_delete_config_group(app.region_name, tenant.tenant_name, app_id)
                 # delete records
                 group_service.delete_app_share_records(tenant.tenant_name, app_id)
                 # delete app
-                app = group_service.get_app_by_id(tenant, app.region_name, app_id)
+                # NOTE: get_app_by_id may return None; loop var typed ServiceGroup (assignment).
+                app = group_service.get_app_by_id(tenant, app.region_name, app_id)  # type: ignore[assignment]
                 group_service.delete_app(tenant, app.region_name, app)
         return Response({"bean": "delete success"}, status=200)


### PR DESCRIPTION
## What

P5 (part 2): annotate the **entire `openapi/` package** and bring it into the mypy strict whitelist (`[mypy-openapi.*]`). Independent of the `console.views` P5 PR (#1972) — openapi has its own view base hierarchy.

## How

- `openapi/views/base.py` (keystone) establishes the context-attribute convention for the OpenAPI view hierarchy `BaseOpenAPIView → TeamNoRegionAPIView → TeamAPIView → TeamAppAPIView → TeamAppServiceAPIView`: `enterprise`/`user`/`team`/`region`/`region_name`/`app`/`service` typed to their runtime contract via class-level annotations, with a single `# type: ignore[assignment]` per transient `None` default.
- Views, DRF serializers (`validate`/`create`/`to_representation`/method fields), services, auth classes, mcp, v2, and models annotated.

## Guarantees / review notes

- **No behavior changes.** Only signatures, imports, `# type: ignore` + `# NOTE`, and a few behavior-preserving local variable renames (splitting same-named vars of different types). Verified with an AST diff that strips annotations/imports — the executable AST is identical except the reviewed renames.
- OpenAPI-specific: `request.user` is `User | AnonymousUser` per the stubs, so the many `request.user.<attr>` accesses are suppressed with `# type: ignore[union-attr]`. Other legacy mismatches (regionapi `Optional` results, int-as-str ids, py2 `Exception.message`) suppressed with `# type: ignore` + `# NOTE`, never "fixed". Genuine latent bugs found are catalogued for a separate fix PR.

## Verification

- single-module strict (`--disallow-untyped-defs --check-untyped-defs`) → 0
- full-tree gate (`mypy console/ www/ openapi/`) → all whitelisted modules (incl. openapi) 0
- unit-test gate (`scripts/run_pytest.py console/tests`) → 0 failures