### PR TITLE
fix: resolve latent view-layer bugs surfaced by mypy (batch 3)

### DIFF
--- a/console/tests/add_team_namespace_validation_test.py
+++ b/console/tests/add_team_namespace_validation_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.bcode import ErrQualifiedName  # noqa: E402
+from console.views.team import AddTeamView  # noqa: E402
+
+
+# capability_id: console.team.create-invalid-namespace
+class AddTeamInvalidNamespaceTest(TestCase):
+    def test_invalid_namespace_raises_qualified_name_error_not_typeerror(self):
+        view = AddTeamView()
+        request = mock.Mock()
+        request.user = mock.Mock(enterprise_id="ent-1", user_id="u-1")
+        request.data = {
+            "team_alias": "demo",
+            "useable_regions": "",
+            "namespace": "Invalid_NS",
+            "bind_existing_namespace": False,
+            "logo": "",
+        }
+
+        with mock.patch("console.views.team.is_qualified_name", return_value=False):
+            with self.assertRaises(ErrQualifiedName) as ctx:
+                view.post(request)
+
+        # msg_show must be a single well-formed string (the original used ASCII
+        # quotes around the hyphen, tokenizing it as "str" - "str" -> TypeError).
+        self.assertIn("命名空间", ctx.exception.msg_show)
+        self.assertIn("-", ctx.exception.msg_show)

--- a/console/tests/bind_market_token_decode_test.py
+++ b/console/tests/bind_market_token_decode_test.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import base64
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.views.enterprise_active import BindMarketEnterpriseOptimizAccessTokenView  # noqa: E402
+
+
+# capability_id: console.enterprise.bind-market-token-decode
+class BindMarketTokenDecodeTest(TestCase):
+    def test_market_info_is_base64_decoded(self):
+        # base64.decodestring was removed in Python 3.9 -> AttributeError before fix.
+        encoded = base64.b64encode(b"{'eid': 'e1', 'token': 't1'}").decode("utf-8")
+        view = BindMarketEnterpriseOptimizAccessTokenView()
+        request = mock.Mock()
+        request.data = {"market_info": encoded}
+
+        # enterprise_id empty: decoding must succeed first, then the param check
+        # short-circuits to a 400 (no enterprise lookup / region calls reached).
+        response = view.post(request, enterprise_id="")
+
+        self.assertEqual(response.status_code, 400)

--- a/console/tests/enterprise_region_dashboard_notfound_test.py
+++ b/console/tests/enterprise_region_dashboard_notfound_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+from rest_framework.response import Response  # noqa: E402
+
+django.setup()
+
+from console.views import enterprise as enterprise_module  # noqa: E402
+from console.views.enterprise import EnterpriseRegionDashboard  # noqa: E402
+
+
+# capability_id: console.enterprise.region-dashboard-not-found
+class EnterpriseRegionDashboardNotFoundTest(TestCase):
+    def test_missing_region_returns_clean_404(self):
+        view = EnterpriseRegionDashboard()
+        request = mock.Mock()
+        view.initialize_request = mock.Mock(return_value=request)
+        view.initial = mock.Mock()
+        view.finalize_response = mock.Mock(side_effect=lambda req, resp, *a, **k: resp)
+        # If the 404 branch raised (status.HTTP_404_NOTFOUND typo -> AttributeError),
+        # it would be caught here and surfaced as a 500-style error response.
+        view.handle_exception = mock.Mock(return_value=Response({}, status=500))
+
+        with mock.patch.object(enterprise_module, "region_services") as region_services:
+            region_services.get_enterprise_region.return_value = None
+            response = view.dispatch(request, "ent-1", "region-1")
+
+        self.assertEqual(response.status_code, 404)
+        view.handle_exception.assert_not_called()

