### PR TITLE
ci: make typecheck a blocking gate for strict-whitelisted modules

### DIFF
--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -42,7 +42,6 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     container: python:3.11-bookworm
-    continue-on-error: true
     env:
       PIP_SRC: /tmp/pip-src
     steps:
@@ -71,8 +70,8 @@ jobs:
       - name: Install typing dependencies
         run: pip install -r requirements-typing.txt
 
-      - name: Run mypy (advisory)
-        run: make typecheck
+      - name: Run mypy strict gate (whitelisted modules must stay error-free)
+        run: make typecheck-gate
 
   coverage-gate:
     # Advisory for now (continue-on-error): reports diff coverage of new/changed

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,5 @@ build-allinone-image:
 	docker build --build-arg VERSION=V5.3 -t rainbond/rainbond:v5.3 -f Dockerfile.allinone .
 typecheck:
 	@mypy --config-file mypy.ini console/ www/ openapi/ || true
+typecheck-gate:
+	@bash scripts/typecheck_gate.sh

--- a/scripts/typecheck_gate.sh
+++ b/scripts/typecheck_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Blocking mypy gate for the strict-whitelisted modules.
+#
+# `make typecheck` runs mypy over the whole tree for an advisory report, but the
+# not-yet-annotated modules still emit lax-mode errors (var-annotated, arg-type,
+# etc.) that we are not gating on during incremental adoption. This gate fails
+# ONLY when a module that has been brought into the strict whitelist regresses.
+#
+# Keep WHITELIST_RE in sync with the `[mypy-<module>]` strict sections in
+# mypy.ini. Today that is: console/repositories/*, console/services/*,
+# console/views/*, openapi/*, and www/apiclient/regionapi.py.
+set -uo pipefail
+
+WHITELIST_RE='console/repositories/|console/services/|console/views/|openapi/|www/apiclient/regionapi\.py'
+
+OUT=$(mypy --config-file mypy.ini console/ www/ openapi/ 2>&1)
+echo "$OUT" | tail -1
+
+HITS=$(echo "$OUT" | grep ': error' | grep -E "$WHITELIST_RE" || true)
+if [ -n "$HITS" ]; then
+  echo "::error::mypy strict regression in whitelisted modules:"
+  echo "$HITS"
+  exit 1
+fi
+
+echo "typecheck-gate OK: all strict-whitelisted modules are clean"


### PR DESCRIPTION
## What

Turn the `typecheck` CI job from advisory into a **blocking gate** for the modules already in the mypy strict whitelist (`console/repositories`, `console/services`, `console/views`, `openapi`, `www/apiclient/regionapi.py`). This protects the P3–P5 typing investment from silent regressions.

## Why it was a no-op before

- `make typecheck` ends with `|| true` → always exits 0.
- The job had `continue-on-error: true`.

So the check could never fail.

## How it gates without flapping on un-annotated code

Full-tree mypy still reports ~80 lax-mode errors in not-yet-annotated modules (tests, urls, www/utils, …) — those stay advisory. `scripts/typecheck_gate.sh` runs the full report and fails **only** when an error falls under a whitelisted path. `make typecheck` (advisory full report) is kept; a new `make typecheck-gate` is the blocking target the job now runs (with `continue-on-error` removed).

`coverage-gate` remains advisory (unchanged).

## After merge

Add `typecheck` to the branch-protection required checks on `staging/console-optimize` so it actually blocks merges.

## Verification

`bash scripts/typecheck_gate.sh` on current staging → `typecheck-gate OK: all strict-whitelisted modules are clean` (exit 0), while full-tree mypy reports 83 advisory errors in non-whitelisted files.