### PR TITLE
refactor: adopt AppStatus TypedDict for region app status (M2 phase 2)

### DIFF
--- a/console/services/group_service.py
+++ b/console/services/group_service.py
@@ -288,7 +288,7 @@ class GroupService(object):
             app.save()  # type: ignore[union-attr]
         if not app.k8s_app:  # type: ignore[union-attr]
             status = region_api.get_app_status(region_name, tenant.tenant_name, region_app_id)
-            app.k8s_app = status["k8s_app"] if status.get("k8s_app") else ""  # type: ignore[union-attr]
+            app.k8s_app = status["k8s_app"] if status and status.get("k8s_app") else ""  # type: ignore[union-attr]
             app.save()  # type: ignore[union-attr]
         return region_app_id
 
@@ -989,9 +989,12 @@ class GroupService(object):
         port_service.update_by_k8s_services(tenant, region_name, app, k8s_services)
 
     @staticmethod
-    def get_app_status(tenant: Tenants, region_name: str, app_id: str) -> Any:
+    def get_app_status(tenant: Tenants, region_name: str, app_id: str) -> Dict[str, Any]:
         region_app_id = region_app_repo.get_region_app_id(region_name, app_id)
-        status = region_api.get_app_status(region_name, tenant.tenant_name, region_app_id)
+        region_status = region_api.get_app_status(region_name, tenant.tenant_name, region_app_id)
+        # Copy the region AppStatus payload into a plain dict before reshaping it for the
+        # response (status NIL -> None, overrides "k=v" -> [{k: v}]); guards a null payload.
+        status: Dict[str, Any] = dict(region_status) if region_status else {}
         if status.get("status") == "NIL":
             status["status"] = None
         overrides = status.get("overrides", [])

--- a/console/tests/group_app_status_typeddict_test.py
+++ b/console/tests/group_app_status_typeddict_test.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.services import group_service as group_service_module  # noqa: E402
+from console.services.group_service import group_service  # noqa: E402
+
+
+# capability_id: console.app-status.region-status-typeddict
+class GroupAppStatusTypedDictTest(TestCase):
+    def _tenant(self):
+        return mock.Mock(tenant_name="demo-team", enterprise_id="ent-1")
+
+    def test_returns_empty_dict_when_region_status_is_none(self):
+        # region get_app_status payload may be null; the caller must not deref None.
+        with mock.patch.object(group_service_module.region_app_repo, "get_region_app_id", return_value="ra-1"), \
+                mock.patch.object(group_service_module.region_api, "get_app_status", return_value=None), \
+                mock.patch.object(group_service_module.group_repo, "get_group_by_id", return_value=None):
+            status = group_service.get_app_status(self._tenant(), "demo-region", 1)
+        self.assertEqual(status, {})
+
+    def test_normalizes_nil_status_and_overrides(self):
+        region_status = {"status": "NIL", "overrides": ["A=1", "B=2"], "k8s_app": "demo"}
+        with mock.patch.object(group_service_module.region_app_repo, "get_region_app_id", return_value="ra-1"), \
+                mock.patch.object(group_service_module.region_api, "get_app_status", return_value=region_status), \
+                mock.patch.object(group_service_module.group_repo, "get_group_by_id", return_value=None):
+            status = group_service.get_app_status(self._tenant(), "demo-region", 1)
+        self.assertIsNone(status["status"])
+        self.assertEqual(status["overrides"], [{"A": "1"}, {"B": "2"}])
+        self.assertEqual(status["k8s_app"], "demo")

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -9298,6 +9298,26 @@
       ],
       "test_type": "regression",
       "status": "active"
+    },
+    {
+      "id": "console.app-status.region-status-typeddict",
+      "title": "Normalize region app status payload (AppStatus TypedDict adoption)",
+      "title_zh": "归一化集群应用状态返回（AppStatus TypedDict 落地）",
+      "interface_type": "service_method",
+      "interface": "console.services.group_service.GroupService.get_app_status",
+      "code_paths": [
+        "console/services/group_service.py",
+        "www/apiclient/regionapi.py",
+        "www/apiclient/region_types.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/group_app_status_typeddict_test.py",
+          "selector": "GroupAppStatusTypedDictTest"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
     }
   ]
 }

--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -17,7 +17,7 @@ from console.repositories.app import service_repo
 from console.repositories.app_config import configuration_repo, domain_repo
 from www.apiclient.baseclient import client_auth_service
 from www.apiclient.exception import err_region_not_found
-from www.apiclient.region_types import PodDetail, TenantServices
+from www.apiclient.region_types import AppStatus, PodDetail, TenantServices
 from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient
 from www.models.main import TenantRegionInfo, Tenants, ServiceGroup
 from console.exception.bcode import ErrNamespaceExists
@@ -2368,7 +2368,7 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
         res, body = self._put(url, self.default_headers, body=json.dumps(data), region=region_name)
         return body
 
-    def get_app_status(self, region_name: str, tenant_name: str, region_app_id: str) -> Any:
+    def get_app_status(self, region_name: str, tenant_name: str, region_app_id: str) -> Optional[AppStatus]:
         url, token = self.__get_region_access_info(tenant_name, region_name)
         tenant_region = self.__get_tenant_region_info(tenant_name, region_name)
         url = url + "/v2/tenants/" + tenant_region.region_tenant_name + "/apps/" + region_app_id + "/status"


### PR DESCRIPTION
M2 phase 2: adopt the `AppStatus` TypedDict (added in #1978) on the highest-value region status method, with the small caller refactor it required.

## Changes

- `regionapi.get_app_status` → `Optional[AppStatus]` (was `Any`).
- `group_service.GroupService.get_app_status`: copies the region payload into a plain `Dict[str, Any]` before reshaping it for the response (`status` `"NIL"`→`None`, `overrides` `"k=v"`→`[{k: v}]`). The copy lets the response-building mutations keep their off-type values without fighting the `AppStatus` TypedDict, and the `if region_status else {}` also guards a **null payload that previously raised `AttributeError`** (the Go envelope can return `{"bean": null}`).
- Guarded the same unguarded-None deref at the sync caller (`group_service.py:290`).

This is the "adopt-after-a-small-caller-refactor" case flagged in #1978: `get_app_status` couldn't be typed directly because a caller mutated the payload in place with off-type values.

## Tests

New `console/tests/group_app_status_typeddict_test.py`:
- null region payload → returns `{}` instead of crashing (this was **red** before the fix);
- `"NIL"` status normalized to `None` and `overrides` reshaped.

Registered in `test-manifest.json`. The existing `group_service_test.py` get_app_status test still passes unchanged.

## Verification

- `scripts/typecheck_gate.sh` — strict-whitelisted modules clean.
- `python scripts/run_pytest.py console/tests` — full suite green.
- `scripts/validate_test_manifest.py` — passes.

Advisory `coverage-gate` expected red (small/type-only) and non-blocking.