--- a/console/tests/user_accesstoken_delete_log_test.py
+++ b/console/tests/user_accesstoken_delete_log_test.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.views import user_accesstoken as accesstoken_module  # noqa: E402
+from console.views.user_accesstoken import UserAccessTokenRUDView  # noqa: E402
+
+
+# capability_id: console.user.access-token-delete-log
+class UserAccessTokenDeleteLogTest(TestCase):
+    def test_delete_logs_token_note_without_nameerror(self):
+        view = UserAccessTokenRUDView()
+        view.user = mock.Mock(enterprise_id="ent-1")
+        request = mock.Mock()
+        request.user = mock.Mock(user_id="u-1")
+
+        with mock.patch.object(accesstoken_module, "user_access_services") as svc, \
+                mock.patch.object(accesstoken_module, "operation_log_service") as ops:
+            svc.get_user_access_key_by_id.return_value.first.return_value = mock.Mock(note="my-token")
+            response = view.delete(request, "key-1")
+
+        self.assertEqual(response.status_code, 200)
+        svc.delete_user_access_key_by_id.assert_called_once_with("u-1", "key-1")
+        comment_kwargs = ops.generate_generic_comment.call_args.kwargs
+        self.assertEqual(comment_kwargs["module_name"], "my-token")

--- a/console/tests/user_favorite_delete_log_test.py
+++ b/console/tests/user_favorite_delete_log_test.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+import collections
+import collections.abc
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.exceptions import UserFavoriteNotExistError  # noqa: E402
+from console.views import user_operation as user_operation_module  # noqa: E402
+from console.views.user_operation import UserFavoriteUDView  # noqa: E402
+
+
+# capability_id: console.user.favorite-delete-log
+class UserFavoriteDeleteLogTest(TestCase):
+    def test_delete_logs_favorite_name_without_nameerror(self):
+        view = UserFavoriteUDView()
+        view.user = mock.Mock(enterprise_id="ent-1")
+        request = mock.Mock()
+        request.user = mock.Mock(user_id="u-1")
+
+        favorite = mock.Mock()
+        favorite.name = "my-fav"
+
+        with mock.patch.object(user_operation_module, "user_repo") as repo, \
+                mock.patch.object(user_operation_module, "operation_log_service") as ops:
+            repo.get_user_favorite_by_ID.return_value = favorite
+            response = view.delete(request, "ent-1", "fav-1")
+
+        self.assertEqual(response.status_code, 200)
+        repo.delete_user_favorite_by_id.assert_called_once_with("u-1", "fav-1")
+        comment_kwargs = ops.generate_generic_comment.call_args.kwargs
+        self.assertEqual(comment_kwargs["module_name"], " my-fav")
+
+    def test_delete_missing_favorite_returns_404(self):
+        view = UserFavoriteUDView()
+        view.user = mock.Mock(enterprise_id="ent-1")
+        request = mock.Mock()
+        request.user = mock.Mock(user_id="u-1")
+
+        with mock.patch.object(user_operation_module, "user_repo") as repo, \
+                mock.patch.object(user_operation_module, "operation_log_service"):
+            repo.get_user_favorite_by_ID.side_effect = UserFavoriteNotExistError("missing")
+            response = view.delete(request, "ent-1", "fav-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["code"], 404)

--- a/console/views/enterprise.py
+++ b/console/views/enterprise.py
@@ -686,9 +686,7 @@ class EnterpriseRegionDashboard(EnterpriseAdminView):
             self.initial(request, *args, **kwargs)
             region = region_services.get_enterprise_region(enterprise_id, region_id, check_status=False)
             if not region:
-                # NOTE: latent bug — status.HTTP_404_NOTFOUND is a typo for HTTP_404_NOT_FOUND
-                # (AttributeError if reached); behavior preserved (backlog).
-                return Response({}, status=status.HTTP_404_NOTFOUND)  # type: ignore[attr-defined]
+                return Response({}, status=status.HTTP_404_NOT_FOUND)
             full_path = request.get_full_path()
             path = full_path[full_path.index("/dashboard/") + 11:len(full_path)]
             response = region_api.proxy(request, '/kubernetes/dashboard/' + path, region['region_name'])

--- a/console/views/enterprise_active.py
+++ b/console/views/enterprise_active.py
@@ -104,8 +104,7 @@ class BindMarketEnterpriseOptimizAccessTokenView(JWTAuthApiView):
         """
         logger.debug("bind market access token")
         ret = request.data.get('market_info')
-        # NOTE: base64.decodestring was removed in Python 3.9; this is a latent runtime bug (backlog).
-        market_info = eval(base64.decodestring(ret))  # type: ignore[attr-defined]
+        market_info = eval(base64.b64decode(ret))  # type: ignore[arg-type]
         market_client_id = market_info.get('eid')
         market_client_token = market_info.get('token')
         if not enterprise_id or not market_client_id or not market_client_token:

--- a/console/views/team.py
+++ b/console/views/team.py
@@ -154,9 +154,9 @@ class AddTeamView(JWTAuthApiView):
             if bind_existing_namespace and not namespace:
                 return Response(general_message(400, "failed", "namespace 不能为空"), status=400)
             if not is_qualified_name(namespace):
-                # NOTE: latent bug — msg_show string has ASCII quotes around "-" so Python
-                # tokenizes it as "str" - "str" (runtime TypeError if reached); preserved.
-                raise ErrQualifiedName(msg="invalid namespace name", msg_show="命名空间只能由小写字母、数字或"-"组成，并且必须以字母开始、以数字或字母结尾")  # type: ignore[operator]
+                raise ErrQualifiedName(
+                    msg="invalid namespace name",
+                    msg_show="命名空间只能由小写字母、数字或“-”组成，并且必须以字母开始、以数字或字母结尾")
             regions = []
             if not team_alias:
                 result = general_message(400, "failed", "团队名不能为空")

--- a/console/views/user_accesstoken.py
+++ b/console/views/user_accesstoken.py
@@ -74,12 +74,13 @@ class UserAccessTokenRUDView(JWTAuthApiView):
         return Response(result, status=200)
 
     def delete(self, request: Request, id: str, **kwargs: Any) -> Response:
+        access_key = user_access_services.get_user_access_key_by_id(
+            request.user.user_id, id).first()  # type: ignore[union-attr]
         user_access_services.delete_user_access_key_by_id(request.user.user_id, id)  # type: ignore[union-attr]
         result = general_message(200, "success", None)
         comment = operation_log_service.generate_generic_comment(
             operation=Operation.DELETE, module=OperationModule.ACCESSKEY,
-            # NOTE: latent bug — `access_key` is undefined in delete(); behavior preserved.
-            module_name=access_key.note if access_key else "")  # type: ignore[name-defined]
+            module_name=access_key.note if access_key else "")
         operation_log_service.create_enterprise_log(user=self.user, comment=comment,
                                                     enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         return Response(result, status=200)

--- a/console/views/user_operation.py
+++ b/console/views/user_operation.py
@@ -572,10 +572,10 @@ class UserFavoriteUDView(JWTAuthApiView):
     def delete(self, request: Request, enterprise_id: str, favorite_id: str) -> Response:
         result = general_message(200, "success", "删除成功")
         try:
+            favorite = user_repo.get_user_favorite_by_ID(request.user.user_id, favorite_id)  # type: ignore[union-attr]
             user_repo.delete_user_favorite_by_id(request.user.user_id, favorite_id)  # type: ignore[union-attr]
-            # NOTE: `favorite` is undefined here — latent NameError on the happy path (real bug, backlog).
             comment = operation_log_service.generate_generic_comment(
-                operation=Operation.DELETE, module=OperationModule.FAVORITE, module_name=" {}".format(favorite.name))  # type: ignore[name-defined]
+                operation=Operation.DELETE, module=OperationModule.FAVORITE, module_name=" {}".format(favorite.name))
             operation_log_service.create_enterprise_log(user=self.user, comment=comment,
                                                         enterprise_id=self.user.enterprise_id)  # type: ignore[arg-type]
         except UserFavoriteNotExistError as e:

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -9134,6 +9134,96 @@
       ],
       "test_type": "regression",
       "status": "active"
+    },
+    {
+      "id": "console.team.create-invalid-namespace",
+      "title": "Reject team creation with an invalid namespace name",
+      "title_zh": "创建团队时拒绝非法命名空间",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.team.AddTeamView.post",
+      "code_paths": [
+        "console/views/team.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/add_team_namespace_validation_test.py",
+          "selector": "AddTeamInvalidNamespaceTest.test_invalid_namespace_raises_qualified_name_error_not_typeerror"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.enterprise.bind-market-token-decode",
+      "title": "Decode the cloud-market bind token payload",
+      "title_zh": "解码云市绑定企业的认证信息",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.enterprise_active.BindMarketEnterpriseOptimizAccessTokenView.post",
+      "code_paths": [
+        "console/views/enterprise_active.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/bind_market_token_decode_test.py",
+          "selector": "BindMarketTokenDecodeTest.test_market_info_is_base64_decoded"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.enterprise.region-dashboard-not-found",
+      "title": "Return 404 when the region dashboard target is missing",
+      "title_zh": "集群仪表盘目标缺失时返回 404",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.enterprise.EnterpriseRegionDashboard.dispatch",
+      "code_paths": [
+        "console/views/enterprise.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/enterprise_region_dashboard_notfound_test.py",
+          "selector": "EnterpriseRegionDashboardNotFoundTest.test_missing_region_returns_clean_404"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.user.access-token-delete-log",
+      "title": "Log the access token note when deleting a token",
+      "title_zh": "删除访问令牌时记录令牌备注",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.user_accesstoken.UserAccessTokenRUDView.delete",
+      "code_paths": [
+        "console/views/user_accesstoken.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/user_accesstoken_delete_log_test.py",
+          "selector": "UserAccessTokenDeleteLogTest.test_delete_logs_token_note_without_nameerror"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.user.favorite-delete-log",
+      "title": "Log the favorite name when deleting a favorite view",
+      "title_zh": "删除收藏视图时记录收藏名称",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.user_operation.UserFavoriteUDView.delete",
+      "code_paths": [
+        "console/views/user_operation.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/user_favorite_delete_log_test.py",
+          "selector": "UserFavoriteDeleteLogTest"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
     }
   ]
 }


### PR DESCRIPTION
Third batch of latent-bug fixes surfaced by the mypy strict adoption, continuing #1966 / #1967. This batch targets the **view layer** (`console.views`). Each is a high-confidence, live-path bug with an unambiguous fix; each carries a focused regression test, and the `# type: ignore` + NOTE markers that previously suppressed these bugs are removed.

## Fixes

1. **`team.AddTeamView.post`** (`/teams/add-teams`) — the invalid-namespace error message used ASCII quotes around the hyphen, so Python tokenized `msg_show` as `"str" - "str"` → `TypeError` whenever a non-qualified namespace was submitted. Now a single well-formed string (full-width quotes).
2. **`enterprise_active.BindMarketEnterpriseOptimizAccessTokenView.post`** (cloud-market bind) — `base64.decodestring` was removed in Python 3.9, so the endpoint raised `AttributeError` on every call. Switched to `base64.b64decode`.
3. **`enterprise.EnterpriseRegionDashboard.dispatch`** (region dashboard proxy) — `status.HTTP_404_NOTFOUND` is a typo for `HTTP_404_NOT_FOUND`; the resulting `AttributeError` was caught by the surrounding `except` and surfaced as a 500 instead of the intended 404.
4. **`user_accesstoken.UserAccessTokenRUDView.delete`** (`/users/access-token/{id}`) — the operation-log comment referenced an undefined `access_key` → `NameError` on every delete. The token is now looked up before deletion (mirrors the `get`/`put` handlers).
5. **`user_operation.UserFavoriteUDView.delete`** (`/enterprise/{id}/user/favorite/{fid}`) — same pattern: the comment referenced an undefined `favorite` → `NameError`. The favorite is now looked up before deletion; a missing favorite raises `UserFavoriteNotExistError`, which the existing handler turns into a 404.

## Tests

Five new regression tests under `console/tests/` (one per fix; each verified to fail before the fix and pass after), registered in `test-manifest.json` with new `capability_id`s.

## Verification

- `python scripts/run_pytest.py console/tests` — full suite green (no regressions).
- `scripts/typecheck_gate.sh` — strict-whitelisted modules clean (no regression in the gated set).
- `scripts/validate_test_manifest.py` — passes.

Note: the advisory `coverage-gate` (diff-cover ≥80%) is expected to be red for these small, mostly type-only edits and is non-blocking.