### PR TITLE
feat: merge v6.9.2-dev features onto Python 3.11 / Django 5.2 stack

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn goodrain_web.wsgi -k gevent --max-requests=5000 ${AUTO_RELOAD+--reload} --workers=4 --timeout=75 --access-logfile ${ACCESS_LOGFILE:=-} --error-logfile ${ERROR_LOGFILE:=-}
+web: gunicorn goodrain_web.wsgi -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker --max-requests=5000 ${AUTO_RELOAD+--reload} --workers=4 --timeout=75 --access-logfile ${ACCESS_LOGFILE:=-} --error-logfile ${ERROR_LOGFILE:=-}

--- a/console/enum/component_enum.py
+++ b/console/enum/component_enum.py
@@ -9,6 +9,7 @@ class ComponentType(Enum):
     state_multiple = "state_multiple"
     job = "job"
     cronjob = "cronjob"
+    daemonset = "daemonset"
     vm = "vm"
     kubeblocks = "kubeblocks_component"
 
@@ -22,6 +23,8 @@ class ComponentType(Enum):
             return "有状态单实例"
         if key == "state_multiple":
             return "有状态多实例"
+        if key == "daemonset":
+            return "守护进程组件"
         if key == "kubeblocks_component":
             return "KubeBlocks 组件"
 
@@ -49,6 +52,7 @@ def is_support(component_type):
             or component_type == ComponentType.state_multiple.value \
             or component_type == ComponentType.job.value \
             or component_type == ComponentType.cronjob.value \
+            or component_type == ComponentType.daemonset.value \
             or component_type == ComponentType.kubeblocks.value:
         return True
 

--- a/console/models/main.py
+++ b/console/models/main.py
@@ -1202,6 +1202,8 @@ class TeamRegistryAuth(BaseModel):
     tenant_id = models.CharField(max_length=32, help_text="tenant_id")
     secret_id = models.CharField(max_length=32, help_text="secret_id")
     domain = models.CharField(max_length=255, help_text="domain")
+    access_key = models.CharField(max_length=255, null=True, blank=True, default="", help_text="cloud api access key")
+    access_secret = models.CharField(max_length=255, null=True, blank=True, default="", help_text="cloud api access secret")
     username = models.CharField(max_length=255, help_text="username")
     password = models.CharField(max_length=255, help_text="password")
     region_name = models.CharField(max_length=255, help_text="region_name")

--- a/console/models/main.py
+++ b/console/models/main.py
@@ -1207,6 +1207,8 @@ class TeamRegistryAuth(BaseModel):
     region_name = models.CharField(max_length=255, help_text="region_name")
     hub_type = models.CharField(max_length=32, help_text="hub type", default="Docker")
     user_id = models.IntegerField(help_text="用户ID", default=0)
+    scope = models.CharField(max_length=32, help_text="registry scope", default="user")
+    enterprise_id = models.CharField(max_length=32, help_text="enterprise id", default="")
 
 
 class RKECluster(BaseModel):

--- a/console/models/main.py
+++ b/console/models/main.py
@@ -1202,11 +1202,15 @@ class TeamRegistryAuth(BaseModel):
     tenant_id = models.CharField(max_length=32, help_text="tenant_id")
     secret_id = models.CharField(max_length=32, help_text="secret_id")
     domain = models.CharField(max_length=255, help_text="domain")
+    access_key = models.CharField(max_length=255, null=True, blank=True, default="", help_text="cloud api access key")
+    access_secret = models.CharField(max_length=255, null=True, blank=True, default="", help_text="cloud api access secret")
     username = models.CharField(max_length=255, help_text="username")
     password = models.CharField(max_length=255, help_text="password")
     region_name = models.CharField(max_length=255, help_text="region_name")
     hub_type = models.CharField(max_length=32, help_text="hub type", default="Docker")
     user_id = models.IntegerField(help_text="用户ID", default=0)
+    scope = models.CharField(max_length=32, help_text="registry scope", default="user")
+    enterprise_id = models.CharField(max_length=32, help_text="enterprise id", default="")
 
 
 class RKECluster(BaseModel):

--- a/console/repositories/team_repo.py
+++ b/console/repositories/team_repo.py
@@ -352,24 +352,73 @@ class TeamGitlabRepo(object):
 
 
 class TeamRegistryAuthRepo(object):
+    USER_SCOPE = "user"
+    ENTERPRISE_SCOPE = "enterprise"
+
     def list_by_team_id(self, tenant_id, region_name, user_id):
-        return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, user_id=user_id)
+        queryset = TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, user_id=user_id)
+        if tenant_id == '' and region_name == '':
+            queryset = queryset.filter(scope=self.USER_SCOPE)
+        return queryset
+
+    def list_user_registry_auths(self, user_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', user_id=user_id, scope=self.USER_SCOPE)
+
+    def list_enterprise_registry_auths(self, enterprise_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', enterprise_id=enterprise_id, scope=self.ENTERPRISE_SCOPE)
 
     def check_exist_registry_auth(self, secret_id, user_id):
-        return TeamRegistryAuth.objects.filter(secret_id=secret_id, user_id=user_id)
+        return TeamRegistryAuth.objects.filter(
+            secret_id=secret_id, user_id=user_id, tenant_id='', region_name='', scope=self.USER_SCOPE)
+
+    def check_exist_enterprise_registry_auth(self, enterprise_id, secret_id):
+        return TeamRegistryAuth.objects.filter(
+            secret_id=secret_id, enterprise_id=enterprise_id, tenant_id='', region_name='', scope=self.ENTERPRISE_SCOPE)
 
     def create_team_registry_auth(self, **params):
+        params.setdefault("scope", self.USER_SCOPE)
+        params.setdefault("enterprise_id", "")
         return TeamRegistryAuth.objects.create(**params)
 
     def update_team_registry_auth(self, tenant_id, region_name, secret_id, **params):
         return TeamRegistryAuth.objects.filter(
             tenant_id=tenant_id, region_name=region_name, secret_id=secret_id).update(**params)
 
+    def update_user_registry_auth(self, secret_id, user_id, **params):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).update(**params)
+
+    def update_enterprise_registry_auth(self, enterprise_id, secret_id, **params):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).update(**params)
+
     def delete_team_registry_auth(self, tenant_id, region_name, secret_id, user_id):
-        return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, secret_id=secret_id, user_id=user_id).delete()
+        return TeamRegistryAuth.objects.filter(
+            tenant_id=tenant_id, region_name=region_name, secret_id=secret_id, user_id=user_id).delete()
+
+    def delete_user_registry_auth(self, secret_id, user_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).delete()
+
+    def delete_enterprise_registry_auth(self, enterprise_id, secret_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).delete()
 
     def get_by_secret_id(self, secret_id):
         return TeamRegistryAuth.objects.filter(secret_id=secret_id)
+
+    def get_user_registry_auth(self, secret_id, user_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).first()
+
+    def get_enterprise_registry_auth(self, secret_id, enterprise_id):
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).first()
 
     def get_by_team_id_domain(self, tenant_id, region_name, domain):
         return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, domain=domain)

--- a/console/repositories/team_repo.py
+++ b/console/repositories/team_repo.py
@@ -357,25 +357,74 @@ class TeamGitlabRepo(object):
 
 
 class TeamRegistryAuthRepo(object):
+    USER_SCOPE = "user"
+    ENTERPRISE_SCOPE = "enterprise"
+
     def list_by_team_id(self, tenant_id: str, region_name: str, user_id: str) -> "QuerySet[TeamRegistryAuth]":
-        return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, user_id=user_id)
+        queryset = TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, user_id=user_id)
+        if tenant_id == '' and region_name == '':
+            queryset = queryset.filter(scope=self.USER_SCOPE)
+        return queryset
+
+    def list_user_registry_auths(self, user_id: str) -> "QuerySet[TeamRegistryAuth]":
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', user_id=user_id, scope=self.USER_SCOPE)
+
+    def list_enterprise_registry_auths(self, enterprise_id: str) -> "QuerySet[TeamRegistryAuth]":
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', enterprise_id=enterprise_id, scope=self.ENTERPRISE_SCOPE)
 
     def check_exist_registry_auth(self, secret_id: str, user_id: str) -> "QuerySet[TeamRegistryAuth]":
-        return TeamRegistryAuth.objects.filter(secret_id=secret_id, user_id=user_id)
+        return TeamRegistryAuth.objects.filter(
+            secret_id=secret_id, user_id=user_id, tenant_id='', region_name='', scope=self.USER_SCOPE)
+
+    def check_exist_enterprise_registry_auth(self, enterprise_id: str, secret_id: str) -> "QuerySet[TeamRegistryAuth]":
+        return TeamRegistryAuth.objects.filter(
+            secret_id=secret_id, enterprise_id=enterprise_id, tenant_id='', region_name='', scope=self.ENTERPRISE_SCOPE)
 
     def create_team_registry_auth(self, **params: Any) -> TeamRegistryAuth:
+        params.setdefault("scope", self.USER_SCOPE)
+        params.setdefault("enterprise_id", "")
         return TeamRegistryAuth.objects.create(**params)
 
     def update_team_registry_auth(self, tenant_id: str, region_name: str, secret_id: str, **params: Any) -> int:
         return TeamRegistryAuth.objects.filter(
             tenant_id=tenant_id, region_name=region_name, secret_id=secret_id).update(**params)
 
+    def update_user_registry_auth(self, secret_id: str, user_id: str, **params: Any) -> int:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).update(**params)
+
+    def update_enterprise_registry_auth(self, enterprise_id: str, secret_id: str, **params: Any) -> int:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).update(**params)
+
     def delete_team_registry_auth(self, tenant_id: str, region_name: str, secret_id: str,
                                   user_id: str) -> tuple:
-        return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, secret_id=secret_id, user_id=user_id).delete()
+        return TeamRegistryAuth.objects.filter(
+            tenant_id=tenant_id, region_name=region_name, secret_id=secret_id, user_id=user_id).delete()
+
+    def delete_user_registry_auth(self, secret_id: str, user_id: str) -> tuple:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).delete()
+
+    def delete_enterprise_registry_auth(self, enterprise_id: str, secret_id: str) -> tuple:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).delete()
 
     def get_by_secret_id(self, secret_id: str) -> "QuerySet[TeamRegistryAuth]":
         return TeamRegistryAuth.objects.filter(secret_id=secret_id)
+
+    def get_user_registry_auth(self, secret_id: str, user_id: str) -> Optional[TeamRegistryAuth]:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, user_id=user_id, scope=self.USER_SCOPE).first()
+
+    def get_enterprise_registry_auth(self, secret_id: str, enterprise_id: str) -> Optional[TeamRegistryAuth]:
+        return TeamRegistryAuth.objects.filter(
+            tenant_id='', region_name='', secret_id=secret_id, enterprise_id=enterprise_id,
+            scope=self.ENTERPRISE_SCOPE).first()
 
     def get_by_team_id_domain(self, tenant_id: str, region_name: str, domain: str) -> "QuerySet[TeamRegistryAuth]":
         return TeamRegistryAuth.objects.filter(tenant_id=tenant_id, region_name=region_name, domain=domain)

--- a/console/services/app_actions/app_log.py
+++ b/console/services/app_actions/app_log.py
@@ -6,13 +6,11 @@ import datetime
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from django.conf import settings
-
 from console.constants import LogConstants, ServiceEventConstants
 from console.repositories.event_repo import event_repo
-from console.repositories.region_repo import region_repo
 from console.services.plugin.app_plugin import AppPluginService
 from console.utils.timeutil import str_to_time, time_to_str
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from goodrain_web.tools import JuncheePaginator
 from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import ServiceEvent
@@ -50,46 +48,10 @@ class AppWebSocketService(object):
         return ws_url
 
     def __event_ws(self, request: Any, region: str, sufix_uri: str) -> str:
-        # NOTE: region (str param) is reassigned to Optional[RegionConfig]; in the
-        # not-found branch it is None, so EVENT_WEBSOCKET_URL[None] is a potential
-        # latent None-key lookup (preserving existing behavior).
-        region = region_repo.get_region_by_region_name(region_name=region)  # type: ignore[assignment]
-        if not region:
-            default_uri = settings.EVENT_WEBSOCKET_URL[region]  # type: ignore[misc]
-            if default_uri == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return "ws://{0}:6060/{1}".format(host, sufix_uri)
-            else:
-                return "{0}/{1}".format(default_uri, sufix_uri)
-        else:
-            if region.wsurl == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return "ws://{0}:6060/{1}".format(host, sufix_uri)
-            else:
-                return "{0}/{1}".format(region.wsurl, sufix_uri)
+        return build_console_realtime_proxy_url(request, region, sufix_uri, scheme_type="ws")
 
     def get_log_domain(self, request: Any, region: str) -> str:
-        # NOTE: region (str param) reassigned to Optional[RegionConfig]; not-found
-        # branch indexes LOG_DOMAIN[None] (potential latent None-key lookup).
-        region = region_repo.get_region_by_region_name(region_name=region)  # type: ignore[assignment]
-        if not region:
-            default_uri = settings.LOG_DOMAIN[region]  # type: ignore[misc]
-            if default_uri == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return '{0}:6060'.format(host)
-            return default_uri
-        else:
-            if region.wsurl == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return '{0}:6060'.format(host)
-            else:
-                if "://" in region.wsurl:
-                    ws_info = region.wsurl.split("://", 1)
-                    if ws_info[0] == "wss":
-                        return "https://{0}".format(ws_info[1])
-                    else:
-                        return "http://{0}".format(ws_info[1])
-                return region.wsurl
+        return build_console_realtime_proxy_url(request, region, scheme_type="http")
 
 
 class AppEventService(object):

--- a/console/services/app_actions/app_log.py
+++ b/console/services/app_actions/app_log.py
@@ -5,13 +5,11 @@
 import datetime
 import logging
 
-from django.conf import settings
-
 from console.constants import LogConstants, ServiceEventConstants
 from console.repositories.event_repo import event_repo
-from console.repositories.region_repo import region_repo
 from console.services.plugin.app_plugin import AppPluginService
 from console.utils.timeutil import str_to_time, time_to_str
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from goodrain_web.tools import JuncheePaginator
 from www.apiclient.regionapi import RegionInvokeApi
 from console.services.group_service import group_service
@@ -48,41 +46,10 @@ class AppWebSocketService(object):
         return ws_url
 
     def __event_ws(self, request, region, sufix_uri):
-        region = region_repo.get_region_by_region_name(region_name=region)
-        if not region:
-            default_uri = settings.EVENT_WEBSOCKET_URL[region]
-            if default_uri == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return "ws://{0}:6060/{1}".format(host, sufix_uri)
-            else:
-                return "{0}/{1}".format(default_uri, sufix_uri)
-        else:
-            if region.wsurl == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return "ws://{0}:6060/{1}".format(host, sufix_uri)
-            else:
-                return "{0}/{1}".format(region.wsurl, sufix_uri)
+        return build_console_realtime_proxy_url(request, region, sufix_uri, scheme_type="ws")
 
     def get_log_domain(self, request, region):
-        region = region_repo.get_region_by_region_name(region_name=region)
-        if not region:
-            default_uri = settings.LOG_DOMAIN[region]
-            if default_uri == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return '{0}:6060'.format(host)
-            return default_uri
-        else:
-            if region.wsurl == "auto":
-                host = request.META.get('HTTP_HOST').split(':')[0]
-                return '{0}:6060'.format(host)
-            else:
-                if "://" in region.wsurl:
-                    ws_info = region.wsurl.split("://", 1)
-                    if ws_info[0] == "wss":
-                        return "https://{0}".format(ws_info[1])
-                    else:
-                        return "http://{0}".format(ws_info[1])
-                return region.wsurl
+        return build_console_realtime_proxy_url(request, region, scheme_type="http")
 
 
 class AppEventService(object):

--- a/console/services/app_actions/app_manage.py
+++ b/console/services/app_actions/app_manage.py
@@ -1396,14 +1396,21 @@ class AppManageService(AppManageBase):
             return "无状态单实例"
         elif extend_method == "stateless_multiple":
             return "无状态多实例"
+        elif extend_method == "daemonset":
+            return "守护进程组件"
         else:
             return None
 
     def change_service_type(self, tenant, service, extend_method, user_name=''):
+        old_extend_method = service.extend_method
+        if old_extend_method != extend_method and (
+                old_extend_method == ComponentType.daemonset.value or extend_method == ComponentType.daemonset.value):
+            raise ServiceHandleException(
+                msg="daemonset component type cannot be changed",
+                msg_show="DaemonSet 组件类型暂不支持在线切换")
         # 存储限制
         tenant_service_volumes = volume_service.get_service_volumes(tenant, service)
         if tenant_service_volumes:
-            old_extend_method = service.extend_method
             for tenant_service_volume in tenant_service_volumes:
                 if tenant_service_volume["volume_type"] == "share-file" or tenant_service_volume["volume_type"] == "memoryfs":
                     continue

--- a/console/services/app_actions/app_manage.py
+++ b/console/services/app_actions/app_manage.py
@@ -1465,15 +1465,22 @@ class AppManageService(AppManageBase):
             return "无状态单实例"
         elif extend_method == "stateless_multiple":
             return "无状态多实例"
+        elif extend_method == "daemonset":
+            return "守护进程组件"
         else:
             return None
 
     def change_service_type(self, tenant: Tenants, service: TenantServiceInfo, extend_method: str,
                             user_name: str = '') -> None:
+        old_extend_method = service.extend_method
+        if old_extend_method != extend_method and (
+                old_extend_method == ComponentType.daemonset.value or extend_method == ComponentType.daemonset.value):
+            raise ServiceHandleException(
+                msg="daemonset component type cannot be changed",
+                msg_show="DaemonSet 组件类型暂不支持在线切换")
         # 存储限制
         tenant_service_volumes = volume_service.get_service_volumes(tenant, service)
         if tenant_service_volumes:
-            old_extend_method = service.extend_method
             for tenant_service_volume in tenant_service_volumes:
                 if tenant_service_volume["volume_type"] == "share-file" or tenant_service_volume["volume_type"] == "memoryfs":
                     continue

--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -555,7 +555,7 @@ class AppPortService(object):
         if action == "open_outer":
             if not deal_port.is_inner_service:
                 raise ServiceHandleException(msg="inner port is not open", msg_show="对内服务未开启，需先开启对内服务", status_code=404)
-            code, msg = self.__open_outer(tenant, service, region, deal_port, app)
+            code, msg = self.__open_outer(tenant, service, region, deal_port, app, user_name)
         elif action == "only_open_outer":
             code, msg = self.__only_open_outer(tenant, service, region, deal_port, user_name)
         elif action == "close_outer":
@@ -575,6 +575,16 @@ class AppPortService(object):
         if code != 200:
             return code, msg, None
         return 200, "操作成功", new_port
+
+    def __sync_outer_port_to_region(self, tenant, service, deal_port, operation, user_name=''):
+        if service.create_status != "complete":
+            return
+        region_api.manage_outer_port(service.service_region, tenant.tenant_name, service.service_alias,
+                                     deal_port.container_port, {
+                                         "operation": operation,
+                                         "enterprise_id": tenant.enterprise_id,
+                                         "operator": user_name
+                                     })
 
     def defalut_open_outer(self, tenant, service, region, deal_port, app=None):
         if deal_port.protocol == "http":
@@ -668,6 +678,7 @@ class AppPortService(object):
                 tcp_domain.create_service_tcp_domains(service_id, service_name, end_point, create_time, container_port,
                                                       protocol, service_alias, tcp_rule_id, tenant_id, region_id)
 
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "open")
         deal_port.is_outer_service = True
         deal_port.save()
         # component port change, will change entrance network governance plugin configuration
@@ -676,7 +687,7 @@ class AppPortService(object):
             app_plugin_service.update_config_if_have_entrance_plugin(tenant, service)
         return 200, "success"
 
-    def __open_outer(self, tenant, service, region, deal_port, app=None):
+    def __open_outer(self, tenant, service, region, deal_port, app=None, user_name=''):
         if deal_port.protocol == "http":
             service_name = service.service_alias
             container_port = deal_port.container_port
@@ -768,6 +779,7 @@ class AppPortService(object):
                 tcp_domain.create_service_tcp_domains(service_id, service_name, end_point, create_time, container_port,
                                                       protocol, service_alias, tcp_rule_id, tenant_id, region_id)
 
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "open", user_name)
         deal_port.is_outer_service = True
         deal_port.save()
         # component port change, will change entrance network governance plugin configuration
@@ -865,6 +877,7 @@ class AppPortService(object):
                             logger.exception(f"Failed to delete route {delete_path}: {e}")
             except Exception as e:
                 logger.exception(f"Failed to get routes from API Gateway: {e}")
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "close", user_name)
         if service.create_status == "complete":
             from console.services.plugin import app_plugin_service
             app_plugin_service.update_config_if_have_entrance_plugin(tenant, service)

--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -584,7 +584,7 @@ class AppPortService(object):
                 raise ServiceHandleException(msg="inner port is not open", msg_show="对内服务未开启，需先开启对内服务", status_code=404)
             # NOTE: region may be None when region_name is unknown (potential latent
             # None-bug); callees deref region attrs without guarding.
-            code, msg = self.__open_outer(tenant, service, region, deal_port, app)  # type: ignore[arg-type]
+            code, msg = self.__open_outer(tenant, service, region, deal_port, app, user_name)  # type: ignore[arg-type]
         elif action == "only_open_outer":
             code, msg = self.__only_open_outer(tenant, service, region, deal_port, user_name)  # type: ignore[arg-type]
         elif action == "close_outer":
@@ -604,6 +604,17 @@ class AppPortService(object):
         if code != 200:
             return code, msg, None
         return 200, "操作成功", new_port
+
+    def __sync_outer_port_to_region(self, tenant: Tenants, service: TenantServiceInfo,
+                                    deal_port: TenantServicesPort, operation: str, user_name: str = '') -> None:
+        if service.create_status != "complete":
+            return
+        region_api.manage_outer_port(service.service_region, tenant.tenant_name, service.service_alias,
+                                     deal_port.container_port, {
+                                         "operation": operation,
+                                         "enterprise_id": tenant.enterprise_id,
+                                         "operator": user_name
+                                     })
 
     # NOTE: region/deal_port typed Any — callers (other strict modules) pass
     # Optional[RegionConfig]/Optional[TenantServicesPort]; relaxing clears the caller
@@ -710,6 +721,7 @@ class AppPortService(object):
                 tcp_domain.create_service_tcp_domains(service_id, service_name, end_point, create_time, container_port,
                                                       protocol, service_alias, tcp_rule_id, tenant_id, region_id)
 
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "open")
         deal_port.is_outer_service = True
         deal_port.save()
         # component port change, will change entrance network governance plugin configuration
@@ -719,7 +731,8 @@ class AppPortService(object):
         return 200, "success"
 
     def __open_outer(self, tenant: Tenants, service: TenantServiceInfo, region: RegionConfig,
-                     deal_port: TenantServicesPort, app: Optional[ServiceGroup] = None) -> Tuple[int, str]:
+                     deal_port: TenantServicesPort, app: Optional[ServiceGroup] = None,
+                     user_name: str = '') -> Tuple[int, str]:
         if deal_port.protocol == "http":
             service_name = service.service_alias
             container_port = deal_port.container_port
@@ -820,6 +833,7 @@ class AppPortService(object):
                 tcp_domain.create_service_tcp_domains(service_id, service_name, end_point, create_time, container_port,
                                                       protocol, service_alias, tcp_rule_id, tenant_id, region_id)
 
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "open", user_name)
         deal_port.is_outer_service = True
         deal_port.save()
         # component port change, will change entrance network governance plugin configuration
@@ -928,6 +942,7 @@ class AppPortService(object):
                             logger.exception(f"Failed to delete route {delete_path}: {e}")
             except Exception as e:
                 logger.exception(f"Failed to get routes from API Gateway: {e}")
+        self.__sync_outer_port_to_region(tenant, service, deal_port, "close", user_name)
         if service.create_status == "complete":
             from console.services.plugin import app_plugin_service
             app_plugin_service.update_config_if_have_entrance_plugin(tenant, service)

--- a/console/services/app_import_and_export_service.py
+++ b/console/services/app_import_and_export_service.py
@@ -20,6 +20,7 @@ from console.repositories.region_repo import region_repo
 from console.services.app_config.app_relation_service import \
     AppServiceRelationService
 from console.services.region_services import region_services
+from console.utils.realtime_proxy import build_console_realtime_proxy_path, build_region_realtime_proxy_url
 from goodrain_web import settings
 from www.apiclient.regionapi import RegionInvokeApi
 from www.tenantservice.baseservice import BaseTenantService
@@ -327,15 +328,8 @@ class AppExportService(object):
         else:
             return raw_url
 
-    def _wrapper_director_download_url(self, region_name: str, raw_url: str) -> Optional[str]:
-        region = region_repo.get_region_by_region_name(region_name)
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                return "https://" + splits_texts[1] + raw_url
-            else:
-                return "http://" + splits_texts[1] + raw_url
-        return None
+    def _wrapper_director_download_url(self, region_name: str, raw_url: str) -> str:
+        return build_console_realtime_proxy_path(region_name, raw_url)
 
     def get_export_record(self, export_format: str, app: Any) -> Any:
         return app_export_record_repo.get_export_record_by_unique_key(app.group_key, app.version, export_format)
@@ -944,29 +938,17 @@ class AppImportService(object):
         }
         return app_import_record_repo.create_app_import_record(**import_record_params)
 
-    def get_upload_url(self, region: str, event_id: str) -> str:
-        region = region_repo.get_region_by_region_name(region)
-        raw_url = "/app/upload"
-        upload_url = ""
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                upload_url = "https://" + splits_texts[1] + raw_url
-            else:
-                upload_url = "http://" + splits_texts[1] + raw_url
-        return upload_url + "/" + event_id
+    def get_upload_url(self, region: str, event_id: str, proxy: bool = True) -> str:
+        raw_url = "/app/upload/{0}".format(event_id)
+        if proxy:
+            return build_console_realtime_proxy_path(region, raw_url)
+        return build_region_realtime_proxy_url(region, raw_url, scheme_type="http")
 
-    def get_upload_package_url(self, region: str, event_id: str) -> str:
-        region = region_repo.get_region_by_region_name(region)
-        raw_url = "/package_build/component/events"
-        get_upload_package_url = ""
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                get_upload_package_url = "https://" + splits_texts[1] + raw_url
-            else:
-                get_upload_package_url = "http://" + splits_texts[1] + raw_url
-        return get_upload_package_url + "/" + event_id
+    def get_upload_package_url(self, region: str, event_id: str, proxy: bool = True) -> str:
+        raw_url = "/package_build/component/events/{0}".format(event_id)
+        if proxy:
+            return build_console_realtime_proxy_path(region, raw_url)
+        return build_region_realtime_proxy_url(region, raw_url, scheme_type="http")
 
 
 class MyEncoder(json.JSONEncoder):

--- a/console/services/app_import_and_export_service.py
+++ b/console/services/app_import_and_export_service.py
@@ -19,6 +19,7 @@ from console.repositories.region_repo import region_repo
 from console.services.app_config.app_relation_service import \
     AppServiceRelationService
 from console.services.region_services import region_services
+from console.utils.realtime_proxy import build_console_realtime_proxy_path, build_region_realtime_proxy_url
 from goodrain_web import settings
 from www.apiclient.regionapi import RegionInvokeApi
 from www.tenantservice.baseservice import BaseTenantService
@@ -304,13 +305,7 @@ class AppExportService(object):
             return raw_url
 
     def _wrapper_director_download_url(self, region_name, raw_url):
-        region = region_repo.get_region_by_region_name(region_name)
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                return "https://" + splits_texts[1] + raw_url
-            else:
-                return "http://" + splits_texts[1] + raw_url
+        return build_console_realtime_proxy_path(region_name, raw_url)
 
     def get_export_record(self, export_format, app):
         return app_export_record_repo.get_export_record_by_unique_key(app.group_key, app.version, export_format)
@@ -862,29 +857,17 @@ class AppImportService(object):
         }
         return app_import_record_repo.create_app_import_record(**import_record_params)
 
-    def get_upload_url(self, region, event_id):
-        region = region_repo.get_region_by_region_name(region)
-        raw_url = "/app/upload"
-        upload_url = ""
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                upload_url = "https://" + splits_texts[1] + raw_url
-            else:
-                upload_url = "http://" + splits_texts[1] + raw_url
-        return upload_url + "/" + event_id
+    def get_upload_url(self, region, event_id, proxy=True):
+        raw_url = "/app/upload/{0}".format(event_id)
+        if proxy:
+            return build_console_realtime_proxy_path(region, raw_url)
+        return build_region_realtime_proxy_url(region, raw_url, scheme_type="http")
 
-    def get_upload_package_url(self, region, event_id):
-        region = region_repo.get_region_by_region_name(region)
-        raw_url = "/package_build/component/events"
-        get_upload_package_url = ""
-        if region:
-            splits_texts = region.wsurl.split("://")
-            if splits_texts[0] == "wss":
-                get_upload_package_url = "https://" + splits_texts[1] + raw_url
-            else:
-                get_upload_package_url = "http://" + splits_texts[1] + raw_url
-        return get_upload_package_url + "/" + event_id
+    def get_upload_package_url(self, region, event_id, proxy=True):
+        raw_url = "/package_build/component/events/{0}".format(event_id)
+        if proxy:
+            return build_console_realtime_proxy_path(region, raw_url)
+        return build_region_realtime_proxy_url(region, raw_url, scheme_type="http")
 
 
 class MyEncoder(json.JSONEncoder):

--- a/console/services/gateway_api.py
+++ b/console/services/gateway_api.py
@@ -99,8 +99,9 @@ class GatewayAPI(object):
         body = region_api.update_gateway_http_route(region, tenant_name, body)
         return body["bean"]  # type: ignore[index]  # NOTE: caller guarantees body is not None
 
-    def delete_http_route(self, region: str, tenant_name: str, namespace: str, name: str, region_app_id: str) -> Any:
-        body = region_api.delete_gateway_http_route(region, tenant_name, namespace, name, region_app_id)
+    def delete_http_route(self, region: str, tenant_name: str, namespace: str, name: str, region_app_id: str,
+                          operator: str = "") -> Any:
+        body = region_api.delete_gateway_http_route(region, tenant_name, namespace, name, region_app_id, operator)
         return body["bean"]  # type: ignore[index]  # NOTE: caller guarantees body is not None
 
 

--- a/console/services/gateway_api.py
+++ b/console/services/gateway_api.py
@@ -95,8 +95,8 @@ class GatewayAPI(object):
         body = region_api.update_gateway_http_route(region, tenant_name, body)
         return body["bean"]
 
-    def delete_http_route(self, region, tenant_name, namespace, name, region_app_id):
-        body = region_api.delete_gateway_http_route(region, tenant_name, namespace, name, region_app_id)
+    def delete_http_route(self, region, tenant_name, namespace, name, region_app_id, operator=""):
+        body = region_api.delete_gateway_http_route(region, tenant_name, namespace, name, region_app_id, operator)
         return body["bean"]
 
 

--- a/console/services/groupcopy_service.py
+++ b/console/services/groupcopy_service.py
@@ -109,12 +109,33 @@ class GroupAppCopyService(object):
         group_all_service_ids = [service["service_id"] for service in services_metadata["service_group_relation"]]
         if not service_ids:
             service_ids = group_all_service_ids
+        self.validate_services_support_copy(services_metadata, service_ids)
         remove_service_ids = list(set(service_ids) ^ set(group_all_service_ids))
         change_services_map = self.change_services_map(service_ids, old_services_map)
         services_metadata = self.pop_services_metadata(old_team, old_region_name, tar_team, tar_region_name, services_metadata,
                                                        remove_service_ids, service_ids, change_services_map)
         services_metadata = self.change_services_metadata_info(services_metadata, changes)
         return services_metadata, change_services_map
+
+    def validate_services_support_copy(self, services_metadata: Dict[str, Any], service_ids: List[str]) -> None:
+        selected_service_ids = set(service_ids or [])
+        unsupported_services = []
+        for service in services_metadata["apps"]:
+            service_base = service["service_base"]
+            service_id = service_base["service_id"]
+            if selected_service_ids and service_id not in selected_service_ids:
+                continue
+            if service_base.get("service_source") != "package_build":
+                continue
+            service_name = service_base.get("service_cname") or service_base.get(
+                "k8s_component_name") or service_id
+            unsupported_services.append(service_name)
+        if unsupported_services:
+            raise ServiceHandleException(
+                msg="package_build components do not support quick copy",
+                msg_show="上传软件包创建的组件暂不支持快速复制：{}".format(
+                    "、".join(unsupported_services)),
+                status_code=400)
 
     def pop_services_metadata(self,
                               old_team: Tenants,

--- a/console/services/groupcopy_service.py
+++ b/console/services/groupcopy_service.py
@@ -102,12 +102,33 @@ class GroupAppCopyService(object):
         group_all_service_ids = [service["service_id"] for service in services_metadata["service_group_relation"]]
         if not service_ids:
             service_ids = group_all_service_ids
+        self.validate_services_support_copy(services_metadata, service_ids)
         remove_service_ids = list(set(service_ids) ^ set(group_all_service_ids))
         change_services_map = self.change_services_map(service_ids, old_services_map)
         services_metadata = self.pop_services_metadata(old_team, old_region_name, tar_team, tar_region_name, services_metadata,
                                                        remove_service_ids, service_ids, change_services_map)
         services_metadata = self.change_services_metadata_info(services_metadata, changes)
         return services_metadata, change_services_map
+
+    def validate_services_support_copy(self, services_metadata, service_ids):
+        selected_service_ids = set(service_ids or [])
+        unsupported_services = []
+        for service in services_metadata["apps"]:
+            service_base = service["service_base"]
+            service_id = service_base["service_id"]
+            if selected_service_ids and service_id not in selected_service_ids:
+                continue
+            if service_base.get("service_source") != "package_build":
+                continue
+            service_name = service_base.get("service_cname") or service_base.get(
+                "k8s_component_name") or service_id
+            unsupported_services.append(service_name)
+        if unsupported_services:
+            raise ServiceHandleException(
+                msg="package_build components do not support quick copy",
+                msg_show="上传软件包创建的组件暂不支持快速复制：{}".format(
+                    "、".join(unsupported_services)),
+                status_code=400)
 
     def pop_services_metadata(self,
                               old_team,

--- a/console/services/helm_app_yaml.py
+++ b/console/services/helm_app_yaml.py
@@ -80,6 +80,8 @@ class HelmAppService(object):
                 app["extend_method"] = "state_multiple"
             if cv["basic_management"]["resource_type"] == "CronJob":
                 app["extend_method"] = "cronjob"
+            if cv["basic_management"]["resource_type"] == "DaemonSet":
+                app["extend_method"] = "daemonset"
             app_image = cv["basic_management"]["image"].split(":")
             app["version"] = app_image[1] if len(app_image) > 2 else "latest"
             memory = cv["basic_management"].get("memory", 0)

--- a/console/services/helm_app_yaml.py
+++ b/console/services/helm_app_yaml.py
@@ -77,6 +77,8 @@ class HelmAppService(object):
                 app["extend_method"] = "state_multiple"
             if cv["basic_management"]["resource_type"] == "CronJob":
                 app["extend_method"] = "cronjob"
+            if cv["basic_management"]["resource_type"] == "DaemonSet":
+                app["extend_method"] = "daemonset"
             app_image = cv["basic_management"]["image"].split(":")
             app["version"] = app_image[1] if len(app_image) > 2 else "latest"
             memory = cv["basic_management"].get("memory", 0)

--- a/console/services/kubeblocks_service.py
+++ b/console/services/kubeblocks_service.py
@@ -345,6 +345,16 @@ class KubeBlocksService(object):
         """
         构建创建 Cluster 的请求数据
         """
+        rbd_service = {
+            "service_id": new_service.service_id,
+            "service_alias": new_service.service_alias
+        }
+        group_id = cluster_params.get("group_id")
+        if group_id is not None:
+            app_id = str(group_id).strip()
+            if app_id and app_id != "-1":
+                rbd_service["app_id"] = app_id
+
         cluster_data = {
             "name": cluster_params.get("k8s_component_name", "") or cluster_params["cluster_name"],
             "namespace": namespace,
@@ -357,10 +367,7 @@ class KubeBlocksService(object):
             "storageClass": cluster_params.get("storage_class", ""),
             "backupRepo": cluster_params.get("backup_repo", ""),
             "terminationPolicy": cluster_params.get("termination_policy", "Delete"),
-            "rbdService": {
-                "service_id": new_service.service_id,
-                "service_alias": new_service.service_alias
-            }
+            "rbdService": rbd_service
         }
 
         backup_repo = cluster_params.get("backup_repo", "")

--- a/console/services/kubeblocks_service.py
+++ b/console/services/kubeblocks_service.py
@@ -353,6 +353,16 @@ class KubeBlocksService(object):
         """
         构建创建 Cluster 的请求数据
         """
+        rbd_service = {
+            "service_id": new_service.service_id,
+            "service_alias": new_service.service_alias
+        }
+        group_id = cluster_params.get("group_id")
+        if group_id is not None:
+            app_id = str(group_id).strip()
+            if app_id and app_id != "-1":
+                rbd_service["app_id"] = app_id
+
         cluster_data = {
             "name": cluster_params.get("k8s_component_name", "") or cluster_params["cluster_name"],
             "namespace": namespace,
@@ -365,10 +375,7 @@ class KubeBlocksService(object):
             "storageClass": cluster_params.get("storage_class", ""),
             "backupRepo": cluster_params.get("backup_repo", ""),
             "terminationPolicy": cluster_params.get("termination_policy", "Delete"),
-            "rbdService": {
-                "service_id": new_service.service_id,
-                "service_alias": new_service.service_alias
-            }
+            "rbdService": rbd_service
         }
 
         backup_repo = cluster_params.get("backup_repo", "")

--- a/console/services/package_upload_tool_service.py
+++ b/console/services/package_upload_tool_service.py
@@ -71,7 +71,7 @@ class PackageUploadToolService(object):
             )
 
         archive_path, should_cleanup = self._prepare_upload_archive(local_path, archive_name)
-        upload_url = import_service.get_upload_package_url(region_name, event_id)
+        upload_url = import_service.get_upload_package_url(region_name, event_id, proxy=False)
 
         try:
             with open(archive_path, "rb") as archive_file:

--- a/console/services/package_upload_tool_service.py
+++ b/console/services/package_upload_tool_service.py
@@ -70,7 +70,7 @@ class PackageUploadToolService(object):
             )
 
         archive_path, should_cleanup = self._prepare_upload_archive(local_path, archive_name)
-        upload_url = import_service.get_upload_package_url(region_name, event_id)
+        upload_url = import_service.get_upload_package_url(region_name, event_id, proxy=False)
 
         try:
             with open(archive_path, "rb") as archive_file:

--- a/console/services/perm_services.py
+++ b/console/services/perm_services.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from django.db import transaction
 from django.db.models import QuerySet
@@ -123,7 +123,7 @@ class RolePermService(object):
         return data
 
     def get_roles_union_perms(self, roles: Any, kind: Optional[str] = None, is_owner: bool = False,
-                              tenant_id: str = "") -> Dict[str, Any]:
+                              tenant_id: str = "", user: Any = None) -> Dict[str, Any]:
         union_role_perms: List[Any] = []
         app_perms: Dict[str, List[Any]] = dict()
         if roles:
@@ -143,9 +143,16 @@ class RolePermService(object):
         else:
             permissions = self.pack_role_perms_tree(get_perms_model(), union_role_perms, is_owner)
         app_ids = ServiceGroup.objects.filter(tenant_id=tenant_id).values_list("ID", flat=True)
+        creator_app_ids: Set[Any] = set()
+        if user and tenant_id:
+            creator_app_ids = set(
+                ServiceGroup.objects.filter(tenant_id=tenant_id, username=user.nick_name).values_list("ID", flat=True))
         app: Dict[str, Any] = {"sub_models": [], "perms": {}}
         for app_id in app_ids:
-            if str(app_id) not in app_perms:
+            if app_id in creator_app_ids:
+                models = self.pack_role_perms_tree(get_app_perms_model(), [], True)
+                app_permissions = models.get("app")
+            elif str(app_id) not in app_perms:
                 app_permissions = permissions.get("team").get("sub_models")[2].get("team_app_manage")
             else:
                 models = self.pack_role_perms_tree(get_app_perms_model(), app_perms.get(str(app_id)))
@@ -275,7 +282,7 @@ class UserKindPermService(object):
         if is_owner or is_ent_admin:
             is_owner = True
         user_roles = user_kind_role_repo.get_user_roles_model(kind, kind_id, user)
-        perms = role_perm_service.get_roles_union_perms(user_roles, kind, is_owner, tenant_id=kind_id)
+        perms = role_perm_service.get_roles_union_perms(user_roles, kind, is_owner, tenant_id=kind_id, user=user)
         data: Dict[str, Any] = {"user_id": user.user_id}
         data.update(perms)
         return data

--- a/console/services/perm_services.py
+++ b/console/services/perm_services.py
@@ -120,7 +120,7 @@ class RolePermService(object):
             data.append(role_perms_info)
         return data
 
-    def get_roles_union_perms(self, roles, kind=None, is_owner=False, tenant_id=""):
+    def get_roles_union_perms(self, roles, kind=None, is_owner=False, tenant_id="", user=None):
         union_role_perms = []
         app_perms = dict()
         if roles:
@@ -140,9 +140,16 @@ class RolePermService(object):
         else:
             permissions = self.pack_role_perms_tree(get_perms_model(), union_role_perms, is_owner)
         app_ids = ServiceGroup.objects.filter(tenant_id=tenant_id).values_list("ID", flat=True)
+        creator_app_ids = set()
+        if user and tenant_id:
+            creator_app_ids = set(
+                ServiceGroup.objects.filter(tenant_id=tenant_id, username=user.nick_name).values_list("ID", flat=True))
         app = {"sub_models": [], "perms": {}}
         for app_id in app_ids:
-            if str(app_id) not in app_perms:
+            if app_id in creator_app_ids:
+                models = self.pack_role_perms_tree(get_app_perms_model(), [], True)
+                app_permissions = models.get("app")
+            elif str(app_id) not in app_perms:
                 app_permissions = permissions.get("team").get("sub_models")[2].get("team_app_manage")
             else:
                 models = self.pack_role_perms_tree(get_app_perms_model(), app_perms.get(str(app_id)))
@@ -270,7 +277,7 @@ class UserKindPermService(object):
         if is_owner or is_ent_admin:
             is_owner = True
         user_roles = user_kind_role_repo.get_user_roles_model(kind, kind_id, user)
-        perms = role_perm_service.get_roles_union_perms(user_roles, kind, is_owner, tenant_id=kind_id)
+        perms = role_perm_service.get_roles_union_perms(user_roles, kind, is_owner, tenant_id=kind_id, user=user)
         data = {"user_id": user.user_id}
         data.update(perms)
         return data

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import re
 import string
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, quote
@@ -45,6 +46,18 @@ region_api = RegionInvokeApi()
 
 
 class TeamService(object):
+    USER_REGISTRY_SCOPE = "user"
+    ENTERPRISE_REGISTRY_SCOPE = "enterprise"
+    SUPPORTED_REGISTRY_HUB_TYPES = (
+        "Docker", "Harbor", "AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR")
+    LEGACY_REGISTRY_HUB_TYPE_ALIASES = {
+        "Aliyun": "AliyunACR",
+        "Tencent": "TencentTCR",
+        "Huawei": "HuaweiSWR",
+        "Volcano": "VolcanoCR",
+    }
+    CLOUD_REGISTRY_HUB_TYPES = ("AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR")
+
     def get_tenant_by_tenant_name(self, tenant_name: str, exception: bool = True) -> Optional[Tenants]:
         return team_repo.get_tenant_by_tenant_name(tenant_name=tenant_name, exception=exception)
 
@@ -726,9 +739,238 @@ class TeamService(object):
     def list_registry_auths(self, tenant_id: str, region_name: str, user_id: str) -> Any:
         return team_registry_auth_repo.list_by_team_id(tenant_id, region_name, user_id)
 
+    def serialize_registry_auth(self, auth: Any, include_password: bool = False) -> Dict[str, Any]:
+        data = auth.to_dict() if hasattr(auth, "to_dict") else dict(auth.__dict__)
+        scope = data.get("scope") or self.USER_REGISTRY_SCOPE
+        data["scope"] = scope
+        data["hub_type"] = self.normalize_registry_hub_type(data.get("hub_type", "Docker"))
+        data.pop("access_secret", None)
+        if scope == self.ENTERPRISE_REGISTRY_SCOPE and not include_password:
+            data.pop("password", None)
+        return data
+
+    def list_accessible_registry_auths(self, user: Any) -> List[Any]:
+        auths = list(team_registry_auth_repo.list_user_registry_auths(user.user_id))
+        enterprise_id = getattr(user, "enterprise_id", "")
+        if enterprise_id:
+            auths.extend(list(team_registry_auth_repo.list_enterprise_registry_auths(enterprise_id)))
+        return auths
+
+    def resolve_registry_auth(self, user: Any, secret_id: str) -> Any:
+        if not secret_id:
+            raise ServiceHandleException(msg="registry auth id is required", msg_show="缺少镜像仓库认证ID", status_code=400)
+        auth = team_registry_auth_repo.get_user_registry_auth(secret_id, user.user_id)
+        if auth:
+            return auth
+        enterprise_id = getattr(user, "enterprise_id", "")
+        if enterprise_id:
+            auth = team_registry_auth_repo.get_enterprise_registry_auth(secret_id, enterprise_id)
+            if auth:
+                return auth
+        raise ServiceHandleException(msg="registry auth not found", msg_show="镜像仓库不存在", status_code=404)
+
+    def normalize_registry_hub_type(self, hub_type: str) -> str:
+        return self.LEGACY_REGISTRY_HUB_TYPE_ALIASES.get(hub_type, hub_type)
+
+    def validate_registry_hub_type(self, hub_type: str) -> None:
+        if self.normalize_registry_hub_type(hub_type) not in self.SUPPORTED_REGISTRY_HUB_TYPES:
+            raise ServiceHandleException(msg="unsupported registry hub type", msg_show="不支持的镜像仓库类型", status_code=400)
+
+    def _registry_v2_headers(self, username: str, password: str) -> Dict[str, str]:
+        auth = base64.b64encode("{}:{}".format(username, password).encode()).decode()
+        return {"Authorization": "Basic {}".format(auth)}
+
+    def _registry_error_detail(self, response: Any) -> str:
+        body = getattr(response, "text", "") or ""
+        body = body.replace("\n", " ").replace("\r", " ").strip()
+        if len(body) > 300:
+            body = body[:300] + "..."
+        return "status:{}, body:{}".format(response.status_code, body) if body else "status:{}".format(response.status_code)
+
+    def _parse_registry_bearer_challenge(self, header: Optional[str]) -> Optional[Dict[str, str]]:
+        if not header or not header.startswith("Bearer "):
+            return None
+        challenge = header[len("Bearer "):]
+        return dict((key, value) for key, value in re.findall(r'(\w+)="([^"]*)"', challenge))
+
+    def _get_registry_bearer_token(self, challenge: Dict[str, str], username: str, password: str) -> Optional[str]:
+        realm = challenge.get("realm")
+        if not realm:
+            return None
+        params = {}
+        if challenge.get("service"):
+            params["service"] = challenge["service"]
+        if challenge.get("scope"):
+            params["scope"] = challenge["scope"]
+        response = requests.get(
+            realm,
+            params=params,
+            auth=(username, password),
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry bearer token: %s", detail)
+            raise ServiceHandleException(
+                msg="failed to get registry bearer token, {}".format(detail),
+                msg_show="镜像仓库认证失败({})".format(detail),
+                status_code=response.status_code)
+        data = response.json()
+        return data.get("token") or data.get("access_token")
+
+    def _registry_v2_get(self, url: str, username: str, password: str, headers: Optional[Dict[str, str]] = None) -> Any:
+        request_headers = self._registry_v2_headers(username, password)
+        if headers:
+            request_headers.update(headers)
+        response = requests.get(
+            url,
+            headers=request_headers,
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 401:
+            return response
+        challenge = self._parse_registry_bearer_challenge(response.headers.get("WWW-Authenticate"))
+        if not challenge:
+            return response
+        token = self._get_registry_bearer_token(challenge, username, password)
+        if not token:
+            return response
+        bearer_headers = dict(request_headers)
+        bearer_headers["Authorization"] = "Bearer {}".format(token)
+        return requests.get(
+            url,
+            headers=bearer_headers,
+            verify=False,
+            timeout=10,
+        )
+
+    def _registry_base_url(self, domain: str) -> str:
+        parsed_url = urlparse(domain)
+        if not parsed_url.scheme or not parsed_url.netloc:
+            raise ServiceHandleException(msg="invalid registry domain", msg_show="镜像仓库地址格式错误", status_code=400)
+        return parsed_url.scheme + "://" + parsed_url.netloc
+
+    def _region_registry_auth_payload(self, auth: Any) -> Dict[str, Any]:
+        data = auth.to_dict() if hasattr(auth, "to_dict") else dict(auth)
+        return {
+            "tenant_id": data.get("tenant_id", ""),
+            "secret_id": data.get("secret_id", ""),
+            "domain": data.get("domain", ""),
+            "username": data.get("username", ""),
+            "password": data.get("password", ""),
+            "region_name": data.get("region_name", ""),
+            "hub_type": self.normalize_registry_hub_type(data.get("hub_type", "Docker")),
+        }
+
+    def check_registry_connection(self, domain: str, username: str, password: str, hub_type: str) -> bool:
+        self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
+        if hub_type in ("Docker", "Harbor"):
+            self.get_registry_namespaces(domain, username, password, hub_type)
+            return True
+        base_url = self._registry_base_url(domain)
+        try:
+            response = self._registry_v2_get("{}/v2/".format(base_url), username, password)
+        except requests.exceptions.RequestException as e:
+            logger.exception(e)
+            raise ServiceHandleException(
+                msg="failed to connect registry: {}".format(e), msg_show="连接镜像仓库失败", status_code=500)
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to connect registry %s, hub_type=%s, %s", base_url, hub_type, detail)
+            raise ServiceHandleException(
+                msg="failed to connect registry, {}".format(detail),
+                msg_show="镜像仓库连接测试失败({})".format(detail),
+                status_code=response.status_code)
+        return True
+
+    def _get_registry_v2_namespaces(self, base_url: str, username: str, password: str) -> List[str]:
+        response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry namespaces %s, %s", base_url, detail)
+            raise ServiceHandleException(
+                msg="failed to get registry namespaces, {}".format(detail),
+                msg_show="获取镜像仓库命名空间失败({})".format(detail),
+                status_code=response.status_code)
+        repositories = response.json().get("repositories", [])
+        namespaces = set()
+        for repo in repositories:
+            if "/" in repo:
+                namespaces.add(repo.split("/", 1)[0])
+            else:
+                namespaces.add("library")
+        return list(namespaces) or ["library"]
+
+    def _get_registry_v2_images(self, base_url: str, username: str, password: str, hub_type: str, namespace: str,
+                                page: int = 1, page_size: int = 10, search_key: Optional[str] = None) -> Dict[str, Any]:
+        response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry images %s, hub_type=%s, %s", base_url, hub_type, detail)
+            raise ServiceHandleException(
+                msg="failed to get registry images, {}".format(detail),
+                msg_show="获取镜像列表失败({})".format(detail),
+                status_code=response.status_code)
+        repositories = response.json().get("repositories", [])
+        if namespace == "library":
+            filtered_repos = [repo for repo in repositories if "/" not in repo]
+        else:
+            filtered_repos = [repo.split("/", 1)[1] for repo in repositories if repo.startswith(namespace + "/")]
+        if search_key:
+            filtered_repos = [repo for repo in filtered_repos if search_key.lower() in repo.lower()]
+        total = len(filtered_repos)
+        start = (page - 1) * page_size
+        end = start + page_size
+        images = [{
+            "name": repo,
+            "namespace": namespace,
+            "description": "",
+            "is_public": True,
+            "pull_count": 0,
+            "star_count": 0,
+            "created_at": "",
+            "updated_at": "",
+            "status": "active",
+            "registry_type": hub_type,
+        } for repo in filtered_repos[start:end]]
+        return {"images": images, "total": total, "page": page, "page_size": page_size}
+
+    def _get_registry_v2_tags(self, base_url: str, username: str, password: str, namespace: str, name: str,
+                              page: int = 1, page_size: int = 10, search_key: Optional[str] = None) -> Dict[str, Any]:
+        repo_name = name if namespace == "library" else "{}/{}".format(namespace, name)
+        response = self._registry_v2_get("{}/v2/{}/tags/list".format(base_url, repo_name), username, password)
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry tags %s/%s, %s", base_url, repo_name, detail)
+            raise ServiceHandleException(
+                msg="failed to get registry tags, {}".format(detail),
+                msg_show="获取镜像标签失败({})".format(detail),
+                status_code=response.status_code)
+        all_tags = response.json().get("tags", []) or []
+        if search_key:
+            all_tags = [tag for tag in all_tags if search_key.lower() in tag.lower()]
+        total = len(all_tags)
+        start = (page - 1) * page_size
+        end = start + page_size
+        tags = [{
+            "name": tag,
+            "size": 0,
+            "digest": "",
+            "created_at": "",
+            "updated_at": "",
+            "os": "",
+            "architecture": "",
+            "status": "active",
+        } for tag in all_tags[start:end]]
+        return {"tags": tags, "total": total, "page": page, "page_size": page_size}
+
     @transaction.atomic()
     def create_registry_auth(self, tenant: Tenants, region_name: str, domain: str, username: str, password: str,
-                             hub_type: str, user_id: str) -> None:
+                             hub_type: str = "Docker", user_id: int = 0) -> None:
+        hub_type = self.normalize_registry_hub_type(hub_type)
         auth = team_registry_auth_repo.get_by_team_id_domain(tenant.tenant_id, region_name, domain)
         if auth:
             raise ServiceHandleException(
@@ -740,17 +982,23 @@ class TeamService(object):
             "username": username,
             "password": password,
             "region_name": region_name,
+            "hub_type": hub_type,
+            "user_id": user_id,
+            "scope": self.USER_REGISTRY_SCOPE,
+            "enterprise_id": "",
         }
         team_registry_auth_repo.create_team_registry_auth(**params)
-        region_api.create_registry_auth(tenant.tenant_name, region_name, params)
+        region_api.create_registry_auth(tenant.tenant_name, region_name, self._region_registry_auth_payload(params))
 
     @transaction.atomic()
     def update_registry_auth(self, tenant: Tenants, region_name: str, secret_id: str, data: dict) -> None:
         auth = team_registry_auth_repo.get_by_secret_id(secret_id)
         if not auth:
             return
+        if "hub_type" in data:
+            data["hub_type"] = self.normalize_registry_hub_type(data["hub_type"])
         team_registry_auth_repo.update_team_registry_auth(tenant.tenant_id, region_name, secret_id, **data)
-        region_api.update_registry_auth(tenant.tenant_name, region_name, auth[0].to_dict())
+        region_api.update_registry_auth(tenant.tenant_name, region_name, self._region_registry_auth_payload(auth[0]))
 
     @transaction.atomic()
     def delete_registry_auth(self, tenant: Tenants, region_name: str, secret_id: str, user_id: str) -> None:
@@ -761,9 +1009,11 @@ class TeamService(object):
         })
 
     def get_registry_namespaces(self, domain: str, username: str, password: str, hub_type: str) -> Any:
+        self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Harbor":
                 # Harbor API
@@ -811,15 +1061,7 @@ class TeamService(object):
                         return namespaces
                 else:
                     # 自建 Docker Registry API v2
-                    api_url = "{}/v2/_catalog".format(base_url)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
                     if response.status_code == 200:
                         repositories = response.json().get("repositories", [])
                         # 提取命名空间（取第一个/之前的部分作为命名空间）
@@ -832,32 +1074,8 @@ class TeamService(object):
                                 namespace_set.add("library")
                         return list(namespace_set) or ["library"]
                     
-            elif hub_type == "Volcano":
-                # 火山引擎容器镜像服务 API
-                api_url = "{}/v2/manage/namespaces".format(base_url)
-                response = requests.get(
-                    api_url,
-                    auth=(username, password),
-                    verify=False,
-                    timeout=10
-                )
-                if response.status_code == 200:
-                    namespaces = response.json().get("namespaces", [])
-                    return [ns["name"] for ns in namespaces]
-                    
-            elif hub_type == "Aliyun":
-                # 阿里云容器镜像服务 API
-                api_url = "https://cr.{}.aliyuncs.com/v2/repos/namespaces".format(
-                    parsed_url.netloc.split('.')[1]  # 获取地域信息
-                )
-                response = requests.get(
-                    api_url,
-                    headers={"Authorization": "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()},
-                    timeout=10
-                )
-                if response.status_code == 200:
-                    namespaces = response.json().get("data", {}).get("namespaces", [])
-                    return [ns["namespace"] for ns in namespaces]
+            elif hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_namespaces(base_url, username, password)
 
             raise ServiceHandleException(
                 msg="failed to get registry namespaces, status:{}".format(response.status_code),
@@ -905,9 +1123,13 @@ class TeamService(object):
         Returns:
             dict: 包含镜像详细信息的字典
         """
+        self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
+            if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_images(base_url, username, password, hub_type, namespace, page, page_size, search_key)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Harbor":
                 # Harbor API 支持搜索
@@ -989,15 +1211,7 @@ class TeamService(object):
                         }
                 else:
                     # 自建 Docker Registry API v2
-                    api_url = "{}/v2/_catalog".format(base_url)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
                     if response.status_code == 200:
                         repositories = response.json().get("repositories", [])
                         # 过滤指定命名空间的镜像
@@ -1019,19 +1233,15 @@ class TeamService(object):
                         for repo in paginated_repos:
                             # 获取仓库的标签列表
                             tags_url = "{}/v2/{}/tags/list".format(base_url, repo if namespace == "library" else f"{namespace}/{repo}")
-                            tags_response = requests.get(
-                                tags_url,
-                                headers=headers,
-                                verify=False,
-                                timeout=10
-                            )
+                            tags_response = self._registry_v2_get(tags_url, username, password)
+                            updated_at = ""
                             
                             if tags_response.status_code == 200:
                                 tags = tags_response.json().get("tags", [])
                                 if tags:
                                     # 获取最新标签的信息
                                     repo_name = repo if namespace == "library" else f"{namespace}/{repo}"
-                                    tag_info = self._get_registry_tag_info(base_url, repo_name, tags[0], f"Basic {auth}")
+                                    tag_info = self._get_registry_tag_info(base_url, repo_name, tags[0], username, password)
                                     updated_at = tag_info["updated_at"]
                             
                             images.append({
@@ -1076,9 +1286,13 @@ class TeamService(object):
         Returns:
             dict: 包含标签详细信息的字典
         """
+        self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
+            if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_tags(base_url, username, password, namespace, name, page, page_size, search_key)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Docker":
                 if "docker.io" in domain:
@@ -1119,15 +1333,7 @@ class TeamService(object):
                 else:
                     # 自建 Docker Registry API v2
                     repo_name = name if namespace == "library" else f"{namespace}/{name}"
-                    api_url = "{}/v2/{}/tags/list".format(base_url, repo_name)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/{}/tags/list".format(base_url, repo_name), username, password)
                     if response.status_code == 200:
                         all_tags = response.json().get("tags", [])
                         if search_key:
@@ -1141,7 +1347,7 @@ class TeamService(object):
                         tags = []
                         for tag_name in paginated_tags:
                             # 获取标签详细信息
-                            tag_info = self._get_registry_tag_info(base_url, repo_name, tag_name, f"Basic {auth}")
+                            tag_info = self._get_registry_tag_info(base_url, repo_name, tag_name, username, password)
                             
                             tags.append({
                                 "name": tag_name,
@@ -1259,28 +1465,27 @@ class TeamService(object):
                 msg_show="连接镜像仓库失败",
                 status_code=500)
 
-    def _get_registry_tag_info(self, base_url: str, repo_name: str, tag_name: str, auth_header: str) -> dict:
+    def _get_registry_tag_info(self, base_url: str, repo_name: str, tag_name: str,
+                               username: str, password: str) -> dict:
         """获取 Docker Registry 标签的详细信息
         
         Args:
             base_url: 仓库基础URL
             repo_name: 仓库名称
             tag_name: 标签名称
-            auth_header: 认证头信息
+            username: 仓库用户名
+            password: 仓库密码
             
         Returns:
             dict: 包含标签详细信息的字典
         """
         try:
             manifest_url = "{}/v2/{}/manifests/{}".format(base_url, repo_name, tag_name)
-            manifest_response = requests.get(
+            manifest_response = self._registry_v2_get(
                 manifest_url,
-                headers={
-                    "Authorization": auth_header,
-                    "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-                },
-                verify=False,
-                timeout=10
+                username,
+                password,
+                {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
             )
             
             if manifest_response.status_code == 200:
@@ -1292,14 +1497,7 @@ class TeamService(object):
                 
                 if config_digest:
                     config_url = "{}/v2/{}/blobs/{}".format(base_url, repo_name, config_digest)
-                    config_response = requests.get(
-                        config_url,
-                        headers={
-                            "Authorization": auth_header,
-                        },
-                        verify=False,
-                        timeout=10
-                    )
+                    config_response = self._registry_v2_get(config_url, username, password)
                     if config_response.status_code == 200:
                         config = config_response.json()
                         return {

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -684,6 +684,7 @@ class TeamService(object):
         scope = data.get("scope") or self.USER_REGISTRY_SCOPE
         data["scope"] = scope
         data["hub_type"] = self.normalize_registry_hub_type(data.get("hub_type", "Docker"))
+        data.pop("access_secret", None)
         if scope == self.ENTERPRISE_REGISTRY_SCOPE and not include_password:
             data.pop("password", None)
         return data

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import re
 import string
 from urllib.parse import urlparse, quote
 
@@ -45,14 +46,14 @@ class TeamService(object):
     USER_REGISTRY_SCOPE = "user"
     ENTERPRISE_REGISTRY_SCOPE = "enterprise"
     SUPPORTED_REGISTRY_HUB_TYPES = (
-        "Docker", "Harbor", "AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS")
+        "Docker", "Harbor", "AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR")
     LEGACY_REGISTRY_HUB_TYPE_ALIASES = {
         "Aliyun": "AliyunACR",
         "Tencent": "TencentTCR",
         "Huawei": "HuaweiSWR",
-        "Volcano": "VolcanoTOS",
+        "Volcano": "VolcanoCR",
     }
-    CLOUD_REGISTRY_HUB_TYPES = ("AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS")
+    CLOUD_REGISTRY_HUB_TYPES = ("AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR")
 
     def get_tenant_by_tenant_name(self, tenant_name, exception=True):
         return team_repo.get_tenant_by_tenant_name(tenant_name=tenant_name, exception=exception)
@@ -683,13 +684,8 @@ class TeamService(object):
         scope = data.get("scope") or self.USER_REGISTRY_SCOPE
         data["scope"] = scope
         data["hub_type"] = self.normalize_registry_hub_type(data.get("hub_type", "Docker"))
-        if data["hub_type"] in self.CLOUD_REGISTRY_HUB_TYPES:
-            data["access_key"] = data.get("username", "")
-            if include_password:
-                data["access_secret"] = data.get("password", "")
         if scope == self.ENTERPRISE_REGISTRY_SCOPE and not include_password:
             data.pop("password", None)
-            data.pop("access_secret", None)
         return data
 
     def list_accessible_registry_auths(self, user):
@@ -723,6 +719,72 @@ class TeamService(object):
         auth = base64.b64encode("{}:{}".format(username, password).encode()).decode()
         return {"Authorization": "Basic {}".format(auth)}
 
+    def _registry_error_detail(self, response):
+        body = getattr(response, "text", "") or ""
+        body = body.replace("\n", " ").replace("\r", " ").strip()
+        if len(body) > 300:
+            body = body[:300] + "..."
+        return "status:{}, body:{}".format(response.status_code, body) if body else "status:{}".format(response.status_code)
+
+    def _parse_registry_bearer_challenge(self, header):
+        if not header or not header.startswith("Bearer "):
+            return None
+        challenge = header[len("Bearer "):]
+        return dict((key, value) for key, value in re.findall(r'(\w+)="([^"]*)"', challenge))
+
+    def _get_registry_bearer_token(self, challenge, username, password):
+        realm = challenge.get("realm")
+        if not realm:
+            return None
+        params = {}
+        if challenge.get("service"):
+            params["service"] = challenge["service"]
+        if challenge.get("scope"):
+            params["scope"] = challenge["scope"]
+        response = requests.get(
+            realm,
+            params=params,
+            auth=(username, password),
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry bearer token: %s", detail)
+            raise ServiceHandleException(
+                msg="failed to get registry bearer token, {}".format(detail),
+                msg_show="镜像仓库认证失败({})".format(detail),
+                status_code=response.status_code)
+        data = response.json()
+        return data.get("token") or data.get("access_token")
+
+    def _registry_v2_get(self, url, username, password, headers=None):
+        request_headers = self._registry_v2_headers(username, password)
+        if headers:
+            request_headers.update(headers)
+        response = requests.get(
+            url,
+            headers=request_headers,
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 401:
+            return response
+        challenge = self._parse_registry_bearer_challenge(response.headers.get("WWW-Authenticate"))
+        if not challenge:
+            return response
+        token = self._get_registry_bearer_token(challenge, username, password)
+        if not token:
+            return response
+        bearer_headers = dict(request_headers)
+        bearer_headers["Authorization"] = "Bearer {}".format(token)
+        return requests.get(
+            url,
+            headers=bearer_headers,
+            verify=False,
+            timeout=10,
+        )
+
     def _registry_base_url(self, domain):
         parsed_url = urlparse(domain)
         if not parsed_url.scheme or not parsed_url.netloc:
@@ -749,34 +811,28 @@ class TeamService(object):
             return True
         base_url = self._registry_base_url(domain)
         try:
-            response = requests.get(
-                "{}/v2/".format(base_url),
-                headers=self._registry_v2_headers(username, password),
-                verify=False,
-                timeout=10,
-            )
+            response = self._registry_v2_get("{}/v2/".format(base_url), username, password)
         except requests.exceptions.RequestException as e:
             logger.exception(e)
             raise ServiceHandleException(
                 msg="failed to connect registry: {}".format(e), msg_show="连接镜像仓库失败", status_code=500)
         if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to connect registry %s, hub_type=%s, %s", base_url, hub_type, detail)
             raise ServiceHandleException(
-                msg="failed to connect registry, status:{}".format(response.status_code),
-                msg_show="镜像仓库连接测试失败",
+                msg="failed to connect registry, {}".format(detail),
+                msg_show="镜像仓库连接测试失败({})".format(detail),
                 status_code=response.status_code)
         return True
 
     def _get_registry_v2_namespaces(self, base_url, username, password):
-        response = requests.get(
-            "{}/v2/_catalog".format(base_url),
-            headers=self._registry_v2_headers(username, password),
-            verify=False,
-            timeout=10,
-        )
+        response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
         if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry namespaces %s, %s", base_url, detail)
             raise ServiceHandleException(
-                msg="failed to get registry namespaces, status:{}".format(response.status_code),
-                msg_show="获取镜像仓库命名空间失败",
+                msg="failed to get registry namespaces, {}".format(detail),
+                msg_show="获取镜像仓库命名空间失败({})".format(detail),
                 status_code=response.status_code)
         repositories = response.json().get("repositories", [])
         namespaces = set()
@@ -788,16 +844,13 @@ class TeamService(object):
         return list(namespaces) or ["library"]
 
     def _get_registry_v2_images(self, base_url, username, password, hub_type, namespace, page=1, page_size=10, search_key=None):
-        response = requests.get(
-            "{}/v2/_catalog".format(base_url),
-            headers=self._registry_v2_headers(username, password),
-            verify=False,
-            timeout=10,
-        )
+        response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
         if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry images %s, hub_type=%s, %s", base_url, hub_type, detail)
             raise ServiceHandleException(
-                msg="failed to get registry images, status:{}".format(response.status_code),
-                msg_show="获取镜像列表失败",
+                msg="failed to get registry images, {}".format(detail),
+                msg_show="获取镜像列表失败({})".format(detail),
                 status_code=response.status_code)
         repositories = response.json().get("repositories", [])
         if namespace == "library":
@@ -825,16 +878,13 @@ class TeamService(object):
 
     def _get_registry_v2_tags(self, base_url, username, password, namespace, name, page=1, page_size=10, search_key=None):
         repo_name = name if namespace == "library" else "{}/{}".format(namespace, name)
-        response = requests.get(
-            "{}/v2/{}/tags/list".format(base_url, repo_name),
-            headers=self._registry_v2_headers(username, password),
-            verify=False,
-            timeout=10,
-        )
+        response = self._registry_v2_get("{}/v2/{}/tags/list".format(base_url, repo_name), username, password)
         if response.status_code != 200:
+            detail = self._registry_error_detail(response)
+            logger.warning("failed to get registry tags %s/%s, %s", base_url, repo_name, detail)
             raise ServiceHandleException(
-                msg="failed to get registry tags, status:{}".format(response.status_code),
-                msg_show="获取镜像标签失败",
+                msg="failed to get registry tags, {}".format(detail),
+                msg_show="获取镜像标签失败({})".format(detail),
                 status_code=response.status_code)
         all_tags = response.json().get("tags", []) or []
         if search_key:
@@ -947,15 +997,7 @@ class TeamService(object):
                         return namespaces
                 else:
                     # 自建 Docker Registry API v2
-                    api_url = "{}/v2/_catalog".format(base_url)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
                     if response.status_code == 200:
                         repositories = response.json().get("repositories", [])
                         # 提取命名空间（取第一个/之前的部分作为命名空间）
@@ -1104,15 +1146,7 @@ class TeamService(object):
                         }
                 else:
                     # 自建 Docker Registry API v2
-                    api_url = "{}/v2/_catalog".format(base_url)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/_catalog".format(base_url), username, password)
                     if response.status_code == 200:
                         repositories = response.json().get("repositories", [])
                         # 过滤指定命名空间的镜像
@@ -1134,19 +1168,15 @@ class TeamService(object):
                         for repo in paginated_repos:
                             # 获取仓库的标签列表
                             tags_url = "{}/v2/{}/tags/list".format(base_url, repo if namespace == "library" else f"{namespace}/{repo}")
-                            tags_response = requests.get(
-                                tags_url,
-                                headers=headers,
-                                verify=False,
-                                timeout=10
-                            )
+                            tags_response = self._registry_v2_get(tags_url, username, password)
+                            updated_at = ""
                             
                             if tags_response.status_code == 200:
                                 tags = tags_response.json().get("tags", [])
                                 if tags:
                                     # 获取最新标签的信息
                                     repo_name = repo if namespace == "library" else f"{namespace}/{repo}"
-                                    tag_info = self._get_registry_tag_info(base_url, repo_name, tags[0], f"Basic {auth}")
+                                    tag_info = self._get_registry_tag_info(base_url, repo_name, tags[0], username, password)
                                     updated_at = tag_info["updated_at"]
                             
                             images.append({
@@ -1237,15 +1267,7 @@ class TeamService(object):
                 else:
                     # 自建 Docker Registry API v2
                     repo_name = name if namespace == "library" else f"{namespace}/{name}"
-                    api_url = "{}/v2/{}/tags/list".format(base_url, repo_name)
-                    auth = base64.b64encode(f"{username}:{password}".encode()).decode()
-                    headers = {"Authorization": f"Basic {auth}"}
-                    response = requests.get(
-                        api_url,
-                        headers=headers,
-                        verify=False,
-                        timeout=10
-                    )
+                    response = self._registry_v2_get("{}/v2/{}/tags/list".format(base_url, repo_name), username, password)
                     if response.status_code == 200:
                         all_tags = response.json().get("tags", [])
                         if search_key:
@@ -1259,7 +1281,7 @@ class TeamService(object):
                         tags = []
                         for tag_name in paginated_tags:
                             # 获取标签详细信息
-                            tag_info = self._get_registry_tag_info(base_url, repo_name, tag_name, f"Basic {auth}")
+                            tag_info = self._get_registry_tag_info(base_url, repo_name, tag_name, username, password)
                             
                             tags.append({
                                 "name": tag_name,
@@ -1377,28 +1399,26 @@ class TeamService(object):
                 msg_show="连接镜像仓库失败",
                 status_code=500)
 
-    def _get_registry_tag_info(self, base_url, repo_name, tag_name, auth_header):
+    def _get_registry_tag_info(self, base_url, repo_name, tag_name, username, password):
         """获取 Docker Registry 标签的详细信息
         
         Args:
             base_url: 仓库基础URL
             repo_name: 仓库名称
             tag_name: 标签名称
-            auth_header: 认证头信息
+            username: 仓库用户名
+            password: 仓库密码
             
         Returns:
             dict: 包含标签详细信息的字典
         """
         try:
             manifest_url = "{}/v2/{}/manifests/{}".format(base_url, repo_name, tag_name)
-            manifest_response = requests.get(
+            manifest_response = self._registry_v2_get(
                 manifest_url,
-                headers={
-                    "Authorization": auth_header,
-                    "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-                },
-                verify=False,
-                timeout=10
+                username,
+                password,
+                {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
             )
             
             if manifest_response.status_code == 200:
@@ -1410,14 +1430,7 @@ class TeamService(object):
                 
                 if config_digest:
                     config_url = "{}/v2/{}/blobs/{}".format(base_url, repo_name, config_digest)
-                    config_response = requests.get(
-                        config_url,
-                        headers={
-                            "Authorization": auth_header,
-                        },
-                        verify=False,
-                        timeout=10
-                    )
+                    config_response = self._registry_v2_get(config_url, username, password)
                     if config_response.status_code == 200:
                         config = config_response.json()
                         return {

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -42,6 +42,11 @@ region_api = RegionInvokeApi()
 
 
 class TeamService(object):
+    USER_REGISTRY_SCOPE = "user"
+    ENTERPRISE_REGISTRY_SCOPE = "enterprise"
+    SUPPORTED_REGISTRY_HUB_TYPES = ("Docker", "Harbor", "Aliyun", "Tencent", "Huawei", "Volcano")
+    CLOUD_REGISTRY_HUB_TYPES = ("Aliyun", "Tencent", "Huawei", "Volcano")
+
     def get_tenant_by_tenant_name(self, tenant_name, exception=True):
         return team_repo.get_tenant_by_tenant_name(tenant_name=tenant_name, exception=exception)
 
@@ -666,8 +671,174 @@ class TeamService(object):
     def list_registry_auths(self, tenant_id, region_name, user_id):
         return team_registry_auth_repo.list_by_team_id(tenant_id, region_name, user_id)
 
+    def serialize_registry_auth(self, auth, include_password=False):
+        data = auth.to_dict() if hasattr(auth, "to_dict") else dict(auth.__dict__)
+        scope = data.get("scope") or self.USER_REGISTRY_SCOPE
+        data["scope"] = scope
+        if scope == self.ENTERPRISE_REGISTRY_SCOPE and not include_password:
+            data.pop("password", None)
+        return data
+
+    def list_accessible_registry_auths(self, user):
+        auths = list(team_registry_auth_repo.list_user_registry_auths(user.user_id))
+        enterprise_id = getattr(user, "enterprise_id", "")
+        if enterprise_id:
+            auths.extend(list(team_registry_auth_repo.list_enterprise_registry_auths(enterprise_id)))
+        return auths
+
+    def resolve_registry_auth(self, user, secret_id):
+        if not secret_id:
+            raise ServiceHandleException(msg="registry auth id is required", msg_show="缺少镜像仓库认证ID", status_code=400)
+        auth = team_registry_auth_repo.get_user_registry_auth(secret_id, user.user_id)
+        if auth:
+            return auth
+        enterprise_id = getattr(user, "enterprise_id", "")
+        if enterprise_id:
+            auth = team_registry_auth_repo.get_enterprise_registry_auth(secret_id, enterprise_id)
+            if auth:
+                return auth
+        raise ServiceHandleException(msg="registry auth not found", msg_show="镜像仓库不存在", status_code=404)
+
+    def validate_registry_hub_type(self, hub_type):
+        if hub_type not in self.SUPPORTED_REGISTRY_HUB_TYPES:
+            raise ServiceHandleException(msg="unsupported registry hub type", msg_show="不支持的镜像仓库类型", status_code=400)
+
+    def _registry_v2_headers(self, username, password):
+        auth = base64.b64encode("{}:{}".format(username, password).encode()).decode()
+        return {"Authorization": "Basic {}".format(auth)}
+
+    def _registry_base_url(self, domain):
+        parsed_url = urlparse(domain)
+        if not parsed_url.scheme or not parsed_url.netloc:
+            raise ServiceHandleException(msg="invalid registry domain", msg_show="镜像仓库地址格式错误", status_code=400)
+        return parsed_url.scheme + "://" + parsed_url.netloc
+
+    def _region_registry_auth_payload(self, auth):
+        data = auth.to_dict() if hasattr(auth, "to_dict") else dict(auth)
+        return {
+            "tenant_id": data.get("tenant_id", ""),
+            "secret_id": data.get("secret_id", ""),
+            "domain": data.get("domain", ""),
+            "username": data.get("username", ""),
+            "password": data.get("password", ""),
+            "region_name": data.get("region_name", ""),
+            "hub_type": data.get("hub_type", "Docker"),
+        }
+
+    def check_registry_connection(self, domain, username, password, hub_type):
+        self.validate_registry_hub_type(hub_type)
+        if hub_type in ("Docker", "Harbor"):
+            self.get_registry_namespaces(domain, username, password, hub_type)
+            return True
+        base_url = self._registry_base_url(domain)
+        try:
+            response = requests.get(
+                "{}/v2/".format(base_url),
+                headers=self._registry_v2_headers(username, password),
+                verify=False,
+                timeout=10,
+            )
+        except requests.exceptions.RequestException as e:
+            logger.exception(e)
+            raise ServiceHandleException(
+                msg="failed to connect registry: {}".format(e), msg_show="连接镜像仓库失败", status_code=500)
+        if response.status_code != 200:
+            raise ServiceHandleException(
+                msg="failed to connect registry, status:{}".format(response.status_code),
+                msg_show="镜像仓库连接测试失败",
+                status_code=response.status_code)
+        return True
+
+    def _get_registry_v2_namespaces(self, base_url, username, password):
+        response = requests.get(
+            "{}/v2/_catalog".format(base_url),
+            headers=self._registry_v2_headers(username, password),
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise ServiceHandleException(
+                msg="failed to get registry namespaces, status:{}".format(response.status_code),
+                msg_show="获取镜像仓库命名空间失败",
+                status_code=response.status_code)
+        repositories = response.json().get("repositories", [])
+        namespaces = set()
+        for repo in repositories:
+            if "/" in repo:
+                namespaces.add(repo.split("/", 1)[0])
+            else:
+                namespaces.add("library")
+        return list(namespaces) or ["library"]
+
+    def _get_registry_v2_images(self, base_url, username, password, hub_type, namespace, page=1, page_size=10, search_key=None):
+        response = requests.get(
+            "{}/v2/_catalog".format(base_url),
+            headers=self._registry_v2_headers(username, password),
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise ServiceHandleException(
+                msg="failed to get registry images, status:{}".format(response.status_code),
+                msg_show="获取镜像列表失败",
+                status_code=response.status_code)
+        repositories = response.json().get("repositories", [])
+        if namespace == "library":
+            filtered_repos = [repo for repo in repositories if "/" not in repo]
+        else:
+            filtered_repos = [repo.split("/", 1)[1] for repo in repositories if repo.startswith(namespace + "/")]
+        if search_key:
+            filtered_repos = [repo for repo in filtered_repos if search_key.lower() in repo.lower()]
+        total = len(filtered_repos)
+        start = (page - 1) * page_size
+        end = start + page_size
+        images = [{
+            "name": repo,
+            "namespace": namespace,
+            "description": "",
+            "is_public": True,
+            "pull_count": 0,
+            "star_count": 0,
+            "created_at": "",
+            "updated_at": "",
+            "status": "active",
+            "registry_type": hub_type,
+        } for repo in filtered_repos[start:end]]
+        return {"images": images, "total": total, "page": page, "page_size": page_size}
+
+    def _get_registry_v2_tags(self, base_url, username, password, namespace, name, page=1, page_size=10, search_key=None):
+        repo_name = name if namespace == "library" else "{}/{}".format(namespace, name)
+        response = requests.get(
+            "{}/v2/{}/tags/list".format(base_url, repo_name),
+            headers=self._registry_v2_headers(username, password),
+            verify=False,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise ServiceHandleException(
+                msg="failed to get registry tags, status:{}".format(response.status_code),
+                msg_show="获取镜像标签失败",
+                status_code=response.status_code)
+        all_tags = response.json().get("tags", []) or []
+        if search_key:
+            all_tags = [tag for tag in all_tags if search_key.lower() in tag.lower()]
+        total = len(all_tags)
+        start = (page - 1) * page_size
+        end = start + page_size
+        tags = [{
+            "name": tag,
+            "size": 0,
+            "digest": "",
+            "created_at": "",
+            "updated_at": "",
+            "os": "",
+            "architecture": "",
+            "status": "active",
+        } for tag in all_tags[start:end]]
+        return {"tags": tags, "total": total, "page": page, "page_size": page_size}
+
     @transaction.atomic()
-    def create_registry_auth(self, tenant, region_name, domain, username, password, hub_type, user_id):
+    def create_registry_auth(self, tenant, region_name, domain, username, password, hub_type="Docker", user_id=0):
         auth = team_registry_auth_repo.get_by_team_id_domain(tenant.tenant_id, region_name, domain)
         if auth:
             raise ServiceHandleException(
@@ -679,9 +850,13 @@ class TeamService(object):
             "username": username,
             "password": password,
             "region_name": region_name,
+            "hub_type": hub_type,
+            "user_id": user_id,
+            "scope": self.USER_REGISTRY_SCOPE,
+            "enterprise_id": "",
         }
         team_registry_auth_repo.create_team_registry_auth(**params)
-        region_api.create_registry_auth(tenant.tenant_name, region_name, params)
+        region_api.create_registry_auth(tenant.tenant_name, region_name, self._region_registry_auth_payload(params))
 
     @transaction.atomic()
     def update_registry_auth(self, tenant, region_name, secret_id, data):
@@ -689,7 +864,7 @@ class TeamService(object):
         if not auth:
             return
         team_registry_auth_repo.update_team_registry_auth(tenant.tenant_id, region_name, secret_id, **data)
-        region_api.update_registry_auth(tenant.tenant_name, region_name, auth[0].to_dict())
+        region_api.update_registry_auth(tenant.tenant_name, region_name, self._region_registry_auth_payload(auth[0]))
 
     @transaction.atomic()
     def delete_registry_auth(self, tenant, region_name, secret_id, user_id):
@@ -700,9 +875,10 @@ class TeamService(object):
         })
 
     def get_registry_namespaces(self, domain, username, password, hub_type):
+        self.validate_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Harbor":
                 # Harbor API
@@ -771,32 +947,8 @@ class TeamService(object):
                                 namespaces.add("library")
                         return list(namespaces) or ["library"]
                     
-            elif hub_type == "Volcano":
-                # 火山引擎容器镜像服务 API
-                api_url = "{}/v2/manage/namespaces".format(base_url)
-                response = requests.get(
-                    api_url,
-                    auth=(username, password),
-                    verify=False,
-                    timeout=10
-                )
-                if response.status_code == 200:
-                    namespaces = response.json().get("namespaces", [])
-                    return [ns["name"] for ns in namespaces]
-                    
-            elif hub_type == "Aliyun":
-                # 阿里云容器镜像服务 API
-                api_url = "https://cr.{}.aliyuncs.com/v2/repos/namespaces".format(
-                    parsed_url.netloc.split('.')[1]  # 获取地域信息
-                )
-                response = requests.get(
-                    api_url,
-                    headers={"Authorization": "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()},
-                    timeout=10
-                )
-                if response.status_code == 200:
-                    namespaces = response.json().get("data", {}).get("namespaces", [])
-                    return [ns["namespace"] for ns in namespaces]
+            elif hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_namespaces(base_url, username, password)
 
             raise ServiceHandleException(
                 msg="failed to get registry namespaces, status:{}".format(response.status_code),
@@ -843,9 +995,12 @@ class TeamService(object):
         Returns:
             dict: 包含镜像详细信息的字典
         """
+        self.validate_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
+            if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_images(base_url, username, password, hub_type, namespace, page, page_size, search_key)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Harbor":
                 # Harbor API 支持搜索
@@ -1013,9 +1168,12 @@ class TeamService(object):
         Returns:
             dict: 包含标签详细信息的字典
         """
+        self.validate_registry_hub_type(hub_type)
         try:
+            base_url = self._registry_base_url(domain)
+            if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
+                return self._get_registry_v2_tags(base_url, username, password, namespace, name, page, page_size, search_key)
             parsed_url = urlparse(domain)
-            base_url = parsed_url.scheme + "://" + parsed_url.netloc
             
             if hub_type == "Docker":
                 if "docker.io" in domain:

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -44,8 +44,15 @@ region_api = RegionInvokeApi()
 class TeamService(object):
     USER_REGISTRY_SCOPE = "user"
     ENTERPRISE_REGISTRY_SCOPE = "enterprise"
-    SUPPORTED_REGISTRY_HUB_TYPES = ("Docker", "Harbor", "Aliyun", "Tencent", "Huawei", "Volcano")
-    CLOUD_REGISTRY_HUB_TYPES = ("Aliyun", "Tencent", "Huawei", "Volcano")
+    SUPPORTED_REGISTRY_HUB_TYPES = (
+        "Docker", "Harbor", "AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS")
+    LEGACY_REGISTRY_HUB_TYPE_ALIASES = {
+        "Aliyun": "AliyunACR",
+        "Tencent": "TencentTCR",
+        "Huawei": "HuaweiSWR",
+        "Volcano": "VolcanoTOS",
+    }
+    CLOUD_REGISTRY_HUB_TYPES = ("AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS")
 
     def get_tenant_by_tenant_name(self, tenant_name, exception=True):
         return team_repo.get_tenant_by_tenant_name(tenant_name=tenant_name, exception=exception)
@@ -675,8 +682,14 @@ class TeamService(object):
         data = auth.to_dict() if hasattr(auth, "to_dict") else dict(auth.__dict__)
         scope = data.get("scope") or self.USER_REGISTRY_SCOPE
         data["scope"] = scope
+        data["hub_type"] = self.normalize_registry_hub_type(data.get("hub_type", "Docker"))
+        if data["hub_type"] in self.CLOUD_REGISTRY_HUB_TYPES:
+            data["access_key"] = data.get("username", "")
+            if include_password:
+                data["access_secret"] = data.get("password", "")
         if scope == self.ENTERPRISE_REGISTRY_SCOPE and not include_password:
             data.pop("password", None)
+            data.pop("access_secret", None)
         return data
 
     def list_accessible_registry_auths(self, user):
@@ -699,8 +712,11 @@ class TeamService(object):
                 return auth
         raise ServiceHandleException(msg="registry auth not found", msg_show="镜像仓库不存在", status_code=404)
 
+    def normalize_registry_hub_type(self, hub_type):
+        return self.LEGACY_REGISTRY_HUB_TYPE_ALIASES.get(hub_type, hub_type)
+
     def validate_registry_hub_type(self, hub_type):
-        if hub_type not in self.SUPPORTED_REGISTRY_HUB_TYPES:
+        if self.normalize_registry_hub_type(hub_type) not in self.SUPPORTED_REGISTRY_HUB_TYPES:
             raise ServiceHandleException(msg="unsupported registry hub type", msg_show="不支持的镜像仓库类型", status_code=400)
 
     def _registry_v2_headers(self, username, password):
@@ -722,11 +738,12 @@ class TeamService(object):
             "username": data.get("username", ""),
             "password": data.get("password", ""),
             "region_name": data.get("region_name", ""),
-            "hub_type": data.get("hub_type", "Docker"),
+            "hub_type": self.normalize_registry_hub_type(data.get("hub_type", "Docker")),
         }
 
     def check_registry_connection(self, domain, username, password, hub_type):
         self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         if hub_type in ("Docker", "Harbor"):
             self.get_registry_namespaces(domain, username, password, hub_type)
             return True
@@ -839,6 +856,7 @@ class TeamService(object):
 
     @transaction.atomic()
     def create_registry_auth(self, tenant, region_name, domain, username, password, hub_type="Docker", user_id=0):
+        hub_type = self.normalize_registry_hub_type(hub_type)
         auth = team_registry_auth_repo.get_by_team_id_domain(tenant.tenant_id, region_name, domain)
         if auth:
             raise ServiceHandleException(
@@ -863,6 +881,8 @@ class TeamService(object):
         auth = team_registry_auth_repo.get_by_secret_id(secret_id)
         if not auth:
             return
+        if "hub_type" in data:
+            data["hub_type"] = self.normalize_registry_hub_type(data["hub_type"])
         team_registry_auth_repo.update_team_registry_auth(tenant.tenant_id, region_name, secret_id, **data)
         region_api.update_registry_auth(tenant.tenant_name, region_name, self._region_registry_auth_payload(auth[0]))
 
@@ -876,6 +896,7 @@ class TeamService(object):
 
     def get_registry_namespaces(self, domain, username, password, hub_type):
         self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
             base_url = self._registry_base_url(domain)
             parsed_url = urlparse(domain)
@@ -996,6 +1017,7 @@ class TeamService(object):
             dict: 包含镜像详细信息的字典
         """
         self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
             base_url = self._registry_base_url(domain)
             if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:
@@ -1169,6 +1191,7 @@ class TeamService(object):
             dict: 包含标签详细信息的字典
         """
         self.validate_registry_hub_type(hub_type)
+        hub_type = self.normalize_registry_hub_type(hub_type)
         try:
             base_url = self._registry_base_url(domain)
             if hub_type in self.CLOUD_REGISTRY_HUB_TYPES:

--- a/console/tests/app_import_and_export_service_test.py
+++ b/console/tests/app_import_and_export_service_test.py
@@ -294,7 +294,7 @@ class AppExportServiceMetadataTestCase(TestCase):
 
         self.assertTrue(result["rainbond_app"]["is_export_before"])
         self.assertEqual(result["rainbond_app"]["status"], "success")
-        self.assertEqual(result["rainbond_app"]["file_path"], "http://console.example.com/download/app.tgz")
+        self.assertEqual(result["rainbond_app"]["file_path"], "/console/regions/demo-region/websocket/download/app.tgz")
         self.assertTrue(result["helm_chart"]["is_export_before"] is False)
         self.assertTrue(result["slug"]["is_export_before"] is False)
         export_record.save.assert_called_once_with()

--- a/console/tests/app_manage_test.py
+++ b/console/tests/app_manage_test.py
@@ -44,9 +44,77 @@ import django  # noqa: E402
 django.setup()
 
 from django.test import TestCase as DjangoTestCase  # noqa: E402
+from console.enum.component_enum import ComponentType, is_support  # noqa: E402
 from console.services.app_actions import app_manage as app_manage_module  # noqa: E402
+from console.services import helm_app_yaml as helm_app_yaml_module  # noqa: E402
 from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient  # noqa: E402
 from www.models.main import TenantServiceInfo, VirtualMachineImage  # noqa: E402
+
+
+class ComponentDaemonSetSupportTests(TestCase):
+    # capability_id: console.component-type.daemonset
+    def test_daemonset_component_type_is_supported(self):
+        self.assertEqual("daemonset", ComponentType.daemonset.value)
+        self.assertTrue(is_support("daemonset"))
+        self.assertEqual("守护进程组件", ComponentType.to_zh("daemonset"))
+
+    # capability_id: console.component-type.daemonset
+    def test_extend_method_name_supports_daemonset(self):
+        service_manage = app_manage_module.AppManageService()
+
+        self.assertEqual("守护进程组件", service_manage.get_extend_method_name("daemonset"))
+
+    # capability_id: console.component-type.daemonset
+    def test_change_service_type_blocks_daemonset_transition(self):
+        service = mock.Mock(
+            extend_method="stateless_multiple",
+            create_status="complete",
+            min_node=1,
+        )
+        tenant = mock.Mock()
+
+        with mock.patch.object(app_manage_module.volume_service, "get_service_volumes", return_value=[]), \
+                mock.patch.object(app_manage_module.region_api, "update_service") as update_service:
+            service_manage = app_manage_module.AppManageService()
+            with self.assertRaises(app_manage_module.ServiceHandleException):
+                service_manage.change_service_type(tenant, service, "daemonset", user_name="tester")
+
+        update_service.assert_not_called()
+
+    # capability_id: console.helm.daemonset-template
+    def test_helm_template_maps_daemonset_resource_type(self):
+        cvdata = {
+            "kubernetes_resources": [],
+            "convert_resource": [{
+                "components_name": "node-agent",
+                "basic_management": {
+                    "resource_type": "DaemonSet",
+                    "image": "registry.example.com/tools/agent:1.0.0",
+                    "command": "",
+                    "memory": 128,
+                    "cpu": 100,
+                    "replicas": 1,
+                },
+                "health_check_management": None,
+                "port_management": [],
+                "config_management": [],
+                "env_management": [],
+                "component_k8s_attributes_management": [],
+            }],
+        }
+        app_model = mock.Mock(app_id="app-1", app_name="demo", details="", scope="team")
+        tenant = mock.Mock(tenant_id="tenant-1", tenant_name="demo-team", namespace="demo-ns")
+
+        with mock.patch.object(helm_app_yaml_module.region_api, "get_cluster_nodes_arch", return_value=(200, {"list": ["amd64"]})), \
+                mock.patch.object(helm_app_yaml_module, "AppHelmOverrides") as overrides_cls, \
+                mock.patch.object(helm_app_yaml_module, "RainbondCenterAppVersion") as version_cls:
+            helm_app_yaml_module.helm_app_service.generate_template(
+                cvdata, app_model, "1.0.0", tenant, "demo-chart", "region-a", "eid", 7, {}, "region-app-1")
+
+        overrides_cls.return_value.save.assert_called_once()
+        version_cls.return_value.save.assert_called_once()
+        app_template = json.loads(version_cls.call_args.kwargs["app_template"])
+        self.assertEqual("daemonset", app_template["apps"][0]["extend_method"])
 
 
 class AppManageMarketBuildPreferenceTests(TestCase):

--- a/console/tests/dependency_compat_test.py
+++ b/console/tests/dependency_compat_test.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import os
+import re
+import unittest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def read_repo_file(path):
+    with open(os.path.join(REPO_ROOT, path), "r") as handle:
+        return handle.read()
+
+
+def requirement_version(package_name):
+    pattern = re.compile(r"^{0}==([0-9][^\s#]*)$".format(re.escape(package_name)), re.MULTILINE)
+    match = pattern.search(read_repo_file("requirements.txt"))
+    if not match:
+        raise AssertionError("{0} is not pinned in requirements.txt".format(package_name))
+    return match.group(1)
+
+
+def version_tuple(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+class ConsoleImageDependencyCompatibilityTests(unittest.TestCase):
+    # capability_id: console.image.python36-websocket-client
+    def test_websocket_client_pin_stays_installable_on_python36_image(self):
+        dockerfile = read_repo_file("Dockerfile")
+        if "FROM python:3.6-" not in dockerfile:
+            self.skipTest("console image no longer uses Python 3.6")
+
+        pinned_version = version_tuple(requirement_version("websocket-client"))
+
+        self.assertLessEqual(
+            pinned_version,
+            version_tuple("1.3.1"),
+            "websocket-client releases newer than 1.3.1 are not selected by pip for Python 3.6",
+        )
+        self.assertGreaterEqual(
+            pinned_version,
+            version_tuple("0.32.0"),
+            "docker-compose 1.27.4 requires websocket-client >= 0.32.0",
+        )
+        self.assertLess(
+            pinned_version,
+            version_tuple("1.0.0"),
+            "docker-compose 1.27.4 requires websocket-client < 1",
+        )

--- a/console/tests/groupcopy_service_test.py
+++ b/console/tests/groupcopy_service_test.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import collections
+import collections.abc
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import patch
+
+try:
+    from _pytest.fixtures import FixtureRequest, SubRequest
+
+    if not hasattr(FixtureRequest, "funcargnames"):
+        FixtureRequest.funcargnames = property(lambda self: self.fixturenames)
+    if not hasattr(SubRequest, "funcargnames"):
+        SubRequest.funcargnames = property(lambda self: self.fixturenames)
+except Exception:
+    pass
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "src",
+        "openapi-client",
+    )),
+)
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _DummyConfiguration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    class _DummyApiException(Exception):
+        status = 500
+        body = ""
+
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    openapi_client_module.V1AppModelCreateRequest = dict
+    openapi_client_module.V1CreateAppPaaSVersionRequest = dict
+    openapi_client_module.configuration = configuration_module
+    openapi_client_module.rest = rest_module
+    configuration_module.Configuration = _DummyConfiguration
+    rest_module.ApiException = _DummyApiException
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.main import ServiceHandleException  # noqa: E402
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+# capability_id: console.groupcopy.package-build-guard
+class GroupAppCopyServiceTests(TestCase):
+
+    @patch(
+        "console.services.groupcopy_service.app_service.create_service_alias",
+        return_value="alias-new")
+    @patch(
+        "console.services.groupcopy_service.groupapp_backup_service."
+        "get_group_app_metadata")
+    def test_get_modify_group_metadata_rejects_package_build(
+            self, mock_get_metadata, _):
+        from console.services.groupcopy_service import groupapp_copy_service
+
+        mock_get_metadata.return_value = (
+            0,
+            {
+                "compose_group_info": None,
+                "group_info": {},
+                "plugin_info": {},
+                "app_config_group_info": [],
+                "service_group_relation": [{"service_id": "svc-pkg"}],
+                "apps": [
+                    {
+                        "service_base": {
+                            "service_id": "svc-pkg",
+                            "service_source": "package_build",
+                            "service_cname": "uploaded-jar",
+                            "k8s_component_name": "uploaded-jar",
+                        },
+                        "service_relation": [],
+                        "service_mnts": [],
+                        "service_plugin_config": [],
+                    }
+                ],
+                "compose_service_relation": None,
+            },
+        )
+
+        with self.assertRaises(ServiceHandleException) as ctx:
+            groupapp_copy_service.get_modify_group_metadata(
+                Obj(tenant_id="team-old"),
+                "rainbond",
+                Obj(tenant_id="team-new"),
+                "rainbond",
+                1,
+                ["svc-pkg"],
+                {},
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("package_build", ctx.exception.msg)
+        self.assertIn("uploaded-jar", ctx.exception.msg_show)
+
+    @patch(
+        "console.services.groupcopy_service.app_service.create_service_alias",
+        return_value="alias-new")
+    @patch(
+        "console.services.groupcopy_service.groupapp_backup_service."
+        "get_group_app_metadata")
+    def test_get_modify_group_metadata_allows_source_code(
+            self, mock_get_metadata, _):
+        from console.services.groupcopy_service import groupapp_copy_service
+
+        mock_get_metadata.return_value = (
+            64,
+            {
+                "compose_group_info": None,
+                "group_info": {},
+                "plugin_info": {},
+                "app_config_group_info": [],
+                "service_group_relation": [{"service_id": "svc-code"}],
+                "apps": [
+                    {
+                        "service_base": {
+                            "service_id": "svc-code",
+                            "service_source": "source_code",
+                            "service_cname": "source-code",
+                            "k8s_component_name": "source-code",
+                        },
+                        "service_relation": [],
+                        "service_mnts": [],
+                        "service_plugin_config": [],
+                    }
+                ],
+                "compose_service_relation": None,
+            },
+        )
+
+        metadata, change_services_map = (
+            groupapp_copy_service.get_modify_group_metadata(
+                Obj(tenant_id="team-old"),
+                "rainbond",
+                Obj(tenant_id="team-new"),
+                "rainbond",
+                1,
+                ["svc-code"],
+                {},
+            )
+        )
+
+        self.assertEqual(
+            metadata["apps"][0]["service_base"]["service_id"], "svc-code")
+        self.assertIn("svc-code", change_services_map)

--- a/console/tests/kubeblocks_cluster_validation_test.py
+++ b/console/tests/kubeblocks_cluster_validation_test.py
@@ -87,6 +87,32 @@ class KubeBlocksCreateFlowTests(unittest.TestCase):
     def setUp(self):
         self.service = KubeBlocksService()
 
+    # capability_id: console.kubeblocks.app-resource-statistics
+    def test_build_cluster_request_includes_app_id_for_resource_statistics(self):
+        new_service = SimpleNamespace(
+            service_id="service-1",
+            service_alias="gr000001",
+        )
+
+        cluster_request = self.service._build_cluster_request(
+            {
+                "cluster_name": "mysql-demo",
+                "database_type": "mysql",
+                "version": "8.0.30",
+                "cpu": "500m",
+                "memory": "512Mi",
+                "storage_size": "10Gi",
+                "replicas": 1,
+                "storage_class": "standard",
+                "group_id": 2,
+            },
+            new_service,
+            "team-a-ns",
+        )
+
+        self.assertEqual(cluster_request["rbdService"]["service_id"], "service-1")
+        self.assertEqual(cluster_request["rbdService"]["app_id"], "2")
+
     # capability_id: console.kubeblocks.create-credential-sync
     def test_create_complete_syncs_database_credentials(self):
         tenant = SimpleNamespace(tenant_id="tenant-1", namespace="team-a-ns")

--- a/console/tests/perm_services_test.py
+++ b/console/tests/perm_services_test.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.services import perm_services as perm_services_module  # noqa: E402
+
+
+class FakeRoles(object):
+    def __bool__(self):
+        return True
+
+    def values_list(self, field, flat=False):
+        return [1]
+
+
+class FakeRolePerms(object):
+    def __bool__(self):
+        return True
+
+    def values(self, *fields):
+        return [{
+            "role_id": 1,
+            "perm_code": 300002,
+            "app_id": -1,
+        }]
+
+
+class FakeAppQuerySet(object):
+    def __init__(self, app_ids):
+        self.app_ids = app_ids
+
+    def values_list(self, field, flat=False):
+        return self.app_ids
+
+
+def get_sub_model(model, name):
+    for sub_model in model["sub_models"]:
+        if name in sub_model:
+            return sub_model[name]
+    raise AssertionError("sub model {} not found".format(name))
+
+
+def get_perm(model, perm_name):
+    for perm in model["perms"]:
+        if perm_name in perm:
+            return perm[perm_name]
+    raise AssertionError("permission {} not found".format(perm_name))
+
+
+# capability_id: console.app-creator.full-permissions
+class AppCreatorPermissionTreeTestCase(TestCase):
+    def test_created_app_gets_full_permissions_for_normal_team_member(self):
+        service = perm_services_module.UserKindPermService()
+        user = SimpleNamespace(user_id=2, nick_name="alice")
+
+        def filter_apps(**kwargs):
+            if kwargs == {"tenant_id": "team-1"}:
+                return FakeAppQuerySet([101, 102])
+            if kwargs == {"tenant_id": "team-1", "username": "alice"}:
+                return FakeAppQuerySet([101])
+            return FakeAppQuerySet([])
+
+        with mock.patch.object(perm_services_module.role_perm_relation_repo,
+                               "get_roles_perm_relation",
+                               return_value=FakeRolePerms()), \
+                mock.patch.object(perm_services_module.user_kind_role_repo,
+                                  "get_user_roles_model",
+                                  return_value=FakeRoles()), \
+                mock.patch.object(perm_services_module.ServiceGroup.objects, "filter", side_effect=filter_apps):
+            result = service.get_user_perms(kind="team", kind_id="team-1", user=user)
+
+        team_model = result["permissions"]["team"]
+        team_app_manage = get_sub_model(team_model, "team_app_manage")
+        created_app = get_sub_model(team_app_manage, "app_101")
+        other_app = get_sub_model(team_app_manage, "app_102")
+
+        created_app_overview = get_sub_model(created_app, "app_overview")
+        created_app_release = get_sub_model(created_app, "app_release")
+        self.assertTrue(get_perm(created_app_overview, "describe"))
+        self.assertTrue(get_perm(created_app_overview, "edit"))
+        self.assertTrue(get_perm(created_app_overview, "delete"))
+        self.assertTrue(get_perm(created_app_release, "share"))
+
+        other_app_overview = get_sub_model(other_app, "app_overview")
+        other_app_release = get_sub_model(other_app, "app_release")
+        self.assertTrue(get_perm(other_app_overview, "describe"))
+        self.assertFalse(get_perm(other_app_overview, "edit"))
+        self.assertFalse(get_perm(other_app_overview, "delete"))
+        self.assertFalse(get_perm(other_app_release, "share"))

--- a/console/tests/port_service_delete_test.py
+++ b/console/tests/port_service_delete_test.py
@@ -52,6 +52,7 @@ class PortServiceDeleteTests(TestCase):
             "console.services.app_config.env_service",
             "console.services.app_config.port_service",
             "console.services.app_config.probe_service",
+            "console.services.plugin",
             "console.services.region_services",
             "django.db",
             "validators",
@@ -87,6 +88,7 @@ class PortServiceDeleteTests(TestCase):
         install_stub("console.services.app_config.domain_service", domain_service=MagicMock())
         install_stub("console.services.app_config.env_service", AppEnvVarService=MagicMock)
         install_stub("console.services.app_config.probe_service", ProbeService=MagicMock)
+        install_stub("console.services.plugin", app_plugin_service=MagicMock())
         install_stub("console.services.region_services", region_services=MagicMock())
         install_stub("console.models.main", TenantServiceInfo=object, RegionConfig=object)
         install_stub("www.models.main", ServiceGroup=object, TenantServiceEnvVar=object, TenantServicesPort=object, Tenants=object)
@@ -107,6 +109,139 @@ class PortServiceDeleteTests(TestCase):
         module.probe_repo.get_service_probe.return_value.filter.return_value.first.return_value = None
         module.env_var_service = MagicMock()
         module.domain_service = MagicMock()
+
+    def configure_manage_port_dependencies(self, module, port):
+        region = types.SimpleNamespace(region_id="region-1", httpdomain="apps.example.com")
+        app = types.SimpleNamespace(
+            app_id=7,
+            governance_mode="KUBERNETES_NATIVE_SERVICE",
+        )
+        module.region_repo.get_region_by_region_name.return_value = region
+        module.port_repo.get_service_port_by_port.return_value = port
+        module.domain_repo.get_service_domain_by_container_port.return_value = []
+        module.region_api.api_gateway_bind_http_domain.return_value = None
+        module.region_api.api_gateway_get_proxy.return_value = {"list": ["svc.apps.example.com"]}
+        module.group_repo.get_by_service_id.return_value = app
+        module.env_var_service.add_service_env_var.return_value = (200, "success", None)
+        module.env_var_service.delete_env_by_container_port.return_value = None
+        return app
+
+    # capability_id: console.component.port-toggle-events
+    def test_open_outer_port_synchronizes_region_component_event(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            service_source="source",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=True,
+            is_outer_service=False,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "open_outer", "http", "SVC80", user_name="alice", app=app)
+
+        module.region_api.manage_outer_port.assert_called_once_with(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "open", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+
+    # capability_id: console.component.port-toggle-events
+    def test_close_outer_port_synchronizes_region_component_event(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            service_source="source",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=True,
+            is_outer_service=True,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "close_outer", "http", "SVC80", user_name="alice", app=app)
+
+        module.region_api.manage_outer_port.assert_called_once_with(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "close", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+
+    # capability_id: console.component.port-toggle-events
+    def test_inner_port_toggle_keeps_region_component_event_path(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=False,
+            is_outer_service=False,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "open_inner", "http", "SVC80", user_name="alice", app=app)
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "close_inner", "http", "SVC80", user_name="alice", app=app)
+
+        self.assertEqual(module.region_api.manage_inner_port.call_count, 2)
+        module.region_api.manage_inner_port.assert_any_call(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "open", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+        module.region_api.manage_inner_port.assert_any_call(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "close", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
 
     def test_delete_closed_port_ignores_inactive_custom_http_domains(self):
         module = self.import_port_service_module()

--- a/console/tests/port_service_delete_test.py
+++ b/console/tests/port_service_delete_test.py
@@ -52,6 +52,7 @@ class PortServiceDeleteTests(TestCase):
             "console.services.app_config.env_service",
             "console.services.app_config.port_service",
             "console.services.app_config.probe_service",
+            "console.services.plugin",
             "console.services.region_services",
             "django.db",
             "validators",
@@ -87,6 +88,7 @@ class PortServiceDeleteTests(TestCase):
         install_stub("console.services.app_config.domain_service", domain_service=MagicMock())
         install_stub("console.services.app_config.env_service", AppEnvVarService=MagicMock)
         install_stub("console.services.app_config.probe_service", ProbeService=MagicMock)
+        install_stub("console.services.plugin", app_plugin_service=MagicMock())
         install_stub("console.services.region_services", region_services=MagicMock())
         install_stub("console.models.main", TenantServiceInfo=object)
         install_stub("www.models.main", ServiceGroup=object, TenantServiceEnvVar=object, TenantServicesPort=object)
@@ -107,6 +109,139 @@ class PortServiceDeleteTests(TestCase):
         module.probe_repo.get_service_probe.return_value.filter.return_value.first.return_value = None
         module.env_var_service = MagicMock()
         module.domain_service = MagicMock()
+
+    def configure_manage_port_dependencies(self, module, port):
+        region = types.SimpleNamespace(region_id="region-1", httpdomain="apps.example.com")
+        app = types.SimpleNamespace(
+            app_id=7,
+            governance_mode="KUBERNETES_NATIVE_SERVICE",
+        )
+        module.region_repo.get_region_by_region_name.return_value = region
+        module.port_repo.get_service_port_by_port.return_value = port
+        module.domain_repo.get_service_domain_by_container_port.return_value = []
+        module.region_api.api_gateway_bind_http_domain.return_value = None
+        module.region_api.api_gateway_get_proxy.return_value = {"list": ["svc.apps.example.com"]}
+        module.group_repo.get_by_service_id.return_value = app
+        module.env_var_service.add_service_env_var.return_value = (200, "success", None)
+        module.env_var_service.delete_env_by_container_port.return_value = None
+        return app
+
+    # capability_id: console.component.port-toggle-events
+    def test_open_outer_port_synchronizes_region_component_event(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            service_source="source",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=True,
+            is_outer_service=False,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "open_outer", "http", "SVC80", user_name="alice", app=app)
+
+        module.region_api.manage_outer_port.assert_called_once_with(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "open", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+
+    # capability_id: console.component.port-toggle-events
+    def test_close_outer_port_synchronizes_region_component_event(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            service_source="source",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=True,
+            is_outer_service=True,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "close_outer", "http", "SVC80", user_name="alice", app=app)
+
+        module.region_api.manage_outer_port.assert_called_once_with(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "close", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+
+    # capability_id: console.component.port-toggle-events
+    def test_inner_port_toggle_keeps_region_component_event_path(self):
+        module = self.import_port_service_module()
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=80,
+            protocol="http",
+            port_alias="http",
+            is_inner_service=False,
+            is_outer_service=False,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "open_inner", "http", "SVC80", user_name="alice", app=app)
+        module.AppPortService().manage_port(
+            tenant, service, "region-1", 80, "close_inner", "http", "SVC80", user_name="alice", app=app)
+
+        self.assertEqual(module.region_api.manage_inner_port.call_count, 2)
+        module.region_api.manage_inner_port.assert_any_call(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "open", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
+        module.region_api.manage_inner_port.assert_any_call(
+            "region-1",
+            "default",
+            "gr2dc0bf",
+            80,
+            {"operation": "close", "enterprise_id": "enterprise-1", "operator": "alice"},
+        )
 
     def test_delete_closed_port_ignores_inactive_custom_http_domains(self):
         module = self.import_port_service_module()

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -46,6 +46,8 @@ django.setup()
 from console.services.app_actions.app_log import AppWebSocketService  # noqa: E402
 from console.services.app_import_and_export_service import import_service  # noqa: E402
 from console.utils.realtime_proxy import (  # noqa: E402
+    DockerConsoleActivityTracker,
+    WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS,
     _backend_websocket_subprotocols,
     build_console_realtime_proxy_url,
     build_region_realtime_proxy_url,
@@ -208,7 +210,7 @@ class RealtimeProxyUrlTests(SimpleTestCase):
         self.assertEqual(protocols, ["webtty", "other"])
 
     # capability_id: console.realtime-proxy.websocket-idle-timeout
-    def test_backend_websocket_disables_read_timeout_after_connect(self):
+    def test_backend_websocket_uses_short_read_timeout_for_idle_checks(self):
         request = self.factory.get("/console/regions/rainbond/websocket/docker_console")
         backend_ws = mock.Mock()
         create_connection = mock.Mock(return_value=backend_ws)
@@ -219,4 +221,30 @@ class RealtimeProxyUrlTests(SimpleTestCase):
         _, kwargs = create_connection.call_args
         self.assertEqual(kwargs["timeout"], 10)
         self.assertEqual(kwargs["subprotocols"], ["webtty"])
-        backend_ws.settimeout.assert_called_once_with(None)
+        backend_ws.settimeout.assert_called_once_with(WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS)
+
+    # capability_id: console.realtime-proxy.docker-console-user-idle-timeout
+    def test_docker_console_activity_tracker_ignores_webtty_ping(self):
+        tracker = DockerConsoleActivityTracker("docker_console", idle_timeout_seconds=1800, now=lambda: 1000)
+
+        tracker.mark_client_message("2")
+
+        self.assertFalse(tracker.is_idle_expired(now=2799))
+        self.assertTrue(tracker.is_idle_expired(now=2801))
+
+    # capability_id: console.realtime-proxy.docker-console-user-activity
+    def test_docker_console_activity_tracker_refreshes_on_user_input(self):
+        current_time = [1000]
+        tracker = DockerConsoleActivityTracker("docker_console", idle_timeout_seconds=1800, now=lambda: current_time[0])
+
+        current_time[0] = 2700
+        tracker.mark_client_message("1ls")
+
+        self.assertFalse(tracker.is_idle_expired(now=4400))
+        self.assertTrue(tracker.is_idle_expired(now=4501))
+
+    # capability_id: console.realtime-proxy.non-terminal-no-user-idle-timeout
+    def test_non_docker_console_activity_tracker_never_user_idle_expires(self):
+        tracker = DockerConsoleActivityTracker("event_log", idle_timeout_seconds=1800, now=lambda: 1000)
+
+        self.assertFalse(tracker.is_idle_expired(now=999999))

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _DummyConfiguration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    class _DummyApiException(Exception):
+        status = 500
+        body = ""
+
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    configuration_module.Configuration = _DummyConfiguration
+    rest_module.ApiException = _DummyApiException
+    openapi_client_module.configuration = configuration_module
+    openapi_client_module.rest = rest_module
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+from django.test import RequestFactory, SimpleTestCase  # noqa: E402
+
+django.setup()
+
+from console.services.app_actions.app_log import AppWebSocketService  # noqa: E402
+from console.services.app_import_and_export_service import import_service  # noqa: E402
+from console.utils.realtime_proxy import (  # noqa: E402
+    build_console_realtime_proxy_url,
+    build_region_realtime_proxy_url,
+    proxy_http_request,
+)
+
+
+class RealtimeProxyUrlTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory(HTTP_HOST="console.example.com:7070")
+
+    # capability_id: console.realtime-proxy.websocket-url
+    def test_websocket_service_returns_console_proxy_url_without_6060(self):
+        request = self.factory.get("/console/teams/demo/apps/app/events")
+
+        ws_url = AppWebSocketService().get_event_log_ws(request, "rainbond")
+
+        self.assertEqual(ws_url, "ws://console.example.com:7070/console/regions/rainbond/websocket/event_log")
+        self.assertNotIn(":6060", ws_url)
+
+    # capability_id: console.realtime-proxy.secure-websocket-url
+    def test_console_proxy_url_uses_wss_when_request_is_https(self):
+        request = self.factory.get(
+            "/console/teams/demo/apps/app/events",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+
+        ws_url = build_console_realtime_proxy_url(request, "rainbond", "event_log", scheme_type="ws")
+
+        self.assertEqual(ws_url, "wss://console.example.com:7070/console/regions/rainbond/websocket/event_log")
+
+    # capability_id: console.realtime-proxy.upload-url
+    def test_upload_package_url_returns_console_proxy_path(self):
+        with mock.patch(
+            "console.services.app_import_and_export_service.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ):
+            upload_url = import_service.get_upload_package_url("rainbond", "evt-1")
+
+        self.assertEqual(upload_url, "/console/regions/rainbond/websocket/package_build/component/events/evt-1")
+        self.assertNotIn(":6060", upload_url)
+
+    # capability_id: console.realtime-proxy.region-target-url
+    def test_region_proxy_target_keeps_region_websocket_host_for_http(self):
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="wss://region.example.com:6060"),
+        ):
+            target_url = build_region_realtime_proxy_url(
+                "rainbond",
+                "/package_build/component/events/evt-1",
+                "chunk=1",
+                scheme_type="http",
+            )
+
+        self.assertEqual(target_url, "https://region.example.com:6060/package_build/component/events/evt-1?chunk=1")
+
+    # capability_id: console.realtime-proxy.internal-target-override
+    def test_region_proxy_target_prefers_internal_override_for_builtin_region(self):
+        with mock.patch.dict(
+            os.environ,
+            {"REGION_WS_PROXY_TARGET": "ws://127.0.0.1:6060"},
+        ), mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://public.example.com:6060"),
+        ):
+            target_url = build_region_realtime_proxy_url(
+                "rainbond",
+                "/event_log",
+                scheme_type="ws",
+            )
+
+        self.assertEqual(target_url, "ws://127.0.0.1:6060/event_log")
+
+    # capability_id: console.realtime-proxy.http-forward
+    def test_http_proxy_forwards_upload_request_to_region_websocket_service(self):
+        request = self.factory.post(
+            "/console/regions/rainbond/websocket/package_build/component/events/evt-1?chunk=1",
+            data=b"demo-body",
+            content_type="application/octet-stream",
+            HTTP_AUTHORIZATION="JWT token",
+        )
+        backend_response = mock.Mock()
+        backend_response.status_code = 201
+        backend_response.headers = {"Content-Type": "application/json"}
+        backend_response.iter_content.return_value = iter([b'{"ok":true}'])
+
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ), mock.patch("console.utils.realtime_proxy.requests.request", return_value=backend_response) as request_mock:
+            response = proxy_http_request(request, "rainbond", "package_build/component/events/evt-1")
+
+        _, kwargs = request_mock.call_args
+        self.assertEqual(request_mock.call_args[0][0], "POST")
+        self.assertEqual(
+            request_mock.call_args[0][1],
+            "http://region.example.com:6060/package_build/component/events/evt-1?chunk=1",
+        )
+        self.assertEqual(kwargs["headers"]["Authorization"], "JWT token")
+        self.assertIsNotNone(kwargs["data"])
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertEqual(b"".join(response.streaming_content), b'{"ok":true}')

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _DummyConfiguration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    class _DummyApiException(Exception):
+        status = 500
+        body = ""
+
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    configuration_module.Configuration = _DummyConfiguration
+    rest_module.ApiException = _DummyApiException
+    openapi_client_module.configuration = configuration_module
+    openapi_client_module.rest = rest_module
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+from django.core.files.uploadedfile import SimpleUploadedFile  # noqa: E402
+from django.test import RequestFactory, SimpleTestCase  # noqa: E402
+
+django.setup()
+
+from console.services.app_actions.app_log import AppWebSocketService  # noqa: E402
+from console.services.app_import_and_export_service import import_service  # noqa: E402
+from console.utils.realtime_proxy import (  # noqa: E402
+    DockerConsoleActivityTracker,
+    WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS,
+    _backend_websocket_subprotocols,
+    build_console_realtime_proxy_url,
+    build_region_realtime_proxy_url,
+    open_backend_websocket,
+    proxy_http_request,
+)
+
+
+class RealtimeProxyUrlTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory(HTTP_HOST="console.example.com:7070")
+
+    # capability_id: console.realtime-proxy.websocket-url
+    def test_websocket_service_returns_console_proxy_url_without_6060(self):
+        request = self.factory.get("/console/teams/demo/apps/app/events")
+
+        ws_url = AppWebSocketService().get_event_log_ws(request, "rainbond")
+
+        self.assertEqual(ws_url, "ws://console.example.com:7070/console/regions/rainbond/websocket/event_log")
+        self.assertNotIn(":6060", ws_url)
+
+    # capability_id: console.realtime-proxy.secure-websocket-url
+    def test_console_proxy_url_uses_wss_when_request_is_https(self):
+        request = self.factory.get(
+            "/console/teams/demo/apps/app/events",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+
+        ws_url = build_console_realtime_proxy_url(request, "rainbond", "event_log", scheme_type="ws")
+
+        self.assertEqual(ws_url, "wss://console.example.com:7070/console/regions/rainbond/websocket/event_log")
+
+    # capability_id: console.realtime-proxy.upload-url
+    def test_upload_package_url_returns_console_proxy_path(self):
+        with mock.patch(
+            "console.services.app_import_and_export_service.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ):
+            upload_url = import_service.get_upload_package_url("rainbond", "evt-1")
+
+        self.assertEqual(upload_url, "/console/regions/rainbond/websocket/package_build/component/events/evt-1")
+        self.assertNotIn(":6060", upload_url)
+
+    # capability_id: console.realtime-proxy.region-target-url
+    def test_region_proxy_target_keeps_region_websocket_host_for_http(self):
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="wss://region.example.com:6060"),
+        ):
+            target_url = build_region_realtime_proxy_url(
+                "rainbond",
+                "/package_build/component/events/evt-1",
+                "chunk=1",
+                scheme_type="http",
+            )
+
+        self.assertEqual(target_url, "https://region.example.com:6060/package_build/component/events/evt-1?chunk=1")
+
+    # capability_id: console.realtime-proxy.internal-target-override
+    def test_region_proxy_target_prefers_internal_override_for_builtin_region(self):
+        with mock.patch.dict(
+            os.environ,
+            {"REGION_WS_PROXY_TARGET": "ws://127.0.0.1:6060"},
+        ), mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://public.example.com:6060"),
+        ):
+            target_url = build_region_realtime_proxy_url(
+                "rainbond",
+                "/event_log",
+                scheme_type="ws",
+            )
+
+        self.assertEqual(target_url, "ws://127.0.0.1:6060/event_log")
+
+    # capability_id: console.realtime-proxy.http-forward
+    def test_http_proxy_forwards_upload_request_to_region_websocket_service(self):
+        request = self.factory.post(
+            "/console/regions/rainbond/websocket/package_build/component/events/evt-1?chunk=1",
+            data=b"demo-body",
+            content_type="application/octet-stream",
+            HTTP_AUTHORIZATION="JWT token",
+        )
+        backend_response = mock.Mock()
+        backend_response.status_code = 201
+        backend_response.headers = {"Content-Type": "application/json"}
+        backend_response.iter_content.return_value = iter([b'{"ok":true}'])
+
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ), mock.patch("console.utils.realtime_proxy.requests.request", return_value=backend_response) as request_mock:
+            response = proxy_http_request(request, "rainbond", "package_build/component/events/evt-1")
+
+        _, kwargs = request_mock.call_args
+        self.assertEqual(request_mock.call_args[0][0], "POST")
+        self.assertEqual(
+            request_mock.call_args[0][1],
+            "http://region.example.com:6060/package_build/component/events/evt-1?chunk=1",
+        )
+        self.assertEqual(kwargs["headers"]["Authorization"], "JWT token")
+        self.assertIsNotNone(kwargs["data"])
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertEqual(b"".join(response.streaming_content), b'{"ok":true}')
+
+    # capability_id: console.realtime-proxy.multipart-upload-forward
+    def test_http_proxy_rebuilds_multipart_upload_for_app_import(self):
+        upload_file = SimpleUploadedFile(
+            "app.tar.gz",
+            b"app package content",
+            content_type="application/gzip",
+        )
+        request = self.factory.post(
+            "/console/regions/rainbond/websocket/app/upload/evt-1",
+            data={"appTarFile": upload_file},
+            HTTP_AUTHORIZATION="JWT token",
+        )
+        backend_response = mock.Mock()
+        backend_response.status_code = 200
+        backend_response.headers = {"Content-Type": "application/json"}
+        backend_response.iter_content.return_value = iter([b'{"ok":true}'])
+
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ), mock.patch("console.utils.realtime_proxy.requests.request", return_value=backend_response) as request_mock:
+            response = proxy_http_request(request, "rainbond", "app/upload/evt-1")
+
+        _, kwargs = request_mock.call_args
+        self.assertEqual(request_mock.call_args[0][1], "http://region.example.com:6060/app/upload/evt-1")
+        self.assertEqual(kwargs["headers"]["Authorization"], "JWT token")
+        self.assertNotIn("Content-Type", kwargs["headers"])
+        self.assertNotIn("Content-Length", kwargs["headers"])
+        self.assertIn("appTarFile", kwargs["files"])
+        file_name, file_obj, content_type = kwargs["files"]["appTarFile"]
+        self.assertEqual(file_name, "app.tar.gz")
+        self.assertEqual(file_obj.read(), b"app package content")
+        self.assertEqual(content_type, "application/gzip")
+        self.assertEqual(kwargs["data"], {})
+        self.assertEqual(response.status_code, 200)
+
+    # capability_id: console.realtime-proxy.docker-console-subprotocol
+    def test_docker_console_backend_uses_webtty_subprotocol(self):
+        request = self.factory.get("/console/regions/rainbond/websocket/docker_console")
+
+        protocols = _backend_websocket_subprotocols(request, "docker_console")
+
+        self.assertEqual(protocols, ["webtty"])
+
+    # capability_id: console.realtime-proxy.forward-client-subprotocols
+    def test_websocket_proxy_keeps_client_requested_subprotocols(self):
+        request = self.factory.get(
+            "/console/regions/rainbond/websocket/docker_console",
+            HTTP_SEC_WEBSOCKET_PROTOCOL="webtty, other",
+        )
+
+        protocols = _backend_websocket_subprotocols(request, "docker_console")
+
+        self.assertEqual(protocols, ["webtty", "other"])
+
+    # capability_id: console.realtime-proxy.websocket-idle-timeout
+    def test_backend_websocket_uses_short_read_timeout_for_idle_checks(self):
+        request = self.factory.get("/console/regions/rainbond/websocket/docker_console")
+        backend_ws = mock.Mock()
+        create_connection = mock.Mock(return_value=backend_ws)
+
+        result = open_backend_websocket(create_connection, "ws://127.0.0.1:6060/docker_console", request, "docker_console")
+
+        self.assertIs(result, backend_ws)
+        _, kwargs = create_connection.call_args
+        self.assertEqual(kwargs["timeout"], 10)
+        self.assertEqual(kwargs["subprotocols"], ["webtty"])
+        backend_ws.settimeout.assert_called_once_with(WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS)
+
+    # capability_id: console.realtime-proxy.docker-console-user-idle-timeout
+    def test_docker_console_activity_tracker_ignores_webtty_ping(self):
+        tracker = DockerConsoleActivityTracker("docker_console", idle_timeout_seconds=1800, now=lambda: 1000)
+
+        tracker.mark_client_message("2")
+
+        self.assertFalse(tracker.is_idle_expired(now=2799))
+        self.assertTrue(tracker.is_idle_expired(now=2801))
+
+    # capability_id: console.realtime-proxy.docker-console-user-activity
+    def test_docker_console_activity_tracker_refreshes_on_user_input(self):
+        current_time = [1000]
+        tracker = DockerConsoleActivityTracker("docker_console", idle_timeout_seconds=1800, now=lambda: current_time[0])
+
+        current_time[0] = 2700
+        tracker.mark_client_message("1ls")
+
+        self.assertFalse(tracker.is_idle_expired(now=4400))
+        self.assertTrue(tracker.is_idle_expired(now=4501))
+
+    # capability_id: console.realtime-proxy.non-terminal-no-user-idle-timeout
+    def test_non_docker_console_activity_tracker_never_user_idle_expires(self):
+        tracker = DockerConsoleActivityTracker("event_log", idle_timeout_seconds=1800, now=lambda: 1000)
+
+        self.assertFalse(tracker.is_idle_expired(now=999999))

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -49,6 +49,7 @@ from console.utils.realtime_proxy import (  # noqa: E402
     _backend_websocket_subprotocols,
     build_console_realtime_proxy_url,
     build_region_realtime_proxy_url,
+    open_backend_websocket,
     proxy_http_request,
 )
 
@@ -205,3 +206,17 @@ class RealtimeProxyUrlTests(SimpleTestCase):
         protocols = _backend_websocket_subprotocols(request, "docker_console")
 
         self.assertEqual(protocols, ["webtty", "other"])
+
+    # capability_id: console.realtime-proxy.websocket-idle-timeout
+    def test_backend_websocket_disables_read_timeout_after_connect(self):
+        request = self.factory.get("/console/regions/rainbond/websocket/docker_console")
+        backend_ws = mock.Mock()
+        create_connection = mock.Mock(return_value=backend_ws)
+
+        result = open_backend_websocket(create_connection, "ws://127.0.0.1:6060/docker_console", request, "docker_console")
+
+        self.assertIs(result, backend_ws)
+        _, kwargs = create_connection.call_args
+        self.assertEqual(kwargs["timeout"], 10)
+        self.assertEqual(kwargs["subprotocols"], ["webtty"])
+        backend_ws.settimeout.assert_called_once_with(None)

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -46,6 +46,7 @@ django.setup()
 from console.services.app_actions.app_log import AppWebSocketService  # noqa: E402
 from console.services.app_import_and_export_service import import_service  # noqa: E402
 from console.utils.realtime_proxy import (  # noqa: E402
+    _backend_websocket_subprotocols,
     build_console_realtime_proxy_url,
     build_region_realtime_proxy_url,
     proxy_http_request,
@@ -185,3 +186,22 @@ class RealtimeProxyUrlTests(SimpleTestCase):
         self.assertEqual(content_type, "application/gzip")
         self.assertEqual(kwargs["data"], {})
         self.assertEqual(response.status_code, 200)
+
+    # capability_id: console.realtime-proxy.docker-console-subprotocol
+    def test_docker_console_backend_uses_webtty_subprotocol(self):
+        request = self.factory.get("/console/regions/rainbond/websocket/docker_console")
+
+        protocols = _backend_websocket_subprotocols(request, "docker_console")
+
+        self.assertEqual(protocols, ["webtty"])
+
+    # capability_id: console.realtime-proxy.forward-client-subprotocols
+    def test_websocket_proxy_keeps_client_requested_subprotocols(self):
+        request = self.factory.get(
+            "/console/regions/rainbond/websocket/docker_console",
+            HTTP_SEC_WEBSOCKET_PROTOCOL="webtty, other",
+        )
+
+        protocols = _backend_websocket_subprotocols(request, "docker_console")
+
+        self.assertEqual(protocols, ["webtty", "other"])

--- a/console/tests/realtime_proxy_url_test.py
+++ b/console/tests/realtime_proxy_url_test.py
@@ -38,6 +38,7 @@ if "openapi_client" not in sys.modules:
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
 
 import django  # noqa: E402
+from django.core.files.uploadedfile import SimpleUploadedFile  # noqa: E402
 from django.test import RequestFactory, SimpleTestCase  # noqa: E402
 
 django.setup()
@@ -148,3 +149,39 @@ class RealtimeProxyUrlTests(SimpleTestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response["Content-Type"], "application/json")
         self.assertEqual(b"".join(response.streaming_content), b'{"ok":true}')
+
+    # capability_id: console.realtime-proxy.multipart-upload-forward
+    def test_http_proxy_rebuilds_multipart_upload_for_app_import(self):
+        upload_file = SimpleUploadedFile(
+            "app.tar.gz",
+            b"app package content",
+            content_type="application/gzip",
+        )
+        request = self.factory.post(
+            "/console/regions/rainbond/websocket/app/upload/evt-1",
+            data={"appTarFile": upload_file},
+            HTTP_AUTHORIZATION="JWT token",
+        )
+        backend_response = mock.Mock()
+        backend_response.status_code = 200
+        backend_response.headers = {"Content-Type": "application/json"}
+        backend_response.iter_content.return_value = iter([b'{"ok":true}'])
+
+        with mock.patch(
+            "console.utils.realtime_proxy.region_repo.get_region_by_region_name",
+            return_value=mock.Mock(wsurl="ws://region.example.com:6060"),
+        ), mock.patch("console.utils.realtime_proxy.requests.request", return_value=backend_response) as request_mock:
+            response = proxy_http_request(request, "rainbond", "app/upload/evt-1")
+
+        _, kwargs = request_mock.call_args
+        self.assertEqual(request_mock.call_args[0][1], "http://region.example.com:6060/app/upload/evt-1")
+        self.assertEqual(kwargs["headers"]["Authorization"], "JWT token")
+        self.assertNotIn("Content-Type", kwargs["headers"])
+        self.assertNotIn("Content-Length", kwargs["headers"])
+        self.assertIn("appTarFile", kwargs["files"])
+        file_name, file_obj, content_type = kwargs["files"]["appTarFile"]
+        self.assertEqual(file_name, "app.tar.gz")
+        self.assertEqual(file_obj.read(), b"app package content")
+        self.assertEqual(content_type, "application/gzip")
+        self.assertEqual(kwargs["data"], {})
+        self.assertEqual(response.status_code, 200)

--- a/console/tests/registry_global_test.py
+++ b/console/tests/registry_global_test.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase, mock
+
+from rest_framework.test import APIRequestFactory
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.main import ServiceHandleException  # noqa: E402
+from console.services.team_services import team_services  # noqa: E402
+from console.views.app_create.docker_run import DockerRunCreateView  # noqa: E402
+from console.views import registry as registry_views  # noqa: E402
+from console.views.registry import HubRegistryImageView, HubRegistryView  # noqa: E402
+
+
+class RegistryAuth(SimpleNamespace):
+    def to_dict(self):
+        return dict(self.__dict__)
+
+
+class GlobalRegistryAuthTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = SimpleNamespace(user_id=7, enterprise_id="eid-1", is_authenticated=True)
+
+    def test_hub_registry_list_merges_user_and_enterprise_auths_without_enterprise_password(self):
+        personal = RegistryAuth(
+            secret_id="personal",
+            domain="https://harbor.example.com",
+            username="alice",
+            password="personal-password",
+            hub_type="Harbor",
+            user_id=7,
+            enterprise_id="",
+            scope="user",
+        )
+        enterprise = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/hub/registry")
+        view = HubRegistryView()
+        view.user = self.user
+
+        with mock.patch.object(team_services, "list_accessible_registry_auths", return_value=[personal, enterprise]):
+            response = view.get(request)
+
+        self.assertEqual(response.status_code, 200)
+        items = response.data["data"]["list"]
+        self.assertEqual([item["secret_id"] for item in items], ["personal", "company"])
+        self.assertEqual(items[0]["password"], "personal-password")
+        self.assertEqual(items[0]["scope"], "user")
+        self.assertEqual(items[1]["scope"], "enterprise")
+        self.assertNotIn("password", items[1])
+
+    def test_enterprise_registry_list_masks_password_for_admins(self):
+        enterprise = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/enterprise/eid-1/hub/registry")
+        self.assertTrue(hasattr(registry_views, "EnterpriseHubRegistryView"))
+        view = registry_views.EnterpriseHubRegistryView()
+        view.user = self.user
+        view.is_enterprise_admin = True
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.list_enterprise_registry_auths",
+                        return_value=[enterprise]):
+            response = view.get(request, enterprise_id="eid-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["list"][0]["scope"], "enterprise")
+        self.assertNotIn("password", response.data["data"]["list"][0])
+
+    def test_resolve_registry_auth_prefers_user_auth_then_enterprise_auth(self):
+        personal = RegistryAuth(secret_id="same", username="alice", password="personal-password", scope="user")
+        enterprise = RegistryAuth(secret_id="same", username="company", password="enterprise-password", scope="enterprise")
+        user = SimpleNamespace(user_id=7, enterprise_id="eid-1")
+
+        with mock.patch("console.services.team_services.team_registry_auth_repo.get_user_registry_auth",
+                        return_value=personal), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_enterprise_registry_auth",
+                           return_value=enterprise):
+            resolved = team_services.resolve_registry_auth(user, "same")
+
+        self.assertIs(resolved, personal)
+
+    def test_resolve_registry_auth_falls_back_to_enterprise_auth(self):
+        enterprise = RegistryAuth(secret_id="company", username="company", password="enterprise-password", scope="enterprise")
+        user = SimpleNamespace(user_id=7, enterprise_id="eid-1")
+
+        with mock.patch("console.services.team_services.team_registry_auth_repo.get_user_registry_auth",
+                        return_value=None), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_enterprise_registry_auth",
+                           return_value=enterprise):
+            resolved = team_services.resolve_registry_auth(user, "company")
+
+        self.assertIs(resolved, enterprise)
+
+    def test_hub_registry_image_uses_accessible_registry_auth(self):
+        auth = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Aliyun",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/hub/registry/image?secret_id=company")
+        view = HubRegistryImageView()
+        view.user = self.user
+
+        with mock.patch.object(team_services, "resolve_registry_auth", return_value=auth) as resolve_mock, \
+                mock.patch.object(team_services, "get_registry_namespaces", return_value=["prod"]) as namespaces_mock:
+            response = view.get(request)
+
+        self.assertEqual(response.status_code, 200)
+        resolve_mock.assert_called_once_with(self.user, "company")
+        namespaces_mock.assert_called_once_with(
+            domain=auth.domain,
+            username=auth.username,
+            password=auth.password,
+            hub_type=auth.hub_type,
+        )
+        self.assertEqual(response.data["data"]["list"], ["prod"])
+
+    def test_docker_run_resolves_registry_auth_id_credentials_on_server(self):
+        registry_auth = RegistryAuth(secret_id="company", username="company-user", password="enterprise-password")
+        service = SimpleNamespace(service_id="sid-1", to_dict=lambda: {"service_id": "sid-1"})
+        request = SimpleNamespace(data={
+            "image_type": "docker_run",
+            "group_id": 1,
+            "service_cname": "demo",
+            "docker_cmd": "registry.example.com/ns/demo:latest",
+            "registry_auth_id": "company",
+        })
+        view = DockerRunCreateView()
+        view.user = SimpleNamespace(user_id=7, enterprise_id="eid-1", get_username=lambda: "alice")
+        view.tenant = SimpleNamespace(tenant_id="tenant-1")
+        view.response_region = "region-1"
+        view.region_name = "region-1"
+
+        with mock.patch.object(team_services, "resolve_registry_auth", return_value=registry_auth) as resolve_mock, \
+                mock.patch("console.views.app_create.docker_run.app_service.is_k8s_component_name_duplicate",
+                           return_value=False), \
+                mock.patch("console.views.app_create.docker_run.app_service.create_docker_run_app",
+                           return_value=(200, "ok", service)), \
+                mock.patch("console.views.app_create.docker_run.app_service.create_service_source_info") as source_mock, \
+                mock.patch("console.views.app_create.docker_run.group_service.add_service_to_group",
+                           return_value=(200, "ok")):
+            response = view.post(request)
+
+        self.assertEqual(response.status_code, 200)
+        resolve_mock.assert_called_once_with(view.user, "company")
+        source_mock.assert_called_once_with(view.tenant, service, "company-user", "enterprise-password")
+
+
+    def test_team_registry_create_region_payload_excludes_console_scope_fields(self):
+        tenant = SimpleNamespace(tenant_id="tenant-1", tenant_name="team-a")
+
+        with mock.patch("django.db.transaction.Atomic.__enter__", return_value=None), \
+                mock.patch("django.db.transaction.Atomic.__exit__", return_value=False), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_by_team_id_domain",
+                           return_value=[]), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.create_team_registry_auth"), \
+                mock.patch("console.services.team_services.region_api.create_registry_auth") as region_mock:
+            team_services.create_registry_auth(
+                tenant, "region-a", "https://harbor.example.com", "user", "password")
+
+        payload = region_mock.call_args[0][2]
+        self.assertNotIn("scope", payload)
+        self.assertNotIn("enterprise_id", payload)
+        self.assertNotIn("user_id", payload)
+
+    def test_team_registry_update_region_payload_excludes_console_scope_fields(self):
+        tenant = SimpleNamespace(tenant_id="tenant-1", tenant_name="team-a")
+        auth = RegistryAuth(
+            tenant_id="tenant-1",
+            secret_id="secret-a",
+            domain="https://harbor.example.com",
+            username="user",
+            password="password",
+            region_name="region-a",
+            hub_type="Docker",
+            user_id=7,
+            scope="user",
+            enterprise_id="eid-1",
+        )
+
+        with mock.patch("django.db.transaction.Atomic.__enter__", return_value=None), \
+                mock.patch("django.db.transaction.Atomic.__exit__", return_value=False), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_by_secret_id",
+                           return_value=[auth]), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.update_team_registry_auth"), \
+                mock.patch("console.services.team_services.region_api.update_registry_auth") as region_mock:
+            team_services.update_registry_auth(tenant, "region-a", "secret-a", {"username": "new-user"})
+
+        payload = region_mock.call_args[0][2]
+        self.assertNotIn("scope", payload)
+        self.assertNotIn("enterprise_id", payload)
+        self.assertNotIn("user_id", payload)
+
+    def test_check_registry_connection_accepts_supported_cloud_registry_types(self):
+        response = mock.Mock(status_code=200)
+
+        for hub_type in ["Aliyun", "Tencent", "Huawei", "Volcano"]:
+            with self.subTest(hub_type=hub_type):
+                with mock.patch("console.services.team_services.requests.get", return_value=response) as get_mock:
+                    team_services.check_registry_connection(
+                        domain="https://registry.example.com",
+                        username="user",
+                        password="password",
+                        hub_type=hub_type,
+                    )
+
+                self.assertEqual(get_mock.call_args[0][0], "https://registry.example.com/v2/")
+
+    def test_check_registry_connection_rejects_unsupported_registry_type(self):
+        with self.assertRaises(ServiceHandleException):
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="Unknown",
+            )

--- a/console/tests/registry_global_test.py
+++ b/console/tests/registry_global_test.py
@@ -80,11 +80,9 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertEqual(items[0]["scope"], "user")
         self.assertEqual(items[1]["scope"], "enterprise")
         self.assertEqual(items[1]["hub_type"], "AliyunACR")
-        self.assertEqual(items[1]["access_key"], "company-user")
         self.assertNotIn("password", items[1])
-        self.assertNotIn("access_secret", items[1])
 
-    def test_serialize_registry_auth_keeps_legacy_cloud_type_compatible(self):
+    def test_serialize_registry_auth_keeps_legacy_cloud_type_compatible_without_access_key_fields(self):
         auth = RegistryAuth(
             secret_id="company",
             domain="https://registry.cn-hangzhou.aliyuncs.com",
@@ -99,8 +97,8 @@ class GlobalRegistryAuthTests(TestCase):
         data = team_services.serialize_registry_auth(auth, include_password=True)
 
         self.assertEqual(data["hub_type"], "AliyunACR")
-        self.assertEqual(data["access_key"], "company-user")
-        self.assertEqual(data["access_secret"], "enterprise-password")
+        self.assertNotIn("access_key", data)
+        self.assertNotIn("access_secret", data)
 
     def test_enterprise_registry_list_masks_password_for_admins(self):
         enterprise = RegistryAuth(
@@ -126,14 +124,13 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"]["list"][0]["scope"], "enterprise")
         self.assertNotIn("password", response.data["data"]["list"][0])
-        self.assertNotIn("access_secret", response.data["data"]["list"][0])
 
-    def test_enterprise_registry_create_accepts_cloud_access_key_payload(self):
+    def test_enterprise_registry_create_uses_username_password_for_cloud_registry(self):
         request = SimpleNamespace(data={
             "secret_id": "company",
             "domain": "https://registry.cn-hangzhou.aliyuncs.com",
-            "access_key": "ak",
-            "access_secret": "sk",
+            "username": "registry-user",
+            "password": "registry-password",
             "hub_type": "AliyunACR",
         })
         view = registry_views.EnterpriseHubRegistryView()
@@ -148,18 +145,18 @@ class GlobalRegistryAuthTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         check_mock.assert_called_once_with(
-            "https://registry.cn-hangzhou.aliyuncs.com", "ak", "sk", "AliyunACR")
+            "https://registry.cn-hangzhou.aliyuncs.com", "registry-user", "registry-password", "AliyunACR")
         params = create_mock.call_args[1]
-        self.assertEqual(params["username"], "ak")
-        self.assertEqual(params["password"], "sk")
+        self.assertEqual(params["username"], "registry-user")
+        self.assertEqual(params["password"], "registry-password")
         self.assertEqual(params["hub_type"], "AliyunACR")
 
-    def test_user_registry_update_accepts_cloud_access_key_payload(self):
+    def test_user_registry_update_uses_username_password_for_cloud_registry(self):
         request = SimpleNamespace(
             GET={"secret_id": "personal"},
             data={
-                "access_key": "ak",
-                "access_secret": "sk",
+                "username": "registry-user",
+                "password": "registry-password",
                 "hub_type": "TencentTCR",
             },
         )
@@ -173,7 +170,7 @@ class GlobalRegistryAuthTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         update_mock.assert_called_once_with(
-            "personal", self.user.user_id, username="ak", password="sk", hub_type="TencentTCR")
+            "personal", self.user.user_id, username="registry-user", password="registry-password", hub_type="TencentTCR")
 
     def test_resolve_registry_auth_prefers_user_auth_then_enterprise_auth(self):
         personal = RegistryAuth(secret_id="same", username="alice", password="personal-password", scope="user")
@@ -306,7 +303,7 @@ class GlobalRegistryAuthTests(TestCase):
     def test_check_registry_connection_accepts_supported_cloud_registry_types(self):
         response = mock.Mock(status_code=200)
 
-        for hub_type in ["AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS"]:
+        for hub_type in ["AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR"]:
             with self.subTest(hub_type=hub_type):
                 with mock.patch("console.services.team_services.requests.get", return_value=response) as get_mock:
                     team_services.check_registry_connection(
@@ -332,6 +329,59 @@ class GlobalRegistryAuthTests(TestCase):
                     )
 
                 self.assertEqual(get_mock.call_args[0][0], "https://registry.example.com/v2/")
+
+    def test_check_registry_connection_rejects_volcano_tos_alias(self):
+        with self.assertRaises(ServiceHandleException):
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoTOS",
+            )
+
+    def test_check_registry_connection_handles_registry_v2_bearer_challenge(self):
+        challenge = mock.Mock(
+            status_code=401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer realm="https://auth.example.com/token",'
+                    'service="registry.example.com"'
+                )
+            },
+            text="",
+        )
+        token_response = mock.Mock(status_code=200)
+        token_response.json.return_value = {"token": "registry-token"}
+        ok_response = mock.Mock(status_code=200)
+
+        with mock.patch("console.services.team_services.requests.get",
+                        side_effect=[challenge, token_response, ok_response]) as get_mock:
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoCR",
+            )
+
+        self.assertEqual(get_mock.call_args_list[0][0][0], "https://registry.example.com/v2/")
+        self.assertEqual(get_mock.call_args_list[1][0][0], "https://auth.example.com/token")
+        self.assertEqual(get_mock.call_args_list[2][1]["headers"], {"Authorization": "Bearer registry-token"})
+
+    def test_check_registry_connection_error_includes_registry_response_body(self):
+        response = mock.Mock(status_code=403, text='{"errors":[{"message":"denied"}]}')
+
+        with mock.patch("console.services.team_services.requests.get", return_value=response):
+            with self.assertRaises(ServiceHandleException) as ctx:
+                team_services.check_registry_connection(
+                    domain="https://registry.example.com",
+                    username="user",
+                    password="password",
+                    hub_type="VolcanoCR",
+                )
+
+        self.assertIn("status:403", ctx.exception.msg)
+        self.assertIn("denied", ctx.exception.msg)
+        self.assertIn("403", ctx.exception.msg_show)
 
     def test_check_registry_connection_rejects_unsupported_registry_type(self):
         with self.assertRaises(ServiceHandleException):

--- a/console/tests/registry_global_test.py
+++ b/console/tests/registry_global_test.py
@@ -61,6 +61,8 @@ class GlobalRegistryAuthTests(TestCase):
             domain="https://registry.cn-hangzhou.aliyuncs.com",
             username="company-user",
             password="enterprise-password",
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
             hub_type="Aliyun",
             user_id=0,
             enterprise_id="eid-1",
@@ -80,14 +82,18 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertEqual(items[0]["scope"], "user")
         self.assertEqual(items[1]["scope"], "enterprise")
         self.assertEqual(items[1]["hub_type"], "AliyunACR")
+        self.assertEqual(items[1]["access_key"], "cloud-ak")
+        self.assertNotIn("access_secret", items[1])
         self.assertNotIn("password", items[1])
 
-    def test_serialize_registry_auth_keeps_legacy_cloud_type_compatible_without_access_key_fields(self):
+    def test_serialize_registry_auth_masks_cloud_api_secret(self):
         auth = RegistryAuth(
             secret_id="company",
             domain="https://registry.cn-hangzhou.aliyuncs.com",
             username="company-user",
             password="enterprise-password",
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
             hub_type="Aliyun",
             user_id=0,
             enterprise_id="eid-1",
@@ -97,7 +103,7 @@ class GlobalRegistryAuthTests(TestCase):
         data = team_services.serialize_registry_auth(auth, include_password=True)
 
         self.assertEqual(data["hub_type"], "AliyunACR")
-        self.assertNotIn("access_key", data)
+        self.assertEqual(data["access_key"], "cloud-ak")
         self.assertNotIn("access_secret", data)
 
     def test_enterprise_registry_list_masks_password_for_admins(self):
@@ -129,6 +135,8 @@ class GlobalRegistryAuthTests(TestCase):
         request = SimpleNamespace(data={
             "secret_id": "company",
             "domain": "https://registry.cn-hangzhou.aliyuncs.com",
+            "access_key": "cloud-ak",
+            "access_secret": "cloud-sk",
             "username": "registry-user",
             "password": "registry-password",
             "hub_type": "AliyunACR",
@@ -147,6 +155,8 @@ class GlobalRegistryAuthTests(TestCase):
         check_mock.assert_called_once_with(
             "https://registry.cn-hangzhou.aliyuncs.com", "registry-user", "registry-password", "AliyunACR")
         params = create_mock.call_args[1]
+        self.assertEqual(params["access_key"], "cloud-ak")
+        self.assertEqual(params["access_secret"], "cloud-sk")
         self.assertEqual(params["username"], "registry-user")
         self.assertEqual(params["password"], "registry-password")
         self.assertEqual(params["hub_type"], "AliyunACR")
@@ -155,6 +165,8 @@ class GlobalRegistryAuthTests(TestCase):
         request = SimpleNamespace(
             GET={"secret_id": "personal"},
             data={
+                "access_key": "cloud-ak",
+                "access_secret": "cloud-sk",
                 "username": "registry-user",
                 "password": "registry-password",
                 "hub_type": "TencentTCR",
@@ -170,7 +182,13 @@ class GlobalRegistryAuthTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         update_mock.assert_called_once_with(
-            "personal", self.user.user_id, username="registry-user", password="registry-password", hub_type="TencentTCR")
+            "personal",
+            self.user.user_id,
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
+            username="registry-user",
+            password="registry-password",
+            hub_type="TencentTCR")
 
     def test_resolve_registry_auth_prefers_user_auth_then_enterprise_auth(self):
         personal = RegistryAuth(secret_id="same", username="alice", password="personal-password", scope="user")
@@ -203,7 +221,7 @@ class GlobalRegistryAuthTests(TestCase):
             domain="https://registry.cn-hangzhou.aliyuncs.com",
             username="company-user",
             password="enterprise-password",
-            hub_type="Aliyun",
+            hub_type="Harbor",
             scope="enterprise",
         )
         request = self.factory.get("/console/hub/registry/image?secret_id=company")
@@ -365,6 +383,43 @@ class GlobalRegistryAuthTests(TestCase):
 
         self.assertEqual(get_mock.call_args_list[0][0][0], "https://registry.example.com/v2/")
         self.assertEqual(get_mock.call_args_list[1][0][0], "https://auth.example.com/token")
+        self.assertEqual(get_mock.call_args_list[2][1]["headers"], {"Authorization": "Bearer registry-token"})
+
+    def test_cloud_registry_tags_handle_registry_v2_bearer_challenge(self):
+        challenge = mock.Mock(
+            status_code=401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer realm="https://registry.example.com/service/token",'
+                    'service="harbor-registry",'
+                    'scope="repository:rainbond/nginx:pull"'
+                )
+            },
+            text='{"errors":[{"code":"UNAUTHORIZED"}]}',
+        )
+        token_response = mock.Mock(status_code=200)
+        token_response.json.return_value = {"token": "registry-token"}
+        tags_response = mock.Mock(status_code=200)
+        tags_response.json.return_value = {"name": "rainbond/nginx", "tags": ["alpine"]}
+
+        with mock.patch("console.services.team_services.requests.get",
+                        side_effect=[challenge, token_response, tags_response]) as get_mock:
+            data = team_services.get_registry_tags(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoCR",
+                namespace="rainbond",
+                name="nginx",
+            )
+
+        self.assertEqual(data["tags"][0]["name"], "alpine")
+        self.assertEqual(get_mock.call_args_list[0][0][0], "https://registry.example.com/v2/rainbond/nginx/tags/list")
+        self.assertEqual(get_mock.call_args_list[1][0][0], "https://registry.example.com/service/token")
+        self.assertEqual(get_mock.call_args_list[1][1]["params"], {
+            "service": "harbor-registry",
+            "scope": "repository:rainbond/nginx:pull",
+        })
         self.assertEqual(get_mock.call_args_list[2][1]["headers"], {"Authorization": "Bearer registry-token"})
 
     def test_check_registry_connection_error_includes_registry_response_body(self):

--- a/console/tests/registry_global_test.py
+++ b/console/tests/registry_global_test.py
@@ -32,6 +32,14 @@ class RegistryAuth(SimpleNamespace):
         return dict(self.__dict__)
 
 
+class _ExistsQuery(object):
+    def __init__(self, exists=False):
+        self._exists = exists
+
+    def exists(self):
+        return self._exists
+
+
 class GlobalRegistryAuthTests(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -71,7 +79,28 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertEqual(items[0]["password"], "personal-password")
         self.assertEqual(items[0]["scope"], "user")
         self.assertEqual(items[1]["scope"], "enterprise")
+        self.assertEqual(items[1]["hub_type"], "AliyunACR")
+        self.assertEqual(items[1]["access_key"], "company-user")
         self.assertNotIn("password", items[1])
+        self.assertNotIn("access_secret", items[1])
+
+    def test_serialize_registry_auth_keeps_legacy_cloud_type_compatible(self):
+        auth = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+
+        data = team_services.serialize_registry_auth(auth, include_password=True)
+
+        self.assertEqual(data["hub_type"], "AliyunACR")
+        self.assertEqual(data["access_key"], "company-user")
+        self.assertEqual(data["access_secret"], "enterprise-password")
 
     def test_enterprise_registry_list_masks_password_for_admins(self):
         enterprise = RegistryAuth(
@@ -97,6 +126,54 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"]["list"][0]["scope"], "enterprise")
         self.assertNotIn("password", response.data["data"]["list"][0])
+        self.assertNotIn("access_secret", response.data["data"]["list"][0])
+
+    def test_enterprise_registry_create_accepts_cloud_access_key_payload(self):
+        request = SimpleNamespace(data={
+            "secret_id": "company",
+            "domain": "https://registry.cn-hangzhou.aliyuncs.com",
+            "access_key": "ak",
+            "access_secret": "sk",
+            "hub_type": "AliyunACR",
+        })
+        view = registry_views.EnterpriseHubRegistryView()
+        view.user = self.user
+        view.is_enterprise_admin = True
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.check_exist_enterprise_registry_auth",
+                        return_value=_ExistsQuery(False)), \
+                mock.patch.object(team_services, "check_registry_connection") as check_mock, \
+                mock.patch("console.views.registry.team_registry_auth_repo.create_team_registry_auth") as create_mock:
+            response = view.post(request, enterprise_id="eid-1")
+
+        self.assertEqual(response.status_code, 200)
+        check_mock.assert_called_once_with(
+            "https://registry.cn-hangzhou.aliyuncs.com", "ak", "sk", "AliyunACR")
+        params = create_mock.call_args[1]
+        self.assertEqual(params["username"], "ak")
+        self.assertEqual(params["password"], "sk")
+        self.assertEqual(params["hub_type"], "AliyunACR")
+
+    def test_user_registry_update_accepts_cloud_access_key_payload(self):
+        request = SimpleNamespace(
+            GET={"secret_id": "personal"},
+            data={
+                "access_key": "ak",
+                "access_secret": "sk",
+                "hub_type": "TencentTCR",
+            },
+        )
+        auth = RegistryAuth(secret_id="personal", hub_type="TencentTCR")
+        view = HubRegistryView()
+        view.user = self.user
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.get_user_registry_auth", return_value=auth), \
+                mock.patch("console.views.registry.team_registry_auth_repo.update_user_registry_auth") as update_mock:
+            response = view.put(request)
+
+        self.assertEqual(response.status_code, 200)
+        update_mock.assert_called_once_with(
+            "personal", self.user.user_id, username="ak", password="sk", hub_type="TencentTCR")
 
     def test_resolve_registry_auth_prefers_user_auth_then_enterprise_auth(self):
         personal = RegistryAuth(secret_id="same", username="alice", password="personal-password", scope="user")
@@ -227,6 +304,21 @@ class GlobalRegistryAuthTests(TestCase):
         self.assertNotIn("user_id", payload)
 
     def test_check_registry_connection_accepts_supported_cloud_registry_types(self):
+        response = mock.Mock(status_code=200)
+
+        for hub_type in ["AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoTOS"]:
+            with self.subTest(hub_type=hub_type):
+                with mock.patch("console.services.team_services.requests.get", return_value=response) as get_mock:
+                    team_services.check_registry_connection(
+                        domain="https://registry.example.com",
+                        username="user",
+                        password="password",
+                        hub_type=hub_type,
+                    )
+
+                self.assertEqual(get_mock.call_args[0][0], "https://registry.example.com/v2/")
+
+    def test_check_registry_connection_accepts_legacy_cloud_registry_type_aliases(self):
         response = mock.Mock(status_code=200)
 
         for hub_type in ["Aliyun", "Tencent", "Huawei", "Volcano"]:

--- a/console/tests/registry_global_test.py
+++ b/console/tests/registry_global_test.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase, mock
+
+from rest_framework.test import APIRequestFactory
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.exception.main import ServiceHandleException  # noqa: E402
+from console.services.team_services import team_services  # noqa: E402
+from console.views.app_create.docker_run import DockerRunCreateView  # noqa: E402
+from console.views import registry as registry_views  # noqa: E402
+from console.views.registry import HubRegistryImageView, HubRegistryView  # noqa: E402
+
+
+class RegistryAuth(SimpleNamespace):
+    def to_dict(self):
+        return dict(self.__dict__)
+
+
+class _ExistsQuery(object):
+    def __init__(self, exists=False):
+        self._exists = exists
+
+    def exists(self):
+        return self._exists
+
+
+class GlobalRegistryAuthTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = SimpleNamespace(user_id=7, enterprise_id="eid-1", is_authenticated=True)
+
+    def test_hub_registry_list_merges_user_and_enterprise_auths_without_enterprise_password(self):
+        personal = RegistryAuth(
+            secret_id="personal",
+            domain="https://harbor.example.com",
+            username="alice",
+            password="personal-password",
+            hub_type="Harbor",
+            user_id=7,
+            enterprise_id="",
+            scope="user",
+        )
+        enterprise = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/hub/registry")
+        view = HubRegistryView()
+        view.user = self.user
+
+        with mock.patch.object(team_services, "list_accessible_registry_auths", return_value=[personal, enterprise]):
+            response = view.get(request)
+
+        self.assertEqual(response.status_code, 200)
+        items = response.data["data"]["list"]
+        self.assertEqual([item["secret_id"] for item in items], ["personal", "company"])
+        self.assertEqual(items[0]["password"], "personal-password")
+        self.assertEqual(items[0]["scope"], "user")
+        self.assertEqual(items[1]["scope"], "enterprise")
+        self.assertEqual(items[1]["hub_type"], "AliyunACR")
+        self.assertEqual(items[1]["access_key"], "cloud-ak")
+        self.assertNotIn("access_secret", items[1])
+        self.assertNotIn("password", items[1])
+
+    def test_serialize_registry_auth_masks_cloud_api_secret(self):
+        auth = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+
+        data = team_services.serialize_registry_auth(auth, include_password=True)
+
+        self.assertEqual(data["hub_type"], "AliyunACR")
+        self.assertEqual(data["access_key"], "cloud-ak")
+        self.assertNotIn("access_secret", data)
+
+    def test_enterprise_registry_list_masks_password_for_admins(self):
+        enterprise = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Aliyun",
+            user_id=0,
+            enterprise_id="eid-1",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/enterprise/eid-1/hub/registry")
+        self.assertTrue(hasattr(registry_views, "EnterpriseHubRegistryView"))
+        view = registry_views.EnterpriseHubRegistryView()
+        view.user = self.user
+        view.is_enterprise_admin = True
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.list_enterprise_registry_auths",
+                        return_value=[enterprise]):
+            response = view.get(request, enterprise_id="eid-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["list"][0]["scope"], "enterprise")
+        self.assertNotIn("password", response.data["data"]["list"][0])
+
+    def test_enterprise_registry_create_uses_username_password_for_cloud_registry(self):
+        request = SimpleNamespace(data={
+            "secret_id": "company",
+            "domain": "https://registry.cn-hangzhou.aliyuncs.com",
+            "access_key": "cloud-ak",
+            "access_secret": "cloud-sk",
+            "username": "registry-user",
+            "password": "registry-password",
+            "hub_type": "AliyunACR",
+        })
+        view = registry_views.EnterpriseHubRegistryView()
+        view.user = self.user
+        view.is_enterprise_admin = True
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.check_exist_enterprise_registry_auth",
+                        return_value=_ExistsQuery(False)), \
+                mock.patch.object(team_services, "check_registry_connection") as check_mock, \
+                mock.patch("console.views.registry.team_registry_auth_repo.create_team_registry_auth") as create_mock:
+            response = view.post(request, enterprise_id="eid-1")
+
+        self.assertEqual(response.status_code, 200)
+        check_mock.assert_called_once_with(
+            "https://registry.cn-hangzhou.aliyuncs.com", "registry-user", "registry-password", "AliyunACR")
+        params = create_mock.call_args[1]
+        self.assertEqual(params["access_key"], "cloud-ak")
+        self.assertEqual(params["access_secret"], "cloud-sk")
+        self.assertEqual(params["username"], "registry-user")
+        self.assertEqual(params["password"], "registry-password")
+        self.assertEqual(params["hub_type"], "AliyunACR")
+
+    def test_user_registry_update_uses_username_password_for_cloud_registry(self):
+        request = SimpleNamespace(
+            GET={"secret_id": "personal"},
+            data={
+                "access_key": "cloud-ak",
+                "access_secret": "cloud-sk",
+                "username": "registry-user",
+                "password": "registry-password",
+                "hub_type": "TencentTCR",
+            },
+        )
+        auth = RegistryAuth(secret_id="personal", hub_type="TencentTCR")
+        view = HubRegistryView()
+        view.user = self.user
+
+        with mock.patch("console.views.registry.team_registry_auth_repo.get_user_registry_auth", return_value=auth), \
+                mock.patch("console.views.registry.team_registry_auth_repo.update_user_registry_auth") as update_mock:
+            response = view.put(request)
+
+        self.assertEqual(response.status_code, 200)
+        update_mock.assert_called_once_with(
+            "personal",
+            self.user.user_id,
+            access_key="cloud-ak",
+            access_secret="cloud-sk",
+            username="registry-user",
+            password="registry-password",
+            hub_type="TencentTCR")
+
+    def test_resolve_registry_auth_prefers_user_auth_then_enterprise_auth(self):
+        personal = RegistryAuth(secret_id="same", username="alice", password="personal-password", scope="user")
+        enterprise = RegistryAuth(secret_id="same", username="company", password="enterprise-password", scope="enterprise")
+        user = SimpleNamespace(user_id=7, enterprise_id="eid-1")
+
+        with mock.patch("console.services.team_services.team_registry_auth_repo.get_user_registry_auth",
+                        return_value=personal), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_enterprise_registry_auth",
+                           return_value=enterprise):
+            resolved = team_services.resolve_registry_auth(user, "same")
+
+        self.assertIs(resolved, personal)
+
+    def test_resolve_registry_auth_falls_back_to_enterprise_auth(self):
+        enterprise = RegistryAuth(secret_id="company", username="company", password="enterprise-password", scope="enterprise")
+        user = SimpleNamespace(user_id=7, enterprise_id="eid-1")
+
+        with mock.patch("console.services.team_services.team_registry_auth_repo.get_user_registry_auth",
+                        return_value=None), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_enterprise_registry_auth",
+                           return_value=enterprise):
+            resolved = team_services.resolve_registry_auth(user, "company")
+
+        self.assertIs(resolved, enterprise)
+
+    def test_hub_registry_image_uses_accessible_registry_auth(self):
+        auth = RegistryAuth(
+            secret_id="company",
+            domain="https://registry.cn-hangzhou.aliyuncs.com",
+            username="company-user",
+            password="enterprise-password",
+            hub_type="Harbor",
+            scope="enterprise",
+        )
+        request = self.factory.get("/console/hub/registry/image?secret_id=company")
+        view = HubRegistryImageView()
+        view.user = self.user
+
+        with mock.patch.object(team_services, "resolve_registry_auth", return_value=auth) as resolve_mock, \
+                mock.patch.object(team_services, "get_registry_namespaces", return_value=["prod"]) as namespaces_mock:
+            response = view.get(request)
+
+        self.assertEqual(response.status_code, 200)
+        resolve_mock.assert_called_once_with(self.user, "company")
+        namespaces_mock.assert_called_once_with(
+            domain=auth.domain,
+            username=auth.username,
+            password=auth.password,
+            hub_type=auth.hub_type,
+        )
+        self.assertEqual(response.data["data"]["list"], ["prod"])
+
+    def test_docker_run_resolves_registry_auth_id_credentials_on_server(self):
+        registry_auth = RegistryAuth(secret_id="company", username="company-user", password="enterprise-password")
+        service = SimpleNamespace(service_id="sid-1", to_dict=lambda: {"service_id": "sid-1"})
+        request = SimpleNamespace(META={}, data={
+            "image_type": "docker_run",
+            "group_id": 1,
+            "service_cname": "demo",
+            "docker_cmd": "registry.example.com/ns/demo:latest",
+            "registry_auth_id": "company",
+        })
+        view = DockerRunCreateView()
+        view.user = SimpleNamespace(user_id=7, enterprise_id="eid-1", get_username=lambda: "alice")
+        view.tenant = SimpleNamespace(tenant_id="tenant-1")
+        view.response_region = "region-1"
+        view.region_name = "region-1"
+
+        with mock.patch.object(team_services, "resolve_registry_auth", return_value=registry_auth) as resolve_mock, \
+                mock.patch("console.views.app_create.docker_run.app_service.is_k8s_component_name_duplicate",
+                           return_value=False), \
+                mock.patch("console.views.app_create.docker_run.app_service.create_docker_run_app",
+                           return_value=(200, "ok", service)), \
+                mock.patch("console.views.app_create.docker_run.app_service.create_service_source_info") as source_mock, \
+                mock.patch("console.views.app_create.docker_run.group_service.add_service_to_group",
+                           return_value=(200, "ok")):
+            response = view.post(request)
+
+        self.assertEqual(response.status_code, 200)
+        resolve_mock.assert_called_once_with(view.user, "company")
+        source_mock.assert_called_once_with(view.tenant, service, "company-user", "enterprise-password")
+
+
+    def test_team_registry_create_region_payload_excludes_console_scope_fields(self):
+        tenant = SimpleNamespace(tenant_id="tenant-1", tenant_name="team-a")
+
+        with mock.patch("django.db.transaction.Atomic.__enter__", return_value=None), \
+                mock.patch("django.db.transaction.Atomic.__exit__", return_value=False), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_by_team_id_domain",
+                           return_value=[]), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.create_team_registry_auth"), \
+                mock.patch("console.services.team_services.region_api.create_registry_auth") as region_mock:
+            team_services.create_registry_auth(
+                tenant, "region-a", "https://harbor.example.com", "user", "password")
+
+        payload = region_mock.call_args[0][2]
+        self.assertNotIn("scope", payload)
+        self.assertNotIn("enterprise_id", payload)
+        self.assertNotIn("user_id", payload)
+
+    def test_team_registry_update_region_payload_excludes_console_scope_fields(self):
+        tenant = SimpleNamespace(tenant_id="tenant-1", tenant_name="team-a")
+        auth = RegistryAuth(
+            tenant_id="tenant-1",
+            secret_id="secret-a",
+            domain="https://harbor.example.com",
+            username="user",
+            password="password",
+            region_name="region-a",
+            hub_type="Docker",
+            user_id=7,
+            scope="user",
+            enterprise_id="eid-1",
+        )
+
+        with mock.patch("django.db.transaction.Atomic.__enter__", return_value=None), \
+                mock.patch("django.db.transaction.Atomic.__exit__", return_value=False), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.get_by_secret_id",
+                           return_value=[auth]), \
+                mock.patch("console.services.team_services.team_registry_auth_repo.update_team_registry_auth"), \
+                mock.patch("console.services.team_services.region_api.update_registry_auth") as region_mock:
+            team_services.update_registry_auth(tenant, "region-a", "secret-a", {"username": "new-user"})
+
+        payload = region_mock.call_args[0][2]
+        self.assertNotIn("scope", payload)
+        self.assertNotIn("enterprise_id", payload)
+        self.assertNotIn("user_id", payload)
+
+    def test_check_registry_connection_accepts_supported_cloud_registry_types(self):
+        response = mock.Mock(status_code=200)
+
+        for hub_type in ["AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR"]:
+            with self.subTest(hub_type=hub_type):
+                with mock.patch("console.services.team_services.requests.get", return_value=response) as get_mock:
+                    team_services.check_registry_connection(
+                        domain="https://registry.example.com",
+                        username="user",
+                        password="password",
+                        hub_type=hub_type,
+                    )
+
+                self.assertEqual(get_mock.call_args[0][0], "https://registry.example.com/v2/")
+
+    def test_check_registry_connection_accepts_legacy_cloud_registry_type_aliases(self):
+        response = mock.Mock(status_code=200)
+
+        for hub_type in ["Aliyun", "Tencent", "Huawei", "Volcano"]:
+            with self.subTest(hub_type=hub_type):
+                with mock.patch("console.services.team_services.requests.get", return_value=response) as get_mock:
+                    team_services.check_registry_connection(
+                        domain="https://registry.example.com",
+                        username="user",
+                        password="password",
+                        hub_type=hub_type,
+                    )
+
+                self.assertEqual(get_mock.call_args[0][0], "https://registry.example.com/v2/")
+
+    def test_check_registry_connection_rejects_volcano_tos_alias(self):
+        with self.assertRaises(ServiceHandleException):
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoTOS",
+            )
+
+    def test_check_registry_connection_handles_registry_v2_bearer_challenge(self):
+        challenge = mock.Mock(
+            status_code=401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer realm="https://auth.example.com/token",'
+                    'service="registry.example.com"'
+                )
+            },
+            text="",
+        )
+        token_response = mock.Mock(status_code=200)
+        token_response.json.return_value = {"token": "registry-token"}
+        ok_response = mock.Mock(status_code=200)
+
+        with mock.patch("console.services.team_services.requests.get",
+                        side_effect=[challenge, token_response, ok_response]) as get_mock:
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoCR",
+            )
+
+        self.assertEqual(get_mock.call_args_list[0][0][0], "https://registry.example.com/v2/")
+        self.assertEqual(get_mock.call_args_list[1][0][0], "https://auth.example.com/token")
+        self.assertEqual(get_mock.call_args_list[2][1]["headers"], {"Authorization": "Bearer registry-token"})
+
+    def test_cloud_registry_tags_handle_registry_v2_bearer_challenge(self):
+        challenge = mock.Mock(
+            status_code=401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer realm="https://registry.example.com/service/token",'
+                    'service="harbor-registry",'
+                    'scope="repository:rainbond/nginx:pull"'
+                )
+            },
+            text='{"errors":[{"code":"UNAUTHORIZED"}]}',
+        )
+        token_response = mock.Mock(status_code=200)
+        token_response.json.return_value = {"token": "registry-token"}
+        tags_response = mock.Mock(status_code=200)
+        tags_response.json.return_value = {"name": "rainbond/nginx", "tags": ["alpine"]}
+
+        with mock.patch("console.services.team_services.requests.get",
+                        side_effect=[challenge, token_response, tags_response]) as get_mock:
+            data = team_services.get_registry_tags(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="VolcanoCR",
+                namespace="rainbond",
+                name="nginx",
+            )
+
+        self.assertEqual(data["tags"][0]["name"], "alpine")
+        self.assertEqual(get_mock.call_args_list[0][0][0], "https://registry.example.com/v2/rainbond/nginx/tags/list")
+        self.assertEqual(get_mock.call_args_list[1][0][0], "https://registry.example.com/service/token")
+        self.assertEqual(get_mock.call_args_list[1][1]["params"], {
+            "service": "harbor-registry",
+            "scope": "repository:rainbond/nginx:pull",
+        })
+        self.assertEqual(get_mock.call_args_list[2][1]["headers"], {"Authorization": "Bearer registry-token"})
+
+    def test_check_registry_connection_error_includes_registry_response_body(self):
+        response = mock.Mock(status_code=403, text='{"errors":[{"message":"denied"}]}')
+
+        with mock.patch("console.services.team_services.requests.get", return_value=response):
+            with self.assertRaises(ServiceHandleException) as ctx:
+                team_services.check_registry_connection(
+                    domain="https://registry.example.com",
+                    username="user",
+                    password="password",
+                    hub_type="VolcanoCR",
+                )
+
+        self.assertIn("status:403", ctx.exception.msg)
+        self.assertIn("denied", ctx.exception.msg)
+        self.assertIn("403", ctx.exception.msg_show)
+
+    def test_check_registry_connection_rejects_unsupported_registry_type(self):
+        with self.assertRaises(ServiceHandleException):
+            team_services.check_registry_connection(
+                domain="https://registry.example.com",
+                username="user",
+                password="password",
+                hub_type="Unknown",
+            )

--- a/console/tests/webhook_test.py
+++ b/console/tests/webhook_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.views.webhook import (  # noqa: E402
+    UnsupportedImageWebhookEvent,
+    parse_image_webhook_payload,
+)
+
+
+class ImageWebhookPayloadTestCase(TestCase):
+    # capability_id: console.image-webhook.harbor-push-artifact
+    def test_parse_harbor_push_artifact_payload(self):
+        payload = {
+            "type": "PUSH_ARTIFACT",
+            "operator": "alice",
+            "event_data": {
+                "repository": {
+                    "repo_full_name": "demo/web",
+                    "name": "web",
+                },
+                "resources": [{
+                    "tag": "v1.2.3",
+                }],
+            },
+        }
+
+        event = parse_image_webhook_payload(payload)
+
+        self.assertEqual(event.repo_name, "demo/web")
+        self.assertEqual(event.tag, "v1.2.3")
+        self.assertEqual(event.pusher, "alice")
+
+    # capability_id: console.image-webhook.harbor-push-artifact
+    def test_parse_harbor_ignores_non_push_artifact_payload(self):
+        payload = {
+            "type": "DELETE_ARTIFACT",
+            "operator": "alice",
+            "event_data": {
+                "repository": {
+                    "repo_full_name": "demo/web",
+                },
+                "resources": [{
+                    "tag": "v1.2.3",
+                }],
+            },
+        }
+
+        with self.assertRaises(UnsupportedImageWebhookEvent):
+            parse_image_webhook_payload(payload)
+
+    # capability_id: console.image-webhook.harbor-push-artifact
+    def test_parse_registry_payload_keeps_existing_format(self):
+        payload = {
+            "push_data": {
+                "pusher": "bob",
+                "tag": "latest",
+            },
+            "repository": {
+                "repo_name": "demo/api",
+            },
+        }
+
+        event = parse_image_webhook_payload(payload)
+
+        self.assertEqual(event.repo_name, "demo/api")
+        self.assertEqual(event.tag, "latest")
+        self.assertEqual(event.pusher, "bob")

--- a/console/urls/__init__.py
+++ b/console/urls/__init__.py
@@ -145,7 +145,7 @@ from console.views.rbd_plugin import RainbondPluginLView, RainbondOfficialPlugin
 from console.views.platform_plugin import PlatformPluginLView, PlatformPluginInstallView
 from console.views.region import (GetRegionFeature, GetRegionPublicKeyView, MavenSettingRUDView, MavenSettingView,
                                   OpenRegionView, QyeryRegionView, RegQuyView, RegUnopenView, RegionMonitor)
-from console.views.registry import HubRegistryView, HubRegistryImageView
+from console.views.registry import HubRegistryView, HubRegistryImageView, EnterpriseHubRegistryView
 from console.views.rke2 import ClusterRKE, ClusterRKENode, ClusterNodeIP, ClusterRKEInstallRB, \
     ClusterRKERBStatus, ClusterRKERBEvent, ClusterRKEUNInstallInstallRB, InstallRKECluster, RKERegionConfig, \
     ClusterRBComponentLogSSE
@@ -284,6 +284,8 @@ urlpatterns = [
     # 镜像仓库配置
     url(r'^hub/registry$', HubRegistryView.as_view()),
     url(r'^hub/registry/image$', HubRegistryImageView.as_view()),
+    url(r'^enterprise/(?P<enterprise_id>[\w\-]+)/hub/registry$', EnterpriseHubRegistryView.as_view()),
+    url(r'^enterprise/(?P<enterprise_id>[\w\-]+)/hub/registry/(?P<secret_id>[\w\-]+)$', EnterpriseHubRegistryView.as_view()),
     # 我的详情
     url(r'^users/details$', UserDetailsView.as_view()),
     # 模糊查询用户

--- a/console/urls/__init__.py
+++ b/console/urls/__init__.py
@@ -134,6 +134,7 @@ from console.views.pod import AppPodsView
 from console.views.protocols import RegionProtocolView
 from console.views.posthog_proxy import PostHogProxyView
 from console.views.proxy import ProxyPassView, ProxySSEView
+from console.views.realtime_proxy import RegionRealtimeProxyView
 from console.views.sentry_proxy import SentryProxyView
 from console.views.mcp_query import MCPQueryHTTPView, MCPQueryMessageView, MCPQuerySSEView
 from console.views.public_areas import (AllServiceInfo, GroupServiceView, ServiceEventsView, ServiceGroupView,
@@ -144,7 +145,7 @@ from console.views.rbd_plugin import RainbondPluginLView, RainbondOfficialPlugin
 from console.views.platform_plugin import PlatformPluginLView, PlatformPluginInstallView
 from console.views.region import (GetRegionFeature, GetRegionPublicKeyView, MavenSettingRUDView, MavenSettingView,
                                   OpenRegionView, QyeryRegionView, RegQuyView, RegUnopenView, RegionMonitor)
-from console.views.registry import HubRegistryView, HubRegistryImageView
+from console.views.registry import HubRegistryView, HubRegistryImageView, EnterpriseHubRegistryView
 from console.views.rke2 import ClusterRKE, ClusterRKENode, ClusterNodeIP, ClusterRKEInstallRB, \
     ClusterRKERBStatus, ClusterRKERBEvent, ClusterRKEUNInstallInstallRB, InstallRKECluster, RKERegionConfig, \
     ClusterRBComponentLogSSE
@@ -198,6 +199,8 @@ urlpatterns = [
     re_path(r'^api-gateway/convert', AppApiGatewayConvertView.as_view()),
     re_path(r'^posthog/(?P<path>.*)$', PostHogProxyView.as_view()),
     re_path(r'^sentry/(?P<path>.*)$', SentryProxyView.as_view()),
+    re_path(r'^regions/(?P<region_name>[\w\-]+)/websocket$', RegionRealtimeProxyView.as_view(), {"proxy_path": ""}),
+    re_path(r'^regions/(?P<region_name>[\w\-]+)/websocket/(?P<proxy_path>.*)$', RegionRealtimeProxyView.as_view()),
     re_path(r'^v2/proxy-pass/(.*?)', ProxyPassView.as_view()),
     re_path(r'^sse/(.*?)', ProxySSEView.as_view()),
     re_path(r'^mcp/query$', MCPQueryHTTPView.as_view()),
@@ -281,6 +284,8 @@ urlpatterns = [
     # 镜像仓库配置
     re_path(r'^hub/registry$', HubRegistryView.as_view()),
     re_path(r'^hub/registry/image$', HubRegistryImageView.as_view()),
+    re_path(r'^enterprise/(?P<enterprise_id>[\w\-]+)/hub/registry$', EnterpriseHubRegistryView.as_view()),
+    re_path(r'^enterprise/(?P<enterprise_id>[\w\-]+)/hub/registry/(?P<secret_id>[\w\-]+)$', EnterpriseHubRegistryView.as_view()),
     # 我的详情
     re_path(r'^users/details$', UserDetailsView.as_view()),
     # 模糊查询用户

--- a/console/urls/__init__.py
+++ b/console/urls/__init__.py
@@ -134,6 +134,7 @@ from console.views.pod import AppPodsView
 from console.views.protocols import RegionProtocolView
 from console.views.posthog_proxy import PostHogProxyView
 from console.views.proxy import ProxyPassView, ProxySSEView
+from console.views.realtime_proxy import RegionRealtimeProxyView
 from console.views.sentry_proxy import SentryProxyView
 from console.views.mcp_query import MCPQueryHTTPView, MCPQueryMessageView, MCPQuerySSEView
 from console.views.public_areas import (AllServiceInfo, GroupServiceView, ServiceEventsView, ServiceGroupView,
@@ -198,6 +199,8 @@ urlpatterns = [
     url(r'^api-gateway/convert', AppApiGatewayConvertView.as_view()),
     url(r'^posthog/(?P<path>.*)$', PostHogProxyView.as_view()),
     url(r'^sentry/(?P<path>.*)$', SentryProxyView.as_view()),
+    url(r'^regions/(?P<region_name>[\w\-]+)/websocket$', RegionRealtimeProxyView.as_view(), {"proxy_path": ""}),
+    url(r'^regions/(?P<region_name>[\w\-]+)/websocket/(?P<proxy_path>.*)$', RegionRealtimeProxyView.as_view()),
     url(r'^v2/proxy-pass/(.*?)', ProxyPassView.as_view()),
     url(r'^sse/(.*?)', ProxySSEView.as_view()),
     url(r'^mcp/query$', MCPQueryHTTPView.as_view()),

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+
+import requests
+from django.http import HttpResponse, HttpResponseBadRequest, StreamingHttpResponse
+
+from console.repositories.region_repo import region_repo
+
+logger = logging.getLogger("default")
+
+REALTIME_PROXY_PATH = "/console/regions/{region_name}/websocket"
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _strip_slashes(value):
+    return (value or "").strip("/")
+
+
+def normalize_proxy_path(proxy_path):
+    proxy_path = _strip_slashes(proxy_path)
+    if not proxy_path:
+        return ""
+    return "/" + proxy_path
+
+
+def build_console_realtime_proxy_path(region_name, proxy_path=""):
+    return REALTIME_PROXY_PATH.format(region_name=region_name) + normalize_proxy_path(proxy_path)
+
+
+def _request_is_secure(request):
+    forwarded_proto = request.META.get("HTTP_X_FORWARDED_PROTO", "")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.is_secure()
+
+
+def build_console_realtime_proxy_url(request, region_name, proxy_path="", scheme_type="http"):
+    secure = _request_is_secure(request)
+    if scheme_type == "ws":
+        scheme = "wss" if secure else "ws"
+    else:
+        scheme = "https" if secure else "http"
+    return "{scheme}://{host}{path}".format(
+        scheme=scheme,
+        host=request.get_host(),
+        path=build_console_realtime_proxy_path(region_name, proxy_path),
+    )
+
+
+def _auto_region_wsurl(request):
+    if request is None:
+        raise ValueError("request is required when region websocket url is auto")
+    host = request.get_host().split(":", 1)[0]
+    return "ws://{0}:6060".format(host)
+
+
+def get_region_wsurl(region_name, request=None):
+    region = region_repo.get_region_by_region_name(region_name)
+    proxy_target = os.environ.get("REGION_WS_PROXY_TARGET")
+    proxy_region = os.environ.get("REGION_WS_PROXY_REGION", "rainbond")
+    if proxy_target and region_name == proxy_region:
+        return proxy_target.rstrip("/")
+    if not region or not getattr(region, "wsurl", None) or region.wsurl == "auto":
+        return _auto_region_wsurl(request)
+    return region.wsurl.rstrip("/")
+
+
+def _convert_scheme(url, scheme_type):
+    if scheme_type == "ws":
+        if url.startswith("https://"):
+            return "wss://" + url[len("https://"):]
+        if url.startswith("http://"):
+            return "ws://" + url[len("http://"):]
+        return url
+    if url.startswith("wss://"):
+        return "https://" + url[len("wss://"):]
+    if url.startswith("ws://"):
+        return "http://" + url[len("ws://"):]
+    return url
+
+
+def build_region_realtime_proxy_url(region_name, proxy_path="", query_string="", request=None, scheme_type="http"):
+    base_url = _convert_scheme(get_region_wsurl(region_name, request=request), scheme_type).rstrip("/")
+    target_url = base_url + normalize_proxy_path(proxy_path)
+    if query_string:
+        target_url = target_url + "?" + query_string
+    return target_url
+
+
+def build_region_status_probe_url(api_host, token):
+    return "http://{0}:6060/helm_install/region_status/{1}".format(api_host, token)
+
+
+def _header_name(meta_key):
+    return "-".join([part.capitalize() for part in meta_key.split("_")])
+
+
+def build_forward_headers(request):
+    headers = {}
+    for key, value in request.META.items():
+        if key.startswith("HTTP_"):
+            header = _header_name(key[5:])
+        elif key in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+            header = _header_name(key)
+        else:
+            continue
+        if header.lower() in HOP_BY_HOP_HEADERS or header.lower() == "host":
+            continue
+        headers[header] = value
+    return headers
+
+
+def _request_body_stream(request):
+    content_length = request.META.get("CONTENT_LENGTH")
+    if request.method in ("GET", "HEAD", "OPTIONS") or content_length in (None, "", "0"):
+        return None
+    return request.META.get("wsgi.input")
+
+
+def proxy_http_request(request, region_name, proxy_path):
+    target_url = build_region_realtime_proxy_url(
+        region_name,
+        proxy_path,
+        request.META.get("QUERY_STRING", ""),
+        request=request,
+        scheme_type="http",
+    )
+    response = requests.request(
+        request.method,
+        target_url,
+        headers=build_forward_headers(request),
+        data=_request_body_stream(request),
+        stream=True,
+        timeout=(10, 3600),
+        allow_redirects=False,
+    )
+
+    excluded_headers = HOP_BY_HOP_HEADERS | {"content-encoding"}
+    response_headers = {
+        key: value for key, value in response.headers.items()
+        if key.lower() not in excluded_headers
+    }
+
+    if request.method == "HEAD":
+        proxy_response = HttpResponse(status=response.status_code)
+    else:
+        proxy_response = StreamingHttpResponse(
+            _iter_response_content(response),
+            status=response.status_code,
+        )
+    for key, value in response_headers.items():
+        proxy_response[key] = value
+    return proxy_response
+
+
+def _iter_response_content(response):
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if chunk:
+                yield chunk
+    finally:
+        response.close()
+
+
+def _websocket_subprotocols(request):
+    protocols = request.META.get("HTTP_SEC_WEBSOCKET_PROTOCOL", "")
+    return [item.strip() for item in protocols.split(",") if item.strip()]
+
+
+def _websocket_headers(request):
+    headers = []
+    for header in ("Origin", "Cookie", "Authorization", "X-Forwarded-For"):
+        meta_key = "HTTP_" + header.upper().replace("-", "_")
+        value = request.META.get(meta_key)
+        if value:
+            headers.append("{0}: {1}".format(header, value))
+    return headers
+
+
+def proxy_websocket_request(request, region_name, proxy_path):
+    client_ws = getattr(request, "environ", {}).get("wsgi.websocket")
+    if client_ws is None:
+        client_ws = request.META.get("wsgi.websocket")
+    if client_ws is None:
+        return HttpResponseBadRequest("websocket upgrade required")
+
+    try:
+        import gevent
+        from geventwebsocket.exceptions import WebSocketError
+        from websocket import ABNF, WebSocketConnectionClosedException, create_connection
+    except ImportError:
+        logger.exception("websocket proxy dependencies are missing")
+        return HttpResponse("websocket proxy dependencies are missing", status=500)
+
+    target_url = build_region_realtime_proxy_url(
+        region_name,
+        proxy_path,
+        request.META.get("QUERY_STRING", ""),
+        request=request,
+        scheme_type="ws",
+    )
+    backend_ws = create_connection(
+        target_url,
+        timeout=10,
+        header=_websocket_headers(request),
+        subprotocols=_websocket_subprotocols(request),
+    )
+
+    def client_to_backend():
+        while True:
+            try:
+                message = client_ws.receive()
+                if message is None:
+                    break
+                if isinstance(message, bytes):
+                    backend_ws.send_binary(message)
+                else:
+                    backend_ws.send(message)
+            except (WebSocketError, WebSocketConnectionClosedException):
+                break
+            except Exception:
+                logger.exception("websocket proxy client->backend failed")
+                break
+
+    def backend_to_client():
+        while True:
+            try:
+                opcode, data = backend_ws.recv_data()
+                if opcode == ABNF.OPCODE_CLOSE:
+                    break
+                if opcode == ABNF.OPCODE_BINARY:
+                    client_ws.send(data, binary=True)
+                elif opcode == ABNF.OPCODE_TEXT:
+                    if isinstance(data, bytes):
+                        data = data.decode("utf-8")
+                    client_ws.send(data)
+                elif opcode == ABNF.OPCODE_PING:
+                    backend_ws.pong(data)
+            except (WebSocketError, WebSocketConnectionClosedException):
+                break
+            except Exception:
+                logger.exception("websocket proxy backend->client failed")
+                break
+
+    jobs = [gevent.spawn(client_to_backend), gevent.spawn(backend_to_client)]
+    try:
+        gevent.joinall(jobs, count=1)
+    finally:
+        for job in jobs:
+            job.kill()
+        try:
+            backend_ws.close()
+        except Exception:
+            logger.debug("close backend websocket failed", exc_info=True)
+        try:
+            client_ws.close()
+        except Exception:
+            logger.debug("close client websocket failed", exc_info=True)
+    return HttpResponse(status=204)

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
+import time
 
 import requests
 from django.http import HttpResponse, HttpResponseBadRequest, StreamingHttpResponse
@@ -10,6 +11,9 @@ from console.repositories.region_repo import region_repo
 logger = logging.getLogger("default")
 
 REALTIME_PROXY_PATH = "/console/regions/{region_name}/websocket"
+DOCKER_CONSOLE_IDLE_TIMEOUT_SECONDS = 30 * 60
+WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS = 30
+WEBTTY_PING_MESSAGE = "2"
 
 HOP_BY_HOP_HEADERS = {
     "connection",
@@ -227,6 +231,27 @@ def _websocket_headers(request):
     return headers
 
 
+class DockerConsoleActivityTracker(object):
+    def __init__(self, proxy_path, idle_timeout_seconds=DOCKER_CONSOLE_IDLE_TIMEOUT_SECONDS, now=None):
+        self.enabled = normalize_proxy_path(proxy_path) == "/docker_console"
+        self.idle_timeout_seconds = idle_timeout_seconds
+        self.now = now or time.time
+        self.last_user_activity_at = self.now()
+
+    def mark_client_message(self, message):
+        if not self.enabled:
+            return
+        if message == WEBTTY_PING_MESSAGE:
+            return
+        self.last_user_activity_at = self.now()
+
+    def is_idle_expired(self, now=None):
+        if not self.enabled:
+            return False
+        current_time = self.now() if now is None else now
+        return current_time - self.last_user_activity_at > self.idle_timeout_seconds
+
+
 def open_backend_websocket(create_connection, target_url, request, proxy_path):
     backend_ws = create_connection(
         target_url,
@@ -234,7 +259,7 @@ def open_backend_websocket(create_connection, target_url, request, proxy_path):
         header=_websocket_headers(request),
         subprotocols=_backend_websocket_subprotocols(request, proxy_path),
     )
-    backend_ws.settimeout(None)
+    backend_ws.settimeout(WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS)
     return backend_ws
 
 
@@ -248,7 +273,7 @@ def proxy_websocket_request(request, region_name, proxy_path):
     try:
         import gevent
         from geventwebsocket.exceptions import WebSocketError
-        from websocket import ABNF, WebSocketConnectionClosedException, create_connection
+        from websocket import ABNF, WebSocketConnectionClosedException, WebSocketTimeoutException, create_connection
     except ImportError:
         logger.exception("websocket proxy dependencies are missing")
         return HttpResponse("websocket proxy dependencies are missing", status=500)
@@ -266,6 +291,7 @@ def proxy_websocket_request(request, region_name, proxy_path):
         request,
         proxy_path,
     )
+    activity_tracker = DockerConsoleActivityTracker(proxy_path)
 
     def client_to_backend():
         while True:
@@ -273,6 +299,7 @@ def proxy_websocket_request(request, region_name, proxy_path):
                 message = client_ws.receive()
                 if message is None:
                     break
+                activity_tracker.mark_client_message(message)
                 if isinstance(message, bytes):
                     backend_ws.send_binary(message)
                 else:
@@ -286,6 +313,9 @@ def proxy_websocket_request(request, region_name, proxy_path):
     def backend_to_client():
         while True:
             try:
+                if activity_tracker.is_idle_expired():
+                    logger.info("docker console websocket idle timeout reached")
+                    break
                 opcode, data = backend_ws.recv_data()
                 if opcode == ABNF.OPCODE_CLOSE:
                     break
@@ -297,6 +327,8 @@ def proxy_websocket_request(request, region_name, proxy_path):
                     client_ws.send(data)
                 elif opcode == ABNF.OPCODE_PING:
                     backend_ws.pong(data)
+            except WebSocketTimeoutException:
+                continue
             except (WebSocketError, WebSocketConnectionClosedException):
                 break
             except Exception:

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -208,6 +208,15 @@ def _websocket_subprotocols(request):
     return [item.strip() for item in protocols.split(",") if item.strip()]
 
 
+def _backend_websocket_subprotocols(request, proxy_path):
+    protocols = _websocket_subprotocols(request)
+    if protocols:
+        return protocols
+    if normalize_proxy_path(proxy_path) == "/docker_console":
+        return ["webtty"]
+    return []
+
+
 def _websocket_headers(request):
     headers = []
     for header in ("Origin", "Cookie", "Authorization", "X-Forwarded-For"):
@@ -244,7 +253,7 @@ def proxy_websocket_request(request, region_name, proxy_path):
         target_url,
         timeout=10,
         header=_websocket_headers(request),
-        subprotocols=_websocket_subprotocols(request),
+        subprotocols=_backend_websocket_subprotocols(request, proxy_path),
     )
 
     def client_to_backend():

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -1,0 +1,352 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+import time
+
+import requests
+from django.http import HttpResponse, HttpResponseBadRequest, StreamingHttpResponse
+
+from console.repositories.region_repo import region_repo
+
+logger = logging.getLogger("default")
+
+REALTIME_PROXY_PATH = "/console/regions/{region_name}/websocket"
+DOCKER_CONSOLE_IDLE_TIMEOUT_SECONDS = 30 * 60
+WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS = 30
+WEBTTY_PING_MESSAGE = "2"
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _strip_slashes(value):
+    return (value or "").strip("/")
+
+
+def normalize_proxy_path(proxy_path):
+    proxy_path = _strip_slashes(proxy_path)
+    if not proxy_path:
+        return ""
+    return "/" + proxy_path
+
+
+def build_console_realtime_proxy_path(region_name, proxy_path=""):
+    return REALTIME_PROXY_PATH.format(region_name=region_name) + normalize_proxy_path(proxy_path)
+
+
+def _request_is_secure(request):
+    forwarded_proto = request.META.get("HTTP_X_FORWARDED_PROTO", "")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.is_secure()
+
+
+def build_console_realtime_proxy_url(request, region_name, proxy_path="", scheme_type="http"):
+    secure = _request_is_secure(request)
+    if scheme_type == "ws":
+        scheme = "wss" if secure else "ws"
+    else:
+        scheme = "https" if secure else "http"
+    return "{scheme}://{host}{path}".format(
+        scheme=scheme,
+        host=request.get_host(),
+        path=build_console_realtime_proxy_path(region_name, proxy_path),
+    )
+
+
+def _auto_region_wsurl(request):
+    if request is None:
+        raise ValueError("request is required when region websocket url is auto")
+    host = request.get_host().split(":", 1)[0]
+    return "ws://{0}:6060".format(host)
+
+
+def get_region_wsurl(region_name, request=None):
+    region = region_repo.get_region_by_region_name(region_name)
+    proxy_target = os.environ.get("REGION_WS_PROXY_TARGET")
+    proxy_region = os.environ.get("REGION_WS_PROXY_REGION", "rainbond")
+    if proxy_target and region_name == proxy_region:
+        return proxy_target.rstrip("/")
+    if not region or not getattr(region, "wsurl", None) or region.wsurl == "auto":
+        return _auto_region_wsurl(request)
+    return region.wsurl.rstrip("/")
+
+
+def _convert_scheme(url, scheme_type):
+    if scheme_type == "ws":
+        if url.startswith("https://"):
+            return "wss://" + url[len("https://"):]
+        if url.startswith("http://"):
+            return "ws://" + url[len("http://"):]
+        return url
+    if url.startswith("wss://"):
+        return "https://" + url[len("wss://"):]
+    if url.startswith("ws://"):
+        return "http://" + url[len("ws://"):]
+    return url
+
+
+def build_region_realtime_proxy_url(region_name, proxy_path="", query_string="", request=None, scheme_type="http"):
+    base_url = _convert_scheme(get_region_wsurl(region_name, request=request), scheme_type).rstrip("/")
+    target_url = base_url + normalize_proxy_path(proxy_path)
+    if query_string:
+        target_url = target_url + "?" + query_string
+    return target_url
+
+
+def build_region_status_probe_url(api_host, token):
+    return "http://{0}:6060/helm_install/region_status/{1}".format(api_host, token)
+
+
+def _header_name(meta_key):
+    return "-".join([part.capitalize() for part in meta_key.split("_")])
+
+
+def build_forward_headers(request):
+    headers = {}
+    for key, value in request.META.items():
+        if key.startswith("HTTP_"):
+            header = _header_name(key[5:])
+        elif key in ("CONTENT_TYPE", "CONTENT_LENGTH"):
+            header = _header_name(key)
+        else:
+            continue
+        if header.lower() in HOP_BY_HOP_HEADERS or header.lower() == "host":
+            continue
+        headers[header] = value
+    return headers
+
+
+def _is_multipart_request(request):
+    return request.META.get("CONTENT_TYPE", "").lower().startswith("multipart/form-data")
+
+
+def build_multipart_payload(request):
+    data = {}
+    files = {}
+    for key, values in request.POST.lists():
+        data[key] = values if len(values) > 1 else values[0]
+    for key, uploaded_files in request.FILES.lists():
+        file_items = []
+        for uploaded_file in uploaded_files:
+            file_items.append((
+                uploaded_file.name,
+                uploaded_file,
+                uploaded_file.content_type or "application/octet-stream",
+            ))
+        files[key] = file_items if len(file_items) > 1 else file_items[0]
+    return data, files
+
+
+def _request_body_stream(request):
+    content_length = request.META.get("CONTENT_LENGTH")
+    if request.method in ("GET", "HEAD", "OPTIONS") or content_length in (None, "", "0"):
+        return None
+    return request.META.get("wsgi.input")
+
+
+def proxy_http_request(request, region_name, proxy_path):
+    target_url = build_region_realtime_proxy_url(
+        region_name,
+        proxy_path,
+        request.META.get("QUERY_STRING", ""),
+        request=request,
+        scheme_type="http",
+    )
+    headers = build_forward_headers(request)
+    data = _request_body_stream(request)
+    files = None
+    if request.method in ("POST", "PUT", "PATCH") and _is_multipart_request(request):
+        headers.pop("Content-Type", None)
+        headers.pop("Content-Length", None)
+        data, files = build_multipart_payload(request)
+
+    response = requests.request(
+        request.method,
+        target_url,
+        headers=headers,
+        data=data,
+        files=files,
+        stream=True,
+        timeout=(10, 3600),
+        allow_redirects=False,
+    )
+
+    excluded_headers = HOP_BY_HOP_HEADERS | {"content-encoding"}
+    response_headers = {
+        key: value for key, value in response.headers.items()
+        if key.lower() not in excluded_headers
+    }
+
+    if request.method == "HEAD":
+        proxy_response = HttpResponse(status=response.status_code)
+    else:
+        proxy_response = StreamingHttpResponse(
+            _iter_response_content(response),
+            status=response.status_code,
+        )
+    for key, value in response_headers.items():
+        proxy_response[key] = value
+    return proxy_response
+
+
+def _iter_response_content(response):
+    try:
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if chunk:
+                yield chunk
+    finally:
+        response.close()
+
+
+def _websocket_subprotocols(request):
+    protocols = request.META.get("HTTP_SEC_WEBSOCKET_PROTOCOL", "")
+    return [item.strip() for item in protocols.split(",") if item.strip()]
+
+
+def _backend_websocket_subprotocols(request, proxy_path):
+    protocols = _websocket_subprotocols(request)
+    if protocols:
+        return protocols
+    if normalize_proxy_path(proxy_path) == "/docker_console":
+        return ["webtty"]
+    return []
+
+
+def _websocket_headers(request):
+    headers = []
+    for header in ("Origin", "Cookie", "Authorization", "X-Forwarded-For"):
+        meta_key = "HTTP_" + header.upper().replace("-", "_")
+        value = request.META.get(meta_key)
+        if value:
+            headers.append("{0}: {1}".format(header, value))
+    return headers
+
+
+class DockerConsoleActivityTracker(object):
+    def __init__(self, proxy_path, idle_timeout_seconds=DOCKER_CONSOLE_IDLE_TIMEOUT_SECONDS, now=None):
+        self.enabled = normalize_proxy_path(proxy_path) == "/docker_console"
+        self.idle_timeout_seconds = idle_timeout_seconds
+        self.now = now or time.time
+        self.last_user_activity_at = self.now()
+
+    def mark_client_message(self, message):
+        if not self.enabled:
+            return
+        if message == WEBTTY_PING_MESSAGE:
+            return
+        self.last_user_activity_at = self.now()
+
+    def is_idle_expired(self, now=None):
+        if not self.enabled:
+            return False
+        current_time = self.now() if now is None else now
+        return current_time - self.last_user_activity_at > self.idle_timeout_seconds
+
+
+def open_backend_websocket(create_connection, target_url, request, proxy_path):
+    backend_ws = create_connection(
+        target_url,
+        timeout=10,
+        header=_websocket_headers(request),
+        subprotocols=_backend_websocket_subprotocols(request, proxy_path),
+    )
+    backend_ws.settimeout(WEBSOCKET_PROXY_READ_TIMEOUT_SECONDS)
+    return backend_ws
+
+
+def proxy_websocket_request(request, region_name, proxy_path):
+    client_ws = getattr(request, "environ", {}).get("wsgi.websocket")
+    if client_ws is None:
+        client_ws = request.META.get("wsgi.websocket")
+    if client_ws is None:
+        return HttpResponseBadRequest("websocket upgrade required")
+
+    try:
+        import gevent
+        from geventwebsocket.exceptions import WebSocketError
+        from websocket import ABNF, WebSocketConnectionClosedException, WebSocketTimeoutException, create_connection
+    except ImportError:
+        logger.exception("websocket proxy dependencies are missing")
+        return HttpResponse("websocket proxy dependencies are missing", status=500)
+
+    target_url = build_region_realtime_proxy_url(
+        region_name,
+        proxy_path,
+        request.META.get("QUERY_STRING", ""),
+        request=request,
+        scheme_type="ws",
+    )
+    backend_ws = open_backend_websocket(
+        create_connection,
+        target_url,
+        request,
+        proxy_path,
+    )
+    activity_tracker = DockerConsoleActivityTracker(proxy_path)
+
+    def client_to_backend():
+        while True:
+            try:
+                message = client_ws.receive()
+                if message is None:
+                    break
+                activity_tracker.mark_client_message(message)
+                if isinstance(message, bytes):
+                    backend_ws.send_binary(message)
+                else:
+                    backend_ws.send(message)
+            except (WebSocketError, WebSocketConnectionClosedException):
+                break
+            except Exception:
+                logger.exception("websocket proxy client->backend failed")
+                break
+
+    def backend_to_client():
+        while True:
+            try:
+                if activity_tracker.is_idle_expired():
+                    logger.info("docker console websocket idle timeout reached")
+                    break
+                opcode, data = backend_ws.recv_data()
+                if opcode == ABNF.OPCODE_CLOSE:
+                    break
+                if opcode == ABNF.OPCODE_BINARY:
+                    client_ws.send(data, binary=True)
+                elif opcode == ABNF.OPCODE_TEXT:
+                    if isinstance(data, bytes):
+                        data = data.decode("utf-8")
+                    client_ws.send(data)
+                elif opcode == ABNF.OPCODE_PING:
+                    backend_ws.pong(data)
+            except WebSocketTimeoutException:
+                continue
+            except (WebSocketError, WebSocketConnectionClosedException):
+                break
+            except Exception:
+                logger.exception("websocket proxy backend->client failed")
+                break
+
+    jobs = [gevent.spawn(client_to_backend), gevent.spawn(backend_to_client)]
+    try:
+        gevent.joinall(jobs, count=1)
+    finally:
+        for job in jobs:
+            job.kill()
+        try:
+            backend_ws.close()
+        except Exception:
+            logger.debug("close backend websocket failed", exc_info=True)
+        try:
+            client_ws.close()
+        except Exception:
+            logger.debug("close client websocket failed", exc_info=True)
+    return HttpResponse(status=204)

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -121,6 +121,27 @@ def build_forward_headers(request):
     return headers
 
 
+def _is_multipart_request(request):
+    return request.META.get("CONTENT_TYPE", "").lower().startswith("multipart/form-data")
+
+
+def build_multipart_payload(request):
+    data = {}
+    files = {}
+    for key, values in request.POST.lists():
+        data[key] = values if len(values) > 1 else values[0]
+    for key, uploaded_files in request.FILES.lists():
+        file_items = []
+        for uploaded_file in uploaded_files:
+            file_items.append((
+                uploaded_file.name,
+                uploaded_file,
+                uploaded_file.content_type or "application/octet-stream",
+            ))
+        files[key] = file_items if len(file_items) > 1 else file_items[0]
+    return data, files
+
+
 def _request_body_stream(request):
     content_length = request.META.get("CONTENT_LENGTH")
     if request.method in ("GET", "HEAD", "OPTIONS") or content_length in (None, "", "0"):
@@ -136,11 +157,20 @@ def proxy_http_request(request, region_name, proxy_path):
         request=request,
         scheme_type="http",
     )
+    headers = build_forward_headers(request)
+    data = _request_body_stream(request)
+    files = None
+    if request.method in ("POST", "PUT", "PATCH") and _is_multipart_request(request):
+        headers.pop("Content-Type", None)
+        headers.pop("Content-Length", None)
+        data, files = build_multipart_payload(request)
+
     response = requests.request(
         request.method,
         target_url,
-        headers=build_forward_headers(request),
-        data=_request_body_stream(request),
+        headers=headers,
+        data=data,
+        files=files,
         stream=True,
         timeout=(10, 3600),
         allow_redirects=False,

--- a/console/utils/realtime_proxy.py
+++ b/console/utils/realtime_proxy.py
@@ -227,6 +227,17 @@ def _websocket_headers(request):
     return headers
 
 
+def open_backend_websocket(create_connection, target_url, request, proxy_path):
+    backend_ws = create_connection(
+        target_url,
+        timeout=10,
+        header=_websocket_headers(request),
+        subprotocols=_backend_websocket_subprotocols(request, proxy_path),
+    )
+    backend_ws.settimeout(None)
+    return backend_ws
+
+
 def proxy_websocket_request(request, region_name, proxy_path):
     client_ws = getattr(request, "environ", {}).get("wsgi.websocket")
     if client_ws is None:
@@ -249,11 +260,11 @@ def proxy_websocket_request(request, region_name, proxy_path):
         request=request,
         scheme_type="ws",
     )
-    backend_ws = create_connection(
+    backend_ws = open_backend_websocket(
+        create_connection,
         target_url,
-        timeout=10,
-        header=_websocket_headers(request),
-        subprotocols=_backend_websocket_subprotocols(request, proxy_path),
+        request,
+        proxy_path,
     )
 
     def client_to_backend():

--- a/console/views/app_config/app_domain.py
+++ b/console/views/app_config/app_domain.py
@@ -888,7 +888,8 @@ class GatewayRoute(RegionTenantHeaderView):
         name = request.GET.get("name", "")
         namespace = self.tenant.namespace
         app_id = region_app_repo.get_app_id(self.region_name, region_app_id)
-        data = gateway_api.delete_http_route(self.region_name, self.tenant_name, namespace, name, region_app_id)
+        data = gateway_api.delete_http_route(self.region_name, self.tenant_name, namespace, name, region_app_id,
+                                             request.user.nick_name)
         k8s_resources_repo.delete_by_name(app_id, "HTTPRoute", name)
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])

--- a/console/views/app_config/app_domain.py
+++ b/console/views/app_config/app_domain.py
@@ -901,8 +901,9 @@ class GatewayRoute(RegionTenantHeaderView):
         name = request.GET.get("name", "")
         namespace = self.tenant.namespace
         app_id = region_app_repo.get_app_id(self.region_name, region_app_id)  # type: ignore[arg-type]
+        operator = request.user.nick_name  # type: ignore[union-attr]
         data = gateway_api.delete_http_route(
-            self.region_name, self.tenant_name, namespace, name, region_app_id)  # type: ignore[arg-type]
+            self.region_name, self.tenant_name, namespace, name, region_app_id, operator)  # type: ignore[arg-type]
         k8s_resources_repo.delete_by_name(app_id, "HTTPRoute", name)  # type: ignore[arg-type]
         result = general_message(200, "success", "查询成功", bean=data)
         return Response(result, status=result["code"])

--- a/console/views/app_create/docker_compose.py
+++ b/console/views/app_create/docker_compose.py
@@ -11,6 +11,7 @@ from console.repositories.group import group_repo
 from console.services.app_check_service import app_check_service
 from console.services.compose_service import compose_service
 from console.services.group_service import group_service
+from console.services.team_services import team_services
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
 from django.views.decorators.cache import never_cache
@@ -106,6 +107,11 @@ class DockerComposeCreateView(RegionTenantHeaderView):
         group_id = request.data.get("group_id", None)
         hub_user = request.data.get("user_name", "")
         hub_pass = request.data.get("password", "")
+        registry_auth_id = request.data.get("registry_auth_id", "")
+        if registry_auth_id:
+            registry_auth = team_services.resolve_registry_auth(self.user, registry_auth_id)
+            hub_user = registry_auth.username
+            hub_pass = registry_auth.password
         event_id = request.data.get("event_id", "")
         compose_file_path = request.data.get("compose_file_path", "docker-compose.yml")
         group_note = request.data.get("group_note", "")

--- a/console/views/app_create/docker_compose.py
+++ b/console/views/app_create/docker_compose.py
@@ -12,6 +12,7 @@ from console.repositories.group import group_repo
 from console.services.app_check_service import app_check_service
 from console.services.compose_service import compose_service
 from console.services.group_service import group_service
+from console.services.team_services import team_services
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
 from console.utils.cache_decorators import never_cache
@@ -114,6 +115,11 @@ class DockerComposeCreateView(RegionTenantHeaderView):
         group_id = request.data.get("group_id", None)
         hub_user = request.data.get("user_name", "")
         hub_pass = request.data.get("password", "")
+        registry_auth_id = request.data.get("registry_auth_id", "")
+        if registry_auth_id:
+            registry_auth = team_services.resolve_registry_auth(self.user, registry_auth_id)
+            hub_user = registry_auth.username
+            hub_pass = registry_auth.password
         event_id = request.data.get("event_id", "")
         compose_file_path = request.data.get("compose_file_path", "docker-compose.yml")
         group_note = request.data.get("group_note", "")

--- a/console/views/app_create/docker_run.py
+++ b/console/views/app_create/docker_run.py
@@ -17,6 +17,7 @@ from www.utils.crypt import make_uuid
 from www.models.main import ServiceGroup
 from www.utils.return_message import general_message
 from console.services.group_service import group_service
+from console.services.team_services import team_services
 
 logger = logging.getLogger("default")
 
@@ -63,6 +64,11 @@ class DockerRunCreateView(RegionTenantHeaderView):
         # 私有docker仓库地址
         docker_password = request.data.get("password", None)
         docker_user_name = request.data.get("user_name", None)
+        registry_auth_id = request.data.get("registry_auth_id", None)
+        if registry_auth_id:
+            registry_auth = team_services.resolve_registry_auth(self.user, registry_auth_id)
+            docker_user_name = registry_auth.username
+            docker_password = registry_auth.password
         k8s_component_name = request.data.get("k8s_component_name", "")
         arch = request.data.get("arch", "amd64")
         if is_demo:

--- a/console/views/app_create/docker_run.py
+++ b/console/views/app_create/docker_run.py
@@ -15,6 +15,7 @@ from www.utils.crypt import make_uuid
 from www.models.main import ServiceGroup
 from www.utils.return_message import general_message
 from console.services.group_service import group_service
+from console.services.team_services import team_services
 
 logger = logging.getLogger("default")
 
@@ -61,6 +62,11 @@ class DockerRunCreateView(RegionTenantHeaderView):
         # 私有docker仓库地址
         docker_password = request.data.get("password", None)
         docker_user_name = request.data.get("user_name", None)
+        registry_auth_id = request.data.get("registry_auth_id", None)
+        if registry_auth_id:
+            registry_auth = team_services.resolve_registry_auth(self.user, registry_auth_id)
+            docker_user_name = registry_auth.username
+            docker_password = registry_auth.password
         k8s_component_name = request.data.get("k8s_component_name", "")
         arch = request.data.get("arch", "amd64")
         if is_demo:

--- a/console/views/app_overview.py
+++ b/console/views/app_overview.py
@@ -28,12 +28,12 @@ from console.services.market_app_service import market_app_service
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import app_plugin_service
 from console.services.plugin_service import rbd_plugin_service
-from console.services.region_services import region_services
 from console.services.team_services import team_services
 from console.services.kubeblocks_service import kubeblocks_service
 from console.services.virtual_machine import vms
 from console.utils.cnb_build import summarize_build_env
 from console.utils.oauth.oauth_types import get_oauth_instance
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from console.views.app_config.base import AppBaseView
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
@@ -938,13 +938,12 @@ class ManageFile(AppBaseView):
         try:
             res = group_service.get_file_and_dir(region_name, self.tenant_name, self.service.service_alias, host_path, pod_name,
                                                  container_name, self.tenant.namespace)
-            region = region_services.get_region_by_region_name(region_name)
         except Exception as e:
             logger.exception(e)
             raise e
         bean = {
             "host_path": host_path,
-            "ws_url": region.wsurl,
+            "ws_url": build_console_realtime_proxy_url(request, region_name, scheme_type="ws"),
             "namespace": self.tenant.namespace,
             "container_name": container_name or self.service.k8s_component_name
         }

--- a/console/views/app_overview.py
+++ b/console/views/app_overview.py
@@ -29,12 +29,12 @@ from console.services.market_app_service import market_app_service
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import app_plugin_service
 from console.services.plugin_service import rbd_plugin_service
-from console.services.region_services import region_services
 from console.services.team_services import team_services
 from console.services.kubeblocks_service import kubeblocks_service
 from console.services.virtual_machine import vms
 from console.utils.cnb_build import summarize_build_env
 from console.utils.oauth.oauth_types import get_oauth_instance
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from console.views.app_config.base import AppBaseView
 from console.views.base import RegionTenantHeaderView
 from django.db import transaction
@@ -959,13 +959,12 @@ class ManageFile(AppBaseView):
         try:
             res = group_service.get_file_and_dir(region_name, self.tenant_name, self.service.service_alias, host_path, pod_name,
                                                  container_name, self.tenant.namespace)
-            region = region_services.get_region_by_region_name(region_name)
         except Exception as e:
             logger.exception(e)
             raise e
         bean = {
             "host_path": host_path,
-            "ws_url": region.wsurl,  # type: ignore[union-attr]
+            "ws_url": build_console_realtime_proxy_url(request, region_name, scheme_type="ws"),
             "namespace": self.tenant.namespace,
             "container_name": container_name or self.service.k8s_component_name
         }

--- a/console/views/enterprise.py
+++ b/console/views/enterprise.py
@@ -26,6 +26,7 @@ from console.services.region_lang_version import region_lang_version, region_cnb
 from console.services.region_resource_processing import region_resource
 from console.services.region_services import region_services
 from console.services.team_services import team_services
+from console.utils.realtime_proxy import build_region_status_probe_url
 from console.views.base import EnterpriseAdminView, JWTAuthApiView, EnterpriseHeaderView, AlowAnyApiView
 from rest_framework import status
 from rest_framework.response import Response
@@ -734,7 +735,7 @@ class HelmInstallStatus(JWTAuthApiView):
         apiHost = request.GET.get("api_host")
         token = request.GET.get("token")
         try:
-            response = requests.get("http://{}:6060/helm_install/region_status/{}".format(apiHost, token), timeout=5)
+            response = requests.get(build_region_status_probe_url(apiHost, token), timeout=5)
             data = response.json()
             region_info = data.get("bean")
             enterprise_id = self.enterprise.enterprise_id

--- a/console/views/enterprise.py
+++ b/console/views/enterprise.py
@@ -27,6 +27,7 @@ from console.services.region_lang_version import region_lang_version, region_cnb
 from console.services.region_resource_processing import region_resource
 from console.services.region_services import region_services
 from console.services.team_services import team_services
+from console.utils.realtime_proxy import build_region_status_probe_url
 from console.views.base import EnterpriseAdminView, JWTAuthApiView, EnterpriseHeaderView, AlowAnyApiView
 from rest_framework import status
 from rest_framework.request import Request
@@ -759,7 +760,7 @@ class HelmInstallStatus(JWTAuthApiView):
         apiHost = request.GET.get("api_host")
         token = request.GET.get("token")
         try:
-            response = requests.get("http://{}:6060/helm_install/region_status/{}".format(apiHost, token), timeout=5)
+            response = requests.get(build_region_status_probe_url(apiHost, token), timeout=5)
             data = response.json()
             region_info = data.get("bean")
             enterprise_id = self.enterprise.enterprise_id

--- a/console/views/plugin/plugin_config.py
+++ b/console/views/plugin/plugin_config.py
@@ -11,9 +11,9 @@ from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import plugin_config_service
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from console.views.plugin.base import PluginBaseView
 from www.utils.return_message import general_message
-from console.services.region_services import region_services
 from console.constants import PluginMetaType
 
 logger = logging.getLogger("default")
@@ -45,8 +45,7 @@ class ConfigPluginManageView(PluginBaseView):
         config_groups = plugin_config_service.get_config_details(self.plugin_version.plugin_id,
                                                                  self.plugin_version.build_version)
         data = self.plugin_version.to_dict()
-        main_url = region_services.get_region_wsurl(self.response_region)
-        data["web_socket_url"] = "{0}/event_log".format(main_url)
+        data["web_socket_url"] = build_console_realtime_proxy_url(request, self.response_region, "event_log", scheme_type="ws")
 
         result = general_message(200, "success", "查询成功", bean=data, list=config_groups)
         return Response(result, status=result["code"])

--- a/console/views/plugin/plugin_config.py
+++ b/console/views/plugin/plugin_config.py
@@ -9,9 +9,9 @@ from rest_framework.response import Response
 
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import plugin_config_service
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from console.views.plugin.base import PluginBaseView
 from www.utils.return_message import general_message
-from console.services.region_services import region_services
 from console.constants import PluginMetaType
 
 logger = logging.getLogger("default")
@@ -43,8 +43,7 @@ class ConfigPluginManageView(PluginBaseView):
         config_groups = plugin_config_service.get_config_details(self.plugin_version.plugin_id,
                                                                  self.plugin_version.build_version)
         data = self.plugin_version.to_dict()
-        main_url = region_services.get_region_wsurl(self.response_region)
-        data["web_socket_url"] = "{0}/event_log".format(main_url)
+        data["web_socket_url"] = build_console_realtime_proxy_url(request, self.response_region, "event_log", scheme_type="ws")
 
         result = general_message(200, "success", "查询成功", bean=data, list=config_groups)
         return Response(result, status=result["code"])

--- a/console/views/realtime_proxy.py
+++ b/console/views/realtime_proxy.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from typing import Any
+
+from django.http import HttpRequest, HttpResponseBase
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
+
+from console.utils.realtime_proxy import proxy_http_request, proxy_websocket_request
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class RegionRealtimeProxyView(View):
+    http_method_names = ["get", "post", "put", "delete", "head", "options", "patch"]
+
+    @method_decorator(never_cache)
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        if self._is_websocket_request(request):
+            return proxy_websocket_request(request, kwargs.get("region_name"), kwargs.get("proxy_path", ""))
+        return proxy_http_request(request, kwargs.get("region_name"), kwargs.get("proxy_path", ""))
+
+    @staticmethod
+    def _is_websocket_request(request: HttpRequest) -> bool:
+        if getattr(request, "environ", {}).get("wsgi.websocket") or request.META.get("wsgi.websocket"):
+            return True
+        return request.META.get("HTTP_UPGRADE", "").lower() == "websocket"

--- a/console/views/realtime_proxy.py
+++ b/console/views/realtime_proxy.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
+
+from console.utils.realtime_proxy import proxy_http_request, proxy_websocket_request
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class RegionRealtimeProxyView(View):
+    http_method_names = ["get", "post", "put", "delete", "head", "options", "patch"]
+
+    @method_decorator(never_cache)
+    def dispatch(self, request, *args, **kwargs):
+        if self._is_websocket_request(request):
+            return proxy_websocket_request(request, kwargs.get("region_name"), kwargs.get("proxy_path", ""))
+        return proxy_http_request(request, kwargs.get("region_name"), kwargs.get("proxy_path", ""))
+
+    @staticmethod
+    def _is_websocket_request(request):
+        if getattr(request, "environ", {}).get("wsgi.websocket") or request.META.get("wsgi.websocket"):
+            return True
+        return request.META.get("HTTP_UPGRADE", "").lower() == "websocket"

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -1,95 +1,199 @@
 from console.utils.cache_decorators import never_cache
-from console.services.team_services import team_services
-from www.utils.return_message import general_message
 from rest_framework.response import Response
+
+from console.exception.main import ServiceHandleException
 from console.repositories.team_repo import team_registry_auth_repo
+from console.services.team_services import team_services
 from console.utils.reqparse import parse_item
-from typing import Any
+from typing import Any, Optional
 from rest_framework.request import Request
+from console.views.base import EnterpriseAdminView, JWTAuthApiView
+from www.utils.return_message import general_message
 import logging
 
 logger = logging.getLogger('default')
 
-from console.views.base import JWTAuthApiView
+
+def _parse_registry_credentials(request: Request) -> tuple:
+    return (
+        parse_item(request, "username", required=True),
+        parse_item(request, "password", required=True),
+    )
+
+
+def _parse_cloud_registry_credentials(request: Request, hub_type: str) -> dict:
+    if team_services.normalize_registry_hub_type(hub_type) not in team_services.CLOUD_REGISTRY_HUB_TYPES:
+        return {}
+    return {
+        "access_key": parse_item(request, "access_key", required=True),
+        "access_secret": parse_item(request, "access_secret", required=True),
+    }
 
 
 class HubRegistryView(JWTAuthApiView):
     @never_cache
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        # NOTE: Users.user_id is an int AutoField but service expects str (systemic int-as-str; backlog).
-        registry_auths = team_services.list_registry_auths('', '', self.user.user_id)  # type: ignore[arg-type]
-        auths = [auth.to_dict() for auth in registry_auths]
+        registry_auths = team_services.list_accessible_registry_auths(self.user)
+        auths = [team_services.serialize_registry_auth(auth) for auth in registry_auths]
         result = general_message(200, "success", "查询成功", list=auths)
         return Response(result, status=result["code"])
 
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         domain = parse_item(request, "domain", required=True)
-        username = parse_item(request, "username", required=True)
-        password = parse_item(request, "password", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
+        hub_type = team_services.normalize_registry_hub_type(hub_type)
+        username, password = _parse_registry_credentials(request)
+        cloud_credentials = _parse_cloud_registry_credentials(request, hub_type)
         secret_id = parse_item(request, "secret_id", required=True)
         # 检查是否已存在
         ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)  # type: ignore[arg-type]
         if ra.exists():
             result = general_message(400, "error", "资源已存在")
             return Response(result, status=result["code"])
-            
-        # 检测仓库是否可用
+
         try:
-            # 尝试获取命名空间列表来验证认证信息
-            team_services.get_registry_namespaces(
-                domain=domain,
-                username=username,
-                password=password,
-                hub_type=hub_type
-            )
-        except Exception as e:
-            logger.exception(e)
-            result = general_message(400, "connection test failed", 
-                                  "仓库连接测试失败: {}".format(str(e)))
-            return Response(result, status=result["code"])
-        
-        # 仓库可用，创建认证信息
-        try:
+            team_services.check_registry_connection(domain, username, password, hub_type)
             params = {
                 "tenant_id": '',
                 "region_name": '',
                 "secret_id": secret_id,
                 "domain": domain,
+                **cloud_credentials,
                 "username": username,
                 "password": password,
                 "hub_type": hub_type,
                 "user_id": self.user.user_id,
+                "scope": team_services.USER_REGISTRY_SCOPE,
+                "enterprise_id": "",
             }
             team_registry_auth_repo.create_team_registry_auth(**params)
             result = general_message(200, "success", "创建成功")
             return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
         except Exception as e:
             logger.exception(e)
-            result = general_message(500, "creation failed",  "创建失败: {}".format(str(e)))
+            result = general_message(500, "creation failed", "创建失败: {}".format(str(e)))
             return Response(result, status=result["code"])
 
     def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         secret_id = request.GET.get("secret_id")
-        data = {
-            "username": parse_item(request, "username", required=True),
-            "password": parse_item(request, "password", required=True),
-            "hub_type": parse_item(request, "hub_type", required=True),
-        }
-        # NOTE: GET secret_id is Optional[str] but repo expects str (systemic mismatch; backlog).
-        auth = team_registry_auth_repo.get_by_secret_id(secret_id)  # type: ignore[arg-type]
+        # NOTE: GET secret_id is Optional[str] and Users.user_id int, but repo expects str (systemic mismatch; backlog).
+        auth = team_registry_auth_repo.get_user_registry_auth(secret_id, self.user.user_id)  # type: ignore[arg-type]
         if not auth:
             result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
             return Response(result, status=result["code"])
-        team_registry_auth_repo.update_team_registry_auth('', '', secret_id, **data)  # type: ignore[arg-type]
+        data = {
+            "hub_type": parse_item(request, "hub_type", required=True),
+        }
+        data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data.update(_parse_cloud_registry_credentials(request, data["hub_type"]))
+        data["username"], data["password"] = _parse_registry_credentials(request)
+        try:
+            team_services.validate_registry_hub_type(data["hub_type"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
+        # NOTE: GET secret_id is Optional[str] and Users.user_id int, but repo expects str (systemic mismatch; backlog).
+        team_registry_auth_repo.update_user_registry_auth(secret_id, self.user.user_id, **data)  # type: ignore[arg-type]
 
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result["code"])
 
     def delete(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         secret_id = request.GET.get("secret_id")
-        team_registry_auth_repo.delete_team_registry_auth(
-            '', '', secret_id, self.user.user_id)  # type: ignore[arg-type]
+        # NOTE: GET secret_id is Optional[str] and Users.user_id int, but repo expects str (systemic mismatch; backlog).
+        team_registry_auth_repo.delete_user_registry_auth(secret_id, self.user.user_id)  # type: ignore[arg-type]
+        result = general_message(200, "success", "删除成功")
+        return Response(result, status=result["code"])
+
+
+class EnterpriseHubRegistryView(EnterpriseAdminView):
+    def _check_enterprise_admin(self, enterprise_id: str) -> Optional[Response]:
+        if enterprise_id != getattr(self.user, "enterprise_id", "") or not getattr(self, "is_enterprise_admin", False):
+            result = general_message(403, "permission denied", "无权限操作企业镜像仓库")
+            return Response(result, status=result["code"])
+        return None
+
+    @never_cache
+    def get(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        registry_auths = team_registry_auth_repo.list_enterprise_registry_auths(enterprise_id)
+        auths = [team_services.serialize_registry_auth(auth) for auth in registry_auths]
+        result = general_message(200, "success", "查询成功", list=auths)
+        return Response(result, status=result["code"])
+
+    def post(self, request: Request, enterprise_id: str, *args: Any, **kwargs: Any) -> Response:
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        domain = parse_item(request, "domain", required=True)
+        hub_type = parse_item(request, "hub_type", required=True)
+        hub_type = team_services.normalize_registry_hub_type(hub_type)
+        username, password = _parse_registry_credentials(request)
+        cloud_credentials = _parse_cloud_registry_credentials(request, hub_type)
+        secret_id = parse_item(request, "secret_id", required=True)
+        if team_registry_auth_repo.check_exist_enterprise_registry_auth(enterprise_id, secret_id).exists():
+            result = general_message(400, "error", "资源已存在")
+            return Response(result, status=result["code"])
+        try:
+            team_services.check_registry_connection(domain, username, password, hub_type)
+            params = {
+                "tenant_id": '',
+                "region_name": '',
+                "secret_id": secret_id,
+                "domain": domain,
+                **cloud_credentials,
+                "username": username,
+                "password": password,
+                "hub_type": hub_type,
+                "user_id": 0,
+                "scope": team_services.ENTERPRISE_REGISTRY_SCOPE,
+                "enterprise_id": enterprise_id,
+            }
+            team_registry_auth_repo.create_team_registry_auth(**params)
+            result = general_message(200, "success", "创建成功")
+            return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
+        except Exception as e:
+            logger.exception(e)
+            result = general_message(500, "creation failed", "创建失败: {}".format(str(e)))
+            return Response(result, status=result["code"])
+
+    def put(self, request: Request, enterprise_id: str, secret_id: str, *args: Any, **kwargs: Any) -> Response:
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        auth = team_registry_auth_repo.get_enterprise_registry_auth(secret_id, enterprise_id)
+        if not auth:
+            result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
+            return Response(result, status=result["code"])
+        data = {
+            "domain": request.data.get("domain") or auth.domain,
+            "hub_type": parse_item(request, "hub_type", required=True),
+        }
+        data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data.update(_parse_cloud_registry_credentials(request, data["hub_type"]))
+        data["username"], data["password"] = _parse_registry_credentials(request)
+        try:
+            team_services.check_registry_connection(data["domain"], data["username"], data["password"], data["hub_type"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
+        team_registry_auth_repo.update_enterprise_registry_auth(enterprise_id, secret_id, **data)
+        result = general_message(200, "success", "更新成功")
+        return Response(result, status=result["code"])
+
+    def delete(self, request: Request, enterprise_id: str, secret_id: str, *args: Any, **kwargs: Any) -> Response:
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        team_registry_auth_repo.delete_enterprise_registry_auth(enterprise_id, secret_id)
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
@@ -107,20 +211,14 @@ class HubRegistryImageView(JWTAuthApiView):
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         search_key = request.GET.get("search_key")
-        
+
         if not secret_id:
             result = general_message(400, "error", "缺少secret_id参数")
             return Response(result, status=result["code"])
-            
-        auths = team_registry_auth_repo.get_by_secret_id(secret_id)
-        if not auths:
-            result = general_message(404, "error", "镜像仓库不存在")
-            return Response(result, status=result["code"])
-            
+
         try:
-            auth = auths[0]
+            auth = team_services.resolve_registry_auth(self.user, secret_id)
             if not namespace:
-                # 获取命名空间列表
                 namespaces = team_services.get_registry_namespaces(
                     domain=auth.domain,
                     username=auth.username,
@@ -129,7 +227,6 @@ class HubRegistryImageView(JWTAuthApiView):
                 )
                 result = general_message(200, "success", "查询成功", list=namespaces)
             elif not name:
-                # 获取指定命名空间下的镜像列表(分页)
                 data = team_services.get_registry_images(
                     domain=auth.domain,
                     username=auth.username,
@@ -140,13 +237,12 @@ class HubRegistryImageView(JWTAuthApiView):
                     page_size=page_size,
                     search_key=search_key
                 )
-                result = general_message(200, "success", "查询成功", 
-                                      list=data["images"],
-                                      total=data["total"],
-                                      page=data["page"],
-                                      page_size=data["page_size"])
+                result = general_message(200, "success", "查询成功",
+                                         list=data["images"],
+                                         total=data["total"],
+                                         page=data["page"],
+                                         page_size=data["page_size"])
             elif not tag:
-                # 获取指定镜像的标签列表(分页)
                 data = team_services.get_registry_tags(
                     domain=auth.domain,
                     username=auth.username,
@@ -158,13 +254,12 @@ class HubRegistryImageView(JWTAuthApiView):
                     page_size=page_size,
                     search_key=search_key
                 )
-                result = general_message(200, "success", "查询成功", 
-                                      list=data["tags"],
-                                      total=data["total"],
-                                      page=data["page"],
-                                      page_size=data["page_size"])
+                result = general_message(200, "success", "查询成功",
+                                         list=data["tags"],
+                                         total=data["total"],
+                                         page=data["page"],
+                                         page_size=data["page_size"])
             else:
-                # 获取完整的镜像地址
                 full_image = team_services.get_full_image_name(
                     domain=auth.domain,
                     hub_type=auth.hub_type,
@@ -174,6 +269,9 @@ class HubRegistryImageView(JWTAuthApiView):
                 )
                 result = general_message(200, "success", "查询成功", bean={"image": full_image})
 
+            return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
             return Response(result, status=result["code"])
         except Exception as e:
             result = general_message(500, "error", "查询失败: {}".format(str(e)))

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -12,12 +12,7 @@ import logging
 logger = logging.getLogger('default')
 
 
-def _parse_registry_credentials(request, hub_type):
-    hub_type = team_services.normalize_registry_hub_type(hub_type)
-    if hub_type in team_services.CLOUD_REGISTRY_HUB_TYPES:
-        username = parse_item(request, "access_key", default=None) or parse_item(request, "username", required=True)
-        password = parse_item(request, "access_secret", default=None) or parse_item(request, "password", required=True)
-        return username, password
+def _parse_registry_credentials(request):
     return (
         parse_item(request, "username", required=True),
         parse_item(request, "password", required=True),
@@ -36,7 +31,7 @@ class HubRegistryView(JWTAuthApiView):
         domain = parse_item(request, "domain", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
         hub_type = team_services.normalize_registry_hub_type(hub_type)
-        username, password = _parse_registry_credentials(request, hub_type)
+        username, password = _parse_registry_credentials(request)
         secret_id = parse_item(request, "secret_id", required=True)
         ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)
         if ra.exists():
@@ -78,7 +73,7 @@ class HubRegistryView(JWTAuthApiView):
             "hub_type": parse_item(request, "hub_type", required=True),
         }
         data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
-        data["username"], data["password"] = _parse_registry_credentials(request, data["hub_type"])
+        data["username"], data["password"] = _parse_registry_credentials(request)
         try:
             team_services.validate_registry_hub_type(data["hub_type"])
         except ServiceHandleException as e:
@@ -120,7 +115,7 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
         domain = parse_item(request, "domain", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
         hub_type = team_services.normalize_registry_hub_type(hub_type)
-        username, password = _parse_registry_credentials(request, hub_type)
+        username, password = _parse_registry_credentials(request)
         secret_id = parse_item(request, "secret_id", required=True)
         if team_registry_auth_repo.check_exist_enterprise_registry_auth(enterprise_id, secret_id).exists():
             result = general_message(400, "error", "资源已存在")
@@ -163,7 +158,7 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
             "hub_type": parse_item(request, "hub_type", required=True),
         }
         data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
-        data["username"], data["password"] = _parse_registry_credentials(request, data["hub_type"])
+        data["username"], data["password"] = _parse_registry_credentials(request)
         try:
             team_services.check_registry_connection(data["domain"], data["username"], data["password"], data["hub_type"])
         except ServiceHandleException as e:

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -12,6 +12,18 @@ import logging
 logger = logging.getLogger('default')
 
 
+def _parse_registry_credentials(request, hub_type):
+    hub_type = team_services.normalize_registry_hub_type(hub_type)
+    if hub_type in team_services.CLOUD_REGISTRY_HUB_TYPES:
+        username = parse_item(request, "access_key", default=None) or parse_item(request, "username", required=True)
+        password = parse_item(request, "access_secret", default=None) or parse_item(request, "password", required=True)
+        return username, password
+    return (
+        parse_item(request, "username", required=True),
+        parse_item(request, "password", required=True),
+    )
+
+
 class HubRegistryView(JWTAuthApiView):
     @never_cache
     def get(self, request, *args, **kwargs):
@@ -22,9 +34,9 @@ class HubRegistryView(JWTAuthApiView):
 
     def post(self, request, *args, **kwargs):
         domain = parse_item(request, "domain", required=True)
-        username = parse_item(request, "username", required=True)
-        password = parse_item(request, "password", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
+        hub_type = team_services.normalize_registry_hub_type(hub_type)
+        username, password = _parse_registry_credentials(request, hub_type)
         secret_id = parse_item(request, "secret_id", required=True)
         ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)
         if ra.exists():
@@ -63,10 +75,10 @@ class HubRegistryView(JWTAuthApiView):
             result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
             return Response(result, status=result["code"])
         data = {
-            "username": parse_item(request, "username", required=True),
-            "password": parse_item(request, "password", required=True),
             "hub_type": parse_item(request, "hub_type", required=True),
         }
+        data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data["username"], data["password"] = _parse_registry_credentials(request, data["hub_type"])
         try:
             team_services.validate_registry_hub_type(data["hub_type"])
         except ServiceHandleException as e:
@@ -106,9 +118,9 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
         if denied:
             return denied
         domain = parse_item(request, "domain", required=True)
-        username = parse_item(request, "username", required=True)
-        password = parse_item(request, "password", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
+        hub_type = team_services.normalize_registry_hub_type(hub_type)
+        username, password = _parse_registry_credentials(request, hub_type)
         secret_id = parse_item(request, "secret_id", required=True)
         if team_registry_auth_repo.check_exist_enterprise_registry_auth(enterprise_id, secret_id).exists():
             result = general_message(400, "error", "资源已存在")
@@ -148,10 +160,10 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
             return Response(result, status=result["code"])
         data = {
             "domain": request.data.get("domain") or auth.domain,
-            "username": parse_item(request, "username", required=True),
-            "password": parse_item(request, "password", required=True),
             "hub_type": parse_item(request, "hub_type", required=True),
         }
+        data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data["username"], data["password"] = _parse_registry_credentials(request, data["hub_type"])
         try:
             team_services.check_registry_connection(data["domain"], data["username"], data["password"], data["hub_type"])
         except ServiceHandleException as e:

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -19,6 +19,15 @@ def _parse_registry_credentials(request):
     )
 
 
+def _parse_cloud_registry_credentials(request, hub_type):
+    if team_services.normalize_registry_hub_type(hub_type) not in team_services.CLOUD_REGISTRY_HUB_TYPES:
+        return {}
+    return {
+        "access_key": parse_item(request, "access_key", required=True),
+        "access_secret": parse_item(request, "access_secret", required=True),
+    }
+
+
 class HubRegistryView(JWTAuthApiView):
     @never_cache
     def get(self, request, *args, **kwargs):
@@ -32,6 +41,7 @@ class HubRegistryView(JWTAuthApiView):
         hub_type = parse_item(request, "hub_type", required=True)
         hub_type = team_services.normalize_registry_hub_type(hub_type)
         username, password = _parse_registry_credentials(request)
+        cloud_credentials = _parse_cloud_registry_credentials(request, hub_type)
         secret_id = parse_item(request, "secret_id", required=True)
         ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)
         if ra.exists():
@@ -45,6 +55,7 @@ class HubRegistryView(JWTAuthApiView):
                 "region_name": '',
                 "secret_id": secret_id,
                 "domain": domain,
+                **cloud_credentials,
                 "username": username,
                 "password": password,
                 "hub_type": hub_type,
@@ -73,6 +84,7 @@ class HubRegistryView(JWTAuthApiView):
             "hub_type": parse_item(request, "hub_type", required=True),
         }
         data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data.update(_parse_cloud_registry_credentials(request, data["hub_type"]))
         data["username"], data["password"] = _parse_registry_credentials(request)
         try:
             team_services.validate_registry_hub_type(data["hub_type"])
@@ -116,6 +128,7 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
         hub_type = parse_item(request, "hub_type", required=True)
         hub_type = team_services.normalize_registry_hub_type(hub_type)
         username, password = _parse_registry_credentials(request)
+        cloud_credentials = _parse_cloud_registry_credentials(request, hub_type)
         secret_id = parse_item(request, "secret_id", required=True)
         if team_registry_auth_repo.check_exist_enterprise_registry_auth(enterprise_id, secret_id).exists():
             result = general_message(400, "error", "资源已存在")
@@ -127,6 +140,7 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
                 "region_name": '',
                 "secret_id": secret_id,
                 "domain": domain,
+                **cloud_credentials,
                 "username": username,
                 "password": password,
                 "hub_type": hub_type,
@@ -158,6 +172,7 @@ class EnterpriseHubRegistryView(EnterpriseAdminView):
             "hub_type": parse_item(request, "hub_type", required=True),
         }
         data["hub_type"] = team_services.normalize_registry_hub_type(data["hub_type"])
+        data.update(_parse_cloud_registry_credentials(request, data["hub_type"]))
         data["username"], data["password"] = _parse_registry_credentials(request)
         try:
             team_services.check_registry_connection(data["domain"], data["username"], data["password"], data["hub_type"])

--- a/console/views/registry.py
+++ b/console/views/registry.py
@@ -1,21 +1,22 @@
 from django.views.decorators.cache import never_cache
-from console.services.team_services import team_services
-from www.utils.return_message import general_message
 from rest_framework.response import Response
+
+from console.exception.main import ServiceHandleException
 from console.repositories.team_repo import team_registry_auth_repo
+from console.services.team_services import team_services
 from console.utils.reqparse import parse_item
+from console.views.base import EnterpriseAdminView, JWTAuthApiView
+from www.utils.return_message import general_message
 import logging
 
 logger = logging.getLogger('default')
-
-from console.views.base import JWTAuthApiView
 
 
 class HubRegistryView(JWTAuthApiView):
     @never_cache
     def get(self, request, *args, **kwargs):
-        result = team_services.list_registry_auths('', '', self.user.user_id)
-        auths = [auth.to_dict() for auth in result]
+        result = team_services.list_accessible_registry_auths(self.user)
+        auths = [team_services.serialize_registry_auth(auth) for auth in result]
         result = general_message(200, "success", "查询成功", list=auths)
         return Response(result, status=result["code"])
 
@@ -25,29 +26,13 @@ class HubRegistryView(JWTAuthApiView):
         password = parse_item(request, "password", required=True)
         hub_type = parse_item(request, "hub_type", required=True)
         secret_id = parse_item(request, "secret_id", required=True)
-        # 检查是否已存在
         ra = team_registry_auth_repo.check_exist_registry_auth(secret_id, self.user.user_id)
         if ra.exists():
             result = general_message(400, "error", "资源已存在")
             return Response(result, status=result["code"])
-            
-        # 检测仓库是否可用
+
         try:
-            # 尝试获取命名空间列表来验证认证信息
-            team_services.get_registry_namespaces(
-                domain=domain,
-                username=username,
-                password=password,
-                hub_type=hub_type
-            )
-        except Exception as e:
-            logger.exception(e)
-            result = general_message(400, "connection test failed", 
-                                  "仓库连接测试失败: {}".format(str(e)))
-            return Response(result, status=result["code"])
-        
-        # 仓库可用，创建认证信息
-        try:
+            team_services.check_registry_connection(domain, username, password, hub_type)
             params = {
                 "tenant_id": '',
                 "region_name": '',
@@ -57,34 +42,130 @@ class HubRegistryView(JWTAuthApiView):
                 "password": password,
                 "hub_type": hub_type,
                 "user_id": self.user.user_id,
+                "scope": team_services.USER_REGISTRY_SCOPE,
+                "enterprise_id": "",
             }
             team_registry_auth_repo.create_team_registry_auth(**params)
             result = general_message(200, "success", "创建成功")
             return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
         except Exception as e:
             logger.exception(e)
-            result = general_message(500, "creation failed",  "创建失败: {}".format(str(e)))
+            result = general_message(500, "creation failed", "创建失败: {}".format(str(e)))
             return Response(result, status=result["code"])
 
     def put(self, request, *args, **kwargs):
         secret_id = request.GET.get("secret_id")
+        auth = team_registry_auth_repo.get_user_registry_auth(secret_id, self.user.user_id)
+        if not auth:
+            result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
+            return Response(result, status=result["code"])
         data = {
             "username": parse_item(request, "username", required=True),
             "password": parse_item(request, "password", required=True),
             "hub_type": parse_item(request, "hub_type", required=True),
         }
-        auth = team_registry_auth_repo.get_by_secret_id(secret_id)
-        if not auth:
-            result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
+        try:
+            team_services.validate_registry_hub_type(data["hub_type"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
             return Response(result, status=result["code"])
-        team_registry_auth_repo.update_team_registry_auth('', '', secret_id, **data)
+        team_registry_auth_repo.update_user_registry_auth(secret_id, self.user.user_id, **data)
 
         result = general_message(200, "success", "更新成功")
         return Response(result, status=result["code"])
 
     def delete(self, request, *args, **kwargs):
         secret_id = request.GET.get("secret_id")
-        team_registry_auth_repo.delete_team_registry_auth('', '', secret_id, self.user.user_id)
+        team_registry_auth_repo.delete_user_registry_auth(secret_id, self.user.user_id)
+        result = general_message(200, "success", "删除成功")
+        return Response(result, status=result["code"])
+
+
+class EnterpriseHubRegistryView(EnterpriseAdminView):
+    def _check_enterprise_admin(self, enterprise_id):
+        if enterprise_id != getattr(self.user, "enterprise_id", "") or not getattr(self, "is_enterprise_admin", False):
+            result = general_message(403, "permission denied", "无权限操作企业镜像仓库")
+            return Response(result, status=result["code"])
+        return None
+
+    @never_cache
+    def get(self, request, enterprise_id, *args, **kwargs):
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        result = team_registry_auth_repo.list_enterprise_registry_auths(enterprise_id)
+        auths = [team_services.serialize_registry_auth(auth) for auth in result]
+        result = general_message(200, "success", "查询成功", list=auths)
+        return Response(result, status=result["code"])
+
+    def post(self, request, enterprise_id, *args, **kwargs):
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        domain = parse_item(request, "domain", required=True)
+        username = parse_item(request, "username", required=True)
+        password = parse_item(request, "password", required=True)
+        hub_type = parse_item(request, "hub_type", required=True)
+        secret_id = parse_item(request, "secret_id", required=True)
+        if team_registry_auth_repo.check_exist_enterprise_registry_auth(enterprise_id, secret_id).exists():
+            result = general_message(400, "error", "资源已存在")
+            return Response(result, status=result["code"])
+        try:
+            team_services.check_registry_connection(domain, username, password, hub_type)
+            params = {
+                "tenant_id": '',
+                "region_name": '',
+                "secret_id": secret_id,
+                "domain": domain,
+                "username": username,
+                "password": password,
+                "hub_type": hub_type,
+                "user_id": 0,
+                "scope": team_services.ENTERPRISE_REGISTRY_SCOPE,
+                "enterprise_id": enterprise_id,
+            }
+            team_registry_auth_repo.create_team_registry_auth(**params)
+            result = general_message(200, "success", "创建成功")
+            return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
+        except Exception as e:
+            logger.exception(e)
+            result = general_message(500, "creation failed", "创建失败: {}".format(str(e)))
+            return Response(result, status=result["code"])
+
+    def put(self, request, enterprise_id, secret_id, *args, **kwargs):
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        auth = team_registry_auth_repo.get_enterprise_registry_auth(secret_id, enterprise_id)
+        if not auth:
+            result = general_message(400, "bad request", "您要更新的镜像仓库不存在")
+            return Response(result, status=result["code"])
+        data = {
+            "domain": request.data.get("domain") or auth.domain,
+            "username": parse_item(request, "username", required=True),
+            "password": parse_item(request, "password", required=True),
+            "hub_type": parse_item(request, "hub_type", required=True),
+        }
+        try:
+            team_services.check_registry_connection(data["domain"], data["username"], data["password"], data["hub_type"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
+            return Response(result, status=result["code"])
+        team_registry_auth_repo.update_enterprise_registry_auth(enterprise_id, secret_id, **data)
+        result = general_message(200, "success", "更新成功")
+        return Response(result, status=result["code"])
+
+    def delete(self, request, enterprise_id, secret_id, *args, **kwargs):
+        denied = self._check_enterprise_admin(enterprise_id)
+        if denied:
+            return denied
+        team_registry_auth_repo.delete_enterprise_registry_auth(enterprise_id, secret_id)
         result = general_message(200, "success", "删除成功")
         return Response(result, status=result["code"])
 
@@ -102,20 +183,14 @@ class HubRegistryImageView(JWTAuthApiView):
         page = int(request.GET.get("page", 1))
         page_size = int(request.GET.get("page_size", 10))
         search_key = request.GET.get("search_key")
-        
+
         if not secret_id:
             result = general_message(400, "error", "缺少secret_id参数")
             return Response(result, status=result["code"])
-            
-        auths = team_registry_auth_repo.get_by_secret_id(secret_id)
-        if not auths:
-            result = general_message(404, "error", "镜像仓库不存在")
-            return Response(result, status=result["code"])
-            
+
         try:
-            auth = auths[0]
+            auth = team_services.resolve_registry_auth(self.user, secret_id)
             if not namespace:
-                # 获取命名空间列表
                 namespaces = team_services.get_registry_namespaces(
                     domain=auth.domain,
                     username=auth.username,
@@ -124,7 +199,6 @@ class HubRegistryImageView(JWTAuthApiView):
                 )
                 result = general_message(200, "success", "查询成功", list=namespaces)
             elif not name:
-                # 获取指定命名空间下的镜像列表(分页)
                 data = team_services.get_registry_images(
                     domain=auth.domain,
                     username=auth.username,
@@ -135,13 +209,12 @@ class HubRegistryImageView(JWTAuthApiView):
                     page_size=page_size,
                     search_key=search_key
                 )
-                result = general_message(200, "success", "查询成功", 
-                                      list=data["images"],
-                                      total=data["total"],
-                                      page=data["page"],
-                                      page_size=data["page_size"])
+                result = general_message(200, "success", "查询成功",
+                                         list=data["images"],
+                                         total=data["total"],
+                                         page=data["page"],
+                                         page_size=data["page_size"])
             elif not tag:
-                # 获取指定镜像的标签列表(分页)
                 data = team_services.get_registry_tags(
                     domain=auth.domain,
                     username=auth.username,
@@ -153,13 +226,12 @@ class HubRegistryImageView(JWTAuthApiView):
                     page_size=page_size,
                     search_key=search_key
                 )
-                result = general_message(200, "success", "查询成功", 
-                                      list=data["tags"],
-                                      total=data["total"],
-                                      page=data["page"],
-                                      page_size=data["page_size"])
+                result = general_message(200, "success", "查询成功",
+                                         list=data["tags"],
+                                         total=data["total"],
+                                         page=data["page"],
+                                         page_size=data["page_size"])
             else:
-                # 获取完整的镜像地址
                 full_image = team_services.get_full_image_name(
                     domain=auth.domain,
                     hub_type=auth.hub_type,
@@ -169,6 +241,9 @@ class HubRegistryImageView(JWTAuthApiView):
                 )
                 result = general_message(200, "success", "查询成功", bean={"image": full_image})
 
+            return Response(result, status=result["code"])
+        except ServiceHandleException as e:
+            result = general_message(e.status_code, e.msg, e.msg_show)
             return Response(result, status=result["code"])
         except Exception as e:
             result = general_message(500, "error", "查询失败: {}".format(str(e)))

--- a/console/views/service_docker.py
+++ b/console/views/service_docker.py
@@ -5,13 +5,12 @@
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
-from console.services.region_services import region_services
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from www.utils.md5Util import md5fun
 from www.utils.url import get_redirect_url
 from console.repositories.team_repo import team_repo
 from console.repositories.app import service_repo
 import logging
-from django.conf import settings
 from django.views.generic import View
 from django import http
 
@@ -48,12 +47,10 @@ class DockerContainerView(View):
             context["ctn_id"] = docker_c_id
             context["md5"] = md5fun(self.service.tenant_id + "_" + docker_s_id + "_" + docker_c_id)
 
-            main_url = region_services.get_region_wsurl(self.service.service_region)
-            if main_url == "auto":
-                context["ws_uri"] = '{}://{}:6060/docker_console?nodename={}'.format(
-                    settings.DOCKER_WSS_URL["type"], settings.DOCKER_WSS_URL[self.service.service_region], t_docker_h_id)
-            else:
-                context["ws_uri"] = "{0}/docker_console?nodename={1}".format(main_url, t_docker_h_id)
+            context["ws_uri"] = "{0}?nodename={1}".format(
+                build_console_realtime_proxy_url(request, self.service.service_region, "docker_console", scheme_type="ws"),
+                t_docker_h_id,
+            )
 
             response = TemplateResponse(self.request, "www/console.html", context)
         response.delete_cookie('docker_c_id')

--- a/console/views/service_docker.py
+++ b/console/views/service_docker.py
@@ -7,13 +7,12 @@ from typing import Any
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from console.utils.cache_decorators import never_cache
-from console.services.region_services import region_services
+from console.utils.realtime_proxy import build_console_realtime_proxy_url
 from www.utils.md5Util import md5fun
 from www.utils.url import get_redirect_url
 from console.repositories.team_repo import team_repo
 from console.repositories.app import service_repo
 import logging
-from django.conf import settings
 from django.http import HttpRequest, HttpResponseBase
 from django.views.generic import View
 from django import http
@@ -59,15 +58,10 @@ class DockerContainerView(View):
             context["ctn_id"] = docker_c_id
             context["md5"] = md5fun(self.service.tenant_id + "_" + docker_s_id + "_" + docker_c_id)
 
-            main_url = region_services.get_region_wsurl(self.service.service_region)
-            if main_url == "auto":
-                # NOTE: DOCKER_WSS_URL is a dynamic Django setting not on Settings stub (backlog).
-                context["ws_uri"] = '{}://{}:6060/docker_console?nodename={}'.format(
-                    settings.DOCKER_WSS_URL["type"],  # type: ignore[misc]
-                    settings.DOCKER_WSS_URL[self.service.service_region],  # type: ignore[misc]
-                    t_docker_h_id)
-            else:
-                context["ws_uri"] = "{0}/docker_console?nodename={1}".format(main_url, t_docker_h_id)
+            context["ws_uri"] = "{0}?nodename={1}".format(
+                build_console_realtime_proxy_url(request, self.service.service_region, "docker_console", scheme_type="ws"),
+                t_docker_h_id,
+            )
 
             response = TemplateResponse(self.request, "www/console.html", context)
         response.delete_cookie('docker_c_id')

--- a/console/views/team.py
+++ b/console/views/team.py
@@ -1223,9 +1223,7 @@ class TeamRegistryAuthLView(RegionTenantHeaderView):
         domain = parse_item(request, "domain", required=True)
         username = parse_item(request, "username", required=True)
         password = parse_item(request, "password", required=True)
-        # NOTE: latent bug — create_registry_auth requires hub_type and user_id which are
-        # not passed (TypeError if reached); behavior preserved (backlog).
-        team_services.create_registry_auth(self.tenant, self.region_name, domain, username, password)  # type: ignore[call-arg]
+        team_services.create_registry_auth(self.tenant, self.region_name, domain, username, password)
         result = general_message(200, "success", "创建成功")
         return Response(result, status=result["code"])
 

--- a/console/views/webhook.py
+++ b/console/views/webhook.py
@@ -24,6 +24,66 @@ from www.utils.return_message import error_message, general_message
 logger = logging.getLogger("default")
 
 
+class UnsupportedImageWebhookEvent(Exception):
+    pass
+
+
+class ImageWebhookPayloadError(Exception):
+    pass
+
+
+class ImageWebhookEvent(object):
+    def __init__(self, repo_name, tag, pusher):
+        self.repo_name = repo_name
+        self.tag = tag
+        self.pusher = pusher
+
+
+def parse_image_webhook_payload(data):
+    if is_harbor_webhook_payload(data):
+        return parse_harbor_image_webhook_payload(data)
+    return parse_registry_image_webhook_payload(data)
+
+
+def is_harbor_webhook_payload(data):
+    return "event_data" in data and "resources" in data.get("event_data", {})
+
+
+def parse_harbor_image_webhook_payload(data):
+    if data.get("type") != "PUSH_ARTIFACT":
+        raise UnsupportedImageWebhookEvent("event type not support")
+
+    event_data = data.get("event_data") or {}
+    resources = event_data.get("resources") or []
+    repository = event_data.get("repository") or {}
+    if not resources:
+        raise ImageWebhookPayloadError("Harbor webhook缺少resources信息")
+
+    tag = resources[0].get("tag")
+    repo_name = repository.get("repo_full_name") or repository.get("name")
+    pusher = data.get("operator") or "harbor"
+    return ImageWebhookEvent(repo_name, tag, pusher)
+
+
+def parse_registry_image_webhook_payload(data):
+    repository = data.get("repository")
+    if not repository:
+        raise ImageWebhookPayloadError("缺少repository信息")
+
+    push_data = data.get("push_data")
+    pusher = push_data.get("pusher") if push_data else None
+    tag = push_data.get("tag") if push_data else None
+    repo_name = repository.get("repo_name")
+    if not repo_name:
+        repository_namespace = repository.get("namespace")
+        repository_name = repository.get("name")
+        if repository_namespace and repository_name:
+            repo_name = "fake.repo.aliyun.com/" + repository_namespace + "/" + repository_name
+        else:
+            repo_name = repository.get("repo_full_name")
+    return ImageWebhookEvent(repo_name, tag, pusher)
+
+
 class WebHooksDeploy(AlowAnyApiView):
     def post(self, request, service_id, *args, **kwargs):
         """
@@ -376,7 +436,7 @@ class GetWebHooksUrl(AppBaseView):
                 try:
                     # 首先尝试直接解码
                     secret_key = pickle.loads(base64.b64decode(deploy)).get("secret_key")
-                except Exception as e:
+                except Exception:
                     try:
                         # 如果失败，尝试用 ast.literal_eval 解析
                         secret_key = pickle.loads(base64.b64decode(ast.literal_eval(deploy))).get("secret_key")
@@ -530,7 +590,6 @@ class WebHooksStatus(AppBaseView):
                 result = general_message(200, "success", "关闭成功")
                 op = Operation.CLOSE
 
-
             comment = operation_log_service.generate_component_comment(
                 operation=op,
                 module_name=self.service.service_cname,
@@ -642,36 +701,19 @@ class ImageWebHooksDeploy(AlowAnyApiView):
                 result = general_message(400, "failed", "组件关闭了自动构建")
                 return Response(result, status=400)
             data = request.data
-            # ----------- Harbor webhook 兼容 -----------
-            if "event_data" in data and "resources" in data["event_data"]:
-                event_data = data["event_data"]
-                resources = event_data.get("resources", [])
-                repository = event_data.get("repository", {})
-                if resources:
-                    tag = resources[0].get("tag")
-                    repo_name = repository.get("repo_full_name") or repository.get("name")
-                    pusher = data.get("operator", "harbor")
-                else:
-                    result = general_message(400, "failed", "Harbor webhook缺少resources信息")
-                    return Response(result, status=400)
-            else:
-                # 兼容原有格式
-                repository = data.get("repository")
-                if not repository:
-                    logger.debug("缺少repository信息")
-                    result = general_message(400, "failed", "缺少repository信息")
-                    return Response(result, status=400)
-                push_data = data.get("push_data")
-                pusher = push_data.get("pusher") if push_data else None
-                tag = push_data.get("tag") if push_data else None
-                repo_name = repository.get("repo_name")
-                if not repo_name:
-                    repository_namespace = repository.get("namespace")
-                    repository_name = repository.get("name")
-                    if repository_namespace and repository_name:
-                        repo_name = "fake.repo.aliyun.com/" + repository_namespace + "/" + repository_name
-                    else:
-                        repo_name = repository.get("repo_full_name")
+            try:
+                image_webhook_event = parse_image_webhook_payload(data)
+            except UnsupportedImageWebhookEvent:
+                result = general_message(200, "event type not support", "不支持此事件类型")
+                return Response(result, status=200)
+            except ImageWebhookPayloadError as e:
+                logger.debug(str(e))
+                result = general_message(400, "failed", str(e))
+                return Response(result, status=400)
+
+            tag = image_webhook_event.tag
+            repo_name = image_webhook_event.repo_name
+            pusher = image_webhook_event.pusher
             if not repo_name:
                 result = general_message(400, "failed", "缺少repository名称信息")
                 return Response(result, status=400)

--- a/console/views/webhook.py
+++ b/console/views/webhook.py
@@ -26,6 +26,66 @@ from www.utils.return_message import error_message, general_message
 logger = logging.getLogger("default")
 
 
+class UnsupportedImageWebhookEvent(Exception):
+    pass
+
+
+class ImageWebhookPayloadError(Exception):
+    pass
+
+
+class ImageWebhookEvent(object):
+    def __init__(self, repo_name: Optional[str], tag: Optional[str], pusher: Optional[str]) -> None:
+        self.repo_name = repo_name
+        self.tag = tag
+        self.pusher = pusher
+
+
+def parse_image_webhook_payload(data: Any) -> "ImageWebhookEvent":
+    if is_harbor_webhook_payload(data):
+        return parse_harbor_image_webhook_payload(data)
+    return parse_registry_image_webhook_payload(data)
+
+
+def is_harbor_webhook_payload(data: Any) -> bool:
+    return "event_data" in data and "resources" in data.get("event_data", {})
+
+
+def parse_harbor_image_webhook_payload(data: Any) -> "ImageWebhookEvent":
+    if data.get("type") != "PUSH_ARTIFACT":
+        raise UnsupportedImageWebhookEvent("event type not support")
+
+    event_data = data.get("event_data") or {}
+    resources = event_data.get("resources") or []
+    repository = event_data.get("repository") or {}
+    if not resources:
+        raise ImageWebhookPayloadError("Harbor webhook缺少resources信息")
+
+    tag = resources[0].get("tag")
+    repo_name = repository.get("repo_full_name") or repository.get("name")
+    pusher = data.get("operator") or "harbor"
+    return ImageWebhookEvent(repo_name, tag, pusher)
+
+
+def parse_registry_image_webhook_payload(data: Any) -> "ImageWebhookEvent":
+    repository = data.get("repository")
+    if not repository:
+        raise ImageWebhookPayloadError("缺少repository信息")
+
+    push_data = data.get("push_data")
+    pusher = push_data.get("pusher") if push_data else None
+    tag = push_data.get("tag") if push_data else None
+    repo_name = repository.get("repo_name")
+    if not repo_name:
+        repository_namespace = repository.get("namespace")
+        repository_name = repository.get("name")
+        if repository_namespace and repository_name:
+            repo_name = "fake.repo.aliyun.com/" + repository_namespace + "/" + repository_name
+        else:
+            repo_name = repository.get("repo_full_name")
+    return ImageWebhookEvent(repo_name, tag, pusher)
+
+
 class WebHooksDeploy(AlowAnyApiView):
     def post(self, request: Request, service_id: str, *args: Any, **kwargs: Any) -> Response:
         """
@@ -379,7 +439,7 @@ class GetWebHooksUrl(AppBaseView):
                 try:
                     # 首先尝试直接解码
                     secret_key = pickle.loads(base64.b64decode(deploy)).get("secret_key")
-                except Exception as e:
+                except Exception:
                     try:
                         # 如果失败，尝试用 ast.literal_eval 解析
                         secret_key = pickle.loads(base64.b64decode(ast.literal_eval(deploy))).get("secret_key")
@@ -534,7 +594,6 @@ class WebHooksStatus(AppBaseView):
                 result = general_message(200, "success", "关闭成功")
                 op = Operation.CLOSE
 
-
             comment = operation_log_service.generate_component_comment(
                 operation=op,
                 module_name=self.service.service_cname,
@@ -647,36 +706,19 @@ class ImageWebHooksDeploy(AlowAnyApiView):
                 result = general_message(400, "failed", "组件关闭了自动构建")
                 return Response(result, status=400)
             data = request.data
-            # ----------- Harbor webhook 兼容 -----------
-            if "event_data" in data and "resources" in data["event_data"]:
-                event_data = data["event_data"]
-                resources = event_data.get("resources", [])
-                repository = event_data.get("repository", {})
-                if resources:
-                    tag = resources[0].get("tag")
-                    repo_name = repository.get("repo_full_name") or repository.get("name")
-                    pusher = data.get("operator", "harbor")
-                else:
-                    result = general_message(400, "failed", "Harbor webhook缺少resources信息")
-                    return Response(result, status=400)
-            else:
-                # 兼容原有格式
-                repository = data.get("repository")
-                if not repository:
-                    logger.debug("缺少repository信息")
-                    result = general_message(400, "failed", "缺少repository信息")
-                    return Response(result, status=400)
-                push_data = data.get("push_data")
-                pusher = push_data.get("pusher") if push_data else None
-                tag = push_data.get("tag") if push_data else None
-                repo_name = repository.get("repo_name")
-                if not repo_name:
-                    repository_namespace = repository.get("namespace")
-                    repository_name = repository.get("name")
-                    if repository_namespace and repository_name:
-                        repo_name = "fake.repo.aliyun.com/" + repository_namespace + "/" + repository_name
-                    else:
-                        repo_name = repository.get("repo_full_name")
+            try:
+                image_webhook_event = parse_image_webhook_payload(data)
+            except UnsupportedImageWebhookEvent:
+                result = general_message(200, "event type not support", "不支持此事件类型")
+                return Response(result, status=200)
+            except ImageWebhookPayloadError as e:
+                logger.debug(str(e))
+                result = general_message(400, "failed", str(e))
+                return Response(result, status=400)
+
+            tag = image_webhook_event.tag
+            repo_name = image_webhook_event.repo_name
+            pusher = image_webhook_event.pusher
             if not repo_name:
                 result = general_message(400, "failed", "缺少repository名称信息")
                 return Response(result, status=400)
@@ -690,10 +732,10 @@ class ImageWebHooksDeploy(AlowAnyApiView):
             # 标签匹配
             if service_webhook.trigger:  # type: ignore[union-attr]
                 # 如果有正则表达式根据正则触发
-                if not re.match(service_webhook.trigger, tag):  # type: ignore[union-attr]
+                if not re.match(service_webhook.trigger, tag):  # type: ignore[union-attr,arg-type]
                     result = general_message(400, "failed", "镜像tag与正则表达式不匹配")
                     return Response(result, status=400)
-                service_repo.change_service_image_tag(service_obj, tag)
+                service_repo.change_service_image_tag(service_obj, tag)  # type: ignore[arg-type]
             else:
                 # 如果没有根据标签触发
                 if tag != ref['tag']:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,5 +80,5 @@ else
     init_database
   fi
   # python upgrade.py
-  exec gunicorn goodrain_web.wsgi -b 0.0.0.0:${PORT:-7070} --max-requests=${MAX_REQUESTS:-5000} -k gevent --reload --workers=${WORKERS:-2} --timeout=75 --log-file - --access-logfile - --error-logfile -
+  exec gunicorn goodrain_web.wsgi -b 0.0.0.0:${PORT:-7070} --max-requests=${MAX_REQUESTS:-5000} -k geventwebsocket.gunicorn.workers.GeventWebSocketWorker --reload --workers=${WORKERS:-2} --timeout=75 --log-file - --access-logfile - --error-logfile -
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ djangorestframework-jwt==1.11.0
 oss2==2.4.0
 gevent==22.10.2
 gevent-websocket==0.10.1
-websocket-client==1.3.3
+websocket-client==0.59.0
 pyOpenSSL==20.0.1
 docker-image-py==0.1.4
 pytest==4.6.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ oss2==2.4.0
 gevent==22.10.2
 zope.interface==7.2
 zope.event==5.0
+gevent-websocket==0.10.1
+websocket-client==0.59.0
 pyOpenSSL==20.0.1
 docker-image-py==0.1.4
 pytest==6.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ pypinyin==0.23.0
 djangorestframework-jwt==1.11.0
 oss2==2.4.0
 gevent==22.10.2
+gevent-websocket==0.10.1
+websocket-client==1.3.3
 pyOpenSSL==20.0.1
 docker-image-py==0.1.4
 pytest==4.6.11

--- a/script/install-cluster.sh
+++ b/script/install-cluster.sh
@@ -83,7 +83,7 @@ fatal() {
 
 # check_required_ports checks if required ports are available
 check_required_ports() {
-    REQUIRED_PORTS="6443 9345 10250 2379 2380 2381 80 443 6060 7070 8443 7080 8889 9180"
+    REQUIRED_PORTS="6443 9345 10250 2379 2380 2381 80 443 7070 8443 7080 8889 9180"
     OCCUPIED_PORTS=""
 
     info "checking required ports availability"

--- a/script/install-rainbond-gpu.sh
+++ b/script/install-rainbond-gpu.sh
@@ -165,7 +165,7 @@ function check_ports_only_macos() {
   fi
 
   # Check ports
-  local ports=("7070" "80" "443" "6060")
+  local ports=("7070" "80" "443")
   local occupied_ports=()
   
   for port in "${ports[@]}"; do
@@ -345,7 +345,7 @@ function check_base_env() {
   fi
 
   # Check ports
-  local ports=("7070" "80" "443" "6060")
+  local ports=("7070" "80" "443")
   local occupied_ports=()
   
   for port in "${ports[@]}"; do
@@ -578,12 +578,12 @@ docker run --privileged -d \\
   -p 7070:7070 \\
   -p 80:80 \\
   -p 443:443 \\
-  -p 6060:6060 \\
   -p 30000-30010:30000-30010 \\
   --name=rainbond \\
   --restart=always \\
   ${VOLUME_OPTS}\\
   -e EIP=${EIP} \\
+  -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 \\
   -e UUID=${UUID} \\
   ${IMAGE}
 EOF
@@ -595,12 +595,12 @@ docker run --privileged -d \\
   -p 7070:7070 \\
   -p 80:80 \\
   -p 443:443 \\
-  -p 6060:6060 \\
   -p 30000-30010:30000-30010 \\
   --name=rainbond \\
   --restart=always \\
   ${VOLUME_OPTS}\\
   -e EIP=${EIP} \\
+  -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 \\
   -e UUID=${UUID} \\
   ${IMAGE}
 EOF
@@ -1508,8 +1508,8 @@ elif [ "$OS_TYPE" = "Darwin" ]; then
 fi
 
 # Generate cmd
-docker_run_cmd="docker run --privileged -d --gpus all -p 7070:7070 -p 80:80 -p 443:443 -p 6060:6060 -p 30000-30010:30000-30010 --name=rainbond --restart=always \
-${VOLUME_OPTS} -e ENABLE_GPU=${ENABLE_GPU} -e GPU_PROVIDER=${GPU_PROVIDER} -e GPU_RUNTIME_CLASS_NAME=${GPU_RUNTIME_CLASS_NAME} -e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES} -e NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES} -e EIP=$EIP -e UUID=${UUID} ${RBD_IMAGE}"
+docker_run_cmd="docker run --privileged -d --gpus all -p 7070:7070 -p 80:80 -p 443:443 -p 30000-30010:30000-30010 --name=rainbond --restart=always \
+${VOLUME_OPTS} -e ENABLE_GPU=${ENABLE_GPU} -e GPU_PROVIDER=${GPU_PROVIDER} -e GPU_RUNTIME_CLASS_NAME=${GPU_RUNTIME_CLASS_NAME} -e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES} -e NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES} -e EIP=$EIP -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 -e UUID=${UUID} ${RBD_IMAGE}"
 send_info "$docker_run_cmd"
 
 # Pull image with retry mechanism
@@ -1731,7 +1731,6 @@ if [ "$LANG" == "zh_CN.UTF-8" ]; then
 #     - 7070: 控制台访问端口
 #     - 80:   HTTP 服务端口
 #     - 443:  HTTPS 服务端口
-#     - 6060: WebSocket 端口
 #
 # 文档和支持:
 #     📖 文档: https://www.rainbond.com/docs
@@ -1755,7 +1754,6 @@ EOF
 #     - 7070: 控制台访问端口
 #     - 80:   HTTP 服务端口
 #     - 443:  HTTPS 服务端口
-#     - 6060: WebSocket 端口
 #
 # 监控命令:
 #     docker exec -it rainbond bash
@@ -1789,7 +1787,6 @@ else
 #     - 7070: Console access port
 #     - 80:   HTTP service port
 #     - 443:  HTTPS service port
-#     - 6060: WebSocket port
 #
 # Documentation and Support:
 #     📖 Docs: https://www.rainbond.com/docs
@@ -1814,7 +1811,6 @@ EOF
 #     - 7070: Console access port
 #     - 80:   HTTP service port
 #     - 443:  HTTPS service port
-#     - 6060: WebSocket port
 #
 # Monitoring Commands:
 #     docker exec -it rainbond bash

--- a/script/install-rainbond.ps1
+++ b/script/install-rainbond.ps1
@@ -54,7 +54,7 @@ if ($os_info.Name -match 'Microsoft Windows') {
 
 function check_port_occupied {
   param (
-    [int[]]$Ports = @(7070, 80, 443, 6060)
+    [int[]]$Ports = @(7070, 80, 443)
   )
   
   if ($Language -eq "zh-CN") {
@@ -316,7 +316,7 @@ function start_rainbond {
   }
 
   $RBD_IMAGE = "$IMAGE_MIRROR/rainbond:$($RAINBOND_VERSION)-k3s"
-  $docker_run_cmd = "docker run --privileged -d --name=rainbond --restart=always -p 7070:7070 -p 80:80 -p 443:443 -p 6060:6060 -p 30000-30010:30000-30010 -v rainbond-opt:/opt/rainbond -e EIP=$EIP -e uuid=$UUID $RBD_IMAGE"
+  $docker_run_cmd = "docker run --privileged -d --name=rainbond --restart=always -p 7070:7070 -p 80:80 -p 443:443 -p 30000-30010:30000-30010 -v rainbond-opt:/opt/rainbond -e EIP=$EIP -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 -e uuid=$UUID $RBD_IMAGE"
   Write-ColoredText $docker_run_cmd green
   send_msg $docker_run_cmd
 

--- a/script/install-rainbond.sh
+++ b/script/install-rainbond.sh
@@ -205,7 +205,7 @@ function check_ports_only_macos() {
   fi
 
   # Check ports
-  local ports=("7070" "80" "443" "6060")
+  local ports=("7070" "80" "443")
   local occupied_ports=()
   
   for port in "${ports[@]}"; do
@@ -385,7 +385,7 @@ function check_base_env() {
   fi
 
   # Check ports
-  local ports=("7070" "80" "443" "6060")
+  local ports=("7070" "80" "443")
   local occupied_ports=()
   
   for port in "${ports[@]}"; do
@@ -637,13 +637,13 @@ ${GPU_DOCKER_ARGS}\
   -p 7070:7070 \\
   -p 80:80 \\
   -p 443:443 \\
-  -p 6060:6060 \\
   -p 30000-30010:30000-30010 \\
   --name=rainbond \\
   --restart=always \\
   ${VOLUME_OPTS}\\
 ${GPU_ENV_BLOCK}\
   -e EIP=${EIP} \\
+  -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 \\
   -e UUID=${UUID} \\
   ${IMAGE}
 EOF
@@ -656,13 +656,13 @@ ${GPU_DOCKER_ARGS}\
   -p 7070:7070 \\
   -p 80:80 \\
   -p 443:443 \\
-  -p 6060:6060 \\
   -p 30000-30010:30000-30010 \\
   --name=rainbond \\
   --restart=always \\
   ${VOLUME_OPTS}\\
 ${GPU_ENV_BLOCK}\
   -e EIP=${EIP} \\
+  -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 \\
   -e UUID=${UUID} \\
   ${IMAGE}
 EOF
@@ -1374,8 +1374,8 @@ validate_gpu_support_linux() {
 }
 
 build_docker_run_cmd() {
-    docker_run_cmd="docker run --privileged -d ${GPU_DOCKER_ARGS} -p 7070:7070 -p 80:80 -p 443:443 -p 6060:6060 -p 30000-30010:30000-30010 --name=rainbond --restart=always \
-${VOLUME_OPTS} ${GPU_ENV_ARGS} -e EIP=$EIP -e UUID=${UUID} ${RBD_IMAGE}"
+    docker_run_cmd="docker run --privileged -d ${GPU_DOCKER_ARGS} -p 7070:7070 -p 80:80 -p 443:443 -p 30000-30010:30000-30010 --name=rainbond --restart=always \
+${VOLUME_OPTS} ${GPU_ENV_ARGS} -e EIP=$EIP -e REGION_WS_PROXY_TARGET=ws://127.0.0.1:6060 -e UUID=${UUID} ${RBD_IMAGE}"
 }
 
 # Main Docker management function
@@ -1865,7 +1865,6 @@ if [ "$LANG" == "zh_CN.UTF-8" ]; then
 #     - 7070: 控制台访问端口
 #     - 80:   HTTP 服务端口
 #     - 443:  HTTPS 服务端口
-#     - 6060: WebSocket 端口
 #
 # 文档和支持:
 #     📖 文档: https://www.rainbond.com/docs
@@ -1889,7 +1888,6 @@ EOF
 #     - 7070: 控制台访问端口
 #     - 80:   HTTP 服务端口
 #     - 443:  HTTPS 服务端口
-#     - 6060: WebSocket 端口
 #
 # 监控命令:
 #     docker exec -it rainbond bash
@@ -1923,7 +1921,6 @@ else
 #     - 7070: Console access port
 #     - 80:   HTTP service port
 #     - 443:  HTTPS service port
-#     - 6060: WebSocket port
 #
 # Documentation and Support:
 #     📖 Docs: https://www.rainbond.com/docs
@@ -1948,7 +1945,6 @@ EOF
 #     - 7070: Console access port
 #     - 80:   HTTP service port
 #     - 443:  HTTPS service port
-#     - 6060: WebSocket port
 #
 # Monitoring Commands:
 #     docker exec -it rainbond bash

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5768,6 +5768,25 @@
       "status": "active"
     },
     {
+      "id": "console.image.python36-websocket-client",
+      "title": "Console image Python 3.6 websocket-client compatibility",
+      "title_zh": "Console 镜像 Python 3.6 websocket-client 兼容性",
+      "interface_type": "other",
+      "interface": "requirements.txt",
+      "code_paths": [
+        "Dockerfile",
+        "requirements.txt"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/dependency_compat_test.py",
+          "selector": "ConsoleImageDependencyCompatibilityTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.image.runner-detect",
       "title": "Detect runner images by their repository prefix",
       "title_zh": "根据仓库前缀识别 runner 镜像",
@@ -7352,6 +7371,116 @@
         {
           "path": "console/tests/utils/randomutil_test.py",
           "selector": "RandomUtilTests.test_make_default_version"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.http-forward",
+      "title": "Realtime proxy HTTP forward",
+      "title_zh": "实时代理 HTTP 转发",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.proxy_http_request",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.internal-target-override",
+      "title": "Realtime proxy internal target override",
+      "title_zh": "实时代理内部目标覆盖",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_region_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.region-target-url",
+      "title": "Realtime proxy region target URL",
+      "title_zh": "实时代理 Region 目标 URL",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_region_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.secure-websocket-url",
+      "title": "Realtime proxy secure websocket URL",
+      "title_zh": "实时代理安全 WebSocket URL",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_console_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.upload-url",
+      "title": "Realtime proxy upload URL",
+      "title_zh": "实时代理上传 URL",
+      "interface_type": "service_method",
+      "interface": "console.services.app_import_and_export_service.get_upload_package_url",
+      "code_paths": [
+        "console/services/app_import_and_export_service.py",
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.websocket-url",
+      "title": "Realtime proxy websocket URL",
+      "title_zh": "实时代理 WebSocket URL",
+      "interface_type": "service_method",
+      "interface": "console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws",
+      "code_paths": [
+        "console/services/app_actions/app_log.py",
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5477,6 +5477,24 @@
       "status": "active"
     },
     {
+      "id": "console.groupcopy.package-build-guard",
+      "title": "Reject quick copy for package upload components",
+      "title_zh": "上传软件包组件禁止快速复制",
+      "interface_type": "service_method",
+      "interface": "console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata",
+      "code_paths": [
+        "console/services/groupcopy_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/groupcopy_service_test.py",
+          "selector": "GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.helm-release.delete",
       "title": "Delete helm release and cleanup saved source",
       "title_zh": "删除 Helm 发布并清理来源记录",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -9415,6 +9415,403 @@
       "status": "active"
     },
     {
+      "id": "console.app-creator.full-permissions",
+      "title": "App creator full permissions",
+      "title_zh": "App creator full permissions",
+      "interface_type": "service_method",
+      "interface": "console.services.perm_services.UserKindPermService.get_user_perms",
+      "code_paths": [
+        "console/services/perm_services.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/perm_services_test.py"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component-type.daemonset",
+      "title": "DaemonSet component type support",
+      "title_zh": "DaemonSet 组件类型支持",
+      "interface_type": "service_method",
+      "interface": "console.enum.component_enum.ComponentType",
+      "code_paths": [
+        "console/enum/component_enum.py",
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported"
+        },
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset"
+        },
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.port-toggle-events",
+      "title": "Record component port toggle events",
+      "title_zh": "记录组件端口开关事件",
+      "interface_type": "service_method",
+      "interface": "console.services.app_config.port_service.AppPortService.manage_port",
+      "code_paths": [
+        "console/services/app_config/port_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.groupcopy.package-build-guard",
+      "title": "Reject quick copy for package upload components",
+      "title_zh": "上传软件包组件禁止快速复制",
+      "interface_type": "service_method",
+      "interface": "console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata",
+      "code_paths": [
+        "console/services/groupcopy_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/groupcopy_service_test.py",
+          "selector": "GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.helm.daemonset-template",
+      "title": "Map Helm DaemonSet resource to component template",
+      "title_zh": "Helm DaemonSet 资源映射为组件模板",
+      "interface_type": "service_method",
+      "interface": "console.services.helm_app_yaml.HelmAppService.generate_template",
+      "code_paths": [
+        "console/services/helm_app_yaml.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.image-webhook.harbor-push-artifact",
+      "title": "Parse Harbor push artifact image webhooks",
+      "title_zh": "解析 Harbor 镜像推送 Webhook",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.webhook.parse_image_webhook_payload",
+      "code_paths": [
+        "console/views/webhook.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/webhook_test.py",
+          "selector": "ImageWebhookPayloadTestCase"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.image.python36-websocket-client",
+      "title": "Console image Python 3.6 websocket-client compatibility",
+      "title_zh": "Console 镜像 Python 3.6 websocket-client 兼容性",
+      "interface_type": "other",
+      "interface": "requirements.txt",
+      "code_paths": [
+        "Dockerfile",
+        "requirements.txt"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/dependency_compat_test.py",
+          "selector": "ConsoleImageDependencyCompatibilityTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.http-forward",
+      "title": "Realtime proxy HTTP forward",
+      "title_zh": "实时代理 HTTP 转发",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.proxy_http_request",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.internal-target-override",
+      "title": "Realtime proxy internal target override",
+      "title_zh": "实时代理内部目标覆盖",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_region_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.region-target-url",
+      "title": "Realtime proxy region target URL",
+      "title_zh": "实时代理 Region 目标 URL",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_region_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.secure-websocket-url",
+      "title": "Realtime proxy secure websocket URL",
+      "title_zh": "实时代理安全 WebSocket URL",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_console_realtime_proxy_url",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.upload-url",
+      "title": "Realtime proxy upload URL",
+      "title_zh": "实时代理上传 URL",
+      "interface_type": "service_method",
+      "interface": "console.services.app_import_and_export_service.get_upload_package_url",
+      "code_paths": [
+        "console/services/app_import_and_export_service.py",
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.websocket-url",
+      "title": "Realtime proxy websocket URL",
+      "title_zh": "实时代理 WebSocket URL",
+      "interface_type": "service_method",
+      "interface": "console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws",
+      "code_paths": [
+        "console/services/app_actions/app_log.py",
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.multipart-upload-forward",
+      "title": "Realtime proxy rebuilds multipart upload",
+      "title_zh": "实时代理重建分片上传请求",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.build_multipart_payload",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_http_proxy_rebuilds_multipart_upload_for_app_import"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.docker-console-subprotocol",
+      "title": "Docker console backend uses webtty subprotocol",
+      "title_zh": "Docker 控制台后端使用 webtty 子协议",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy._backend_websocket_subprotocols",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_docker_console_backend_uses_webtty_subprotocol"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.forward-client-subprotocols",
+      "title": "Forward client requested websocket subprotocols",
+      "title_zh": "转发客户端请求的 websocket 子协议",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy._backend_websocket_subprotocols",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_websocket_proxy_keeps_client_requested_subprotocols"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.websocket-idle-timeout",
+      "title": "Backend websocket uses short read timeout for idle checks",
+      "title_zh": "后端 websocket 使用短读超时检测空闲",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.open_backend_websocket",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_backend_websocket_uses_short_read_timeout_for_idle_checks"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.docker-console-user-idle-timeout",
+      "title": "Docker console activity tracker ignores webtty ping",
+      "title_zh": "Docker 控制台活动跟踪忽略 webtty 心跳",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.DockerConsoleActivityTracker",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_docker_console_activity_tracker_ignores_webtty_ping"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.docker-console-user-activity",
+      "title": "Docker console activity tracker refreshes on user input",
+      "title_zh": "Docker 控制台活动跟踪在用户输入时刷新",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.DockerConsoleActivityTracker",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_docker_console_activity_tracker_refreshes_on_user_input"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.realtime-proxy.non-terminal-no-user-idle-timeout",
+      "title": "Non terminal realtime proxy never user-idle expires",
+      "title_zh": "非终端实时代理不触发用户空闲超时",
+      "interface_type": "package_function",
+      "interface": "console.utils.realtime_proxy.DockerConsoleActivityTracker",
+      "code_paths": [
+        "console/utils/realtime_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/realtime_proxy_url_test.py",
+          "selector": "RealtimeProxyUrlTests.test_non_docker_console_activity_tracker_never_user_idle_expires"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.kubeblocks.app-resource-statistics",
+      "title": "Include app id in KubeBlocks cluster request for resource statistics",
+      "title_zh": "KubeBlocks 集群请求携带 app id 以支持资源统计",
+      "interface_type": "service_method",
+      "interface": "console.services.kubeblocks_service.KubeBlocksService._build_cluster_request",
+      "code_paths": [
+        "console/services/kubeblocks_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/kubeblocks_cluster_validation_test.py",
+          "selector": "KubeBlocksCreateFlowTests.test_build_cluster_request_includes_app_id_for_resource_statistics"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "openapi.app-service.team-not-found",
       "title": "Raise error when team associated with app is not found",
       "title_zh": "应用关联的团队不存在时返回404错误",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -811,25 +811,6 @@
       "status": "active"
     },
     {
-      "id": "console.app-import.init",
-      "title": "Initialize application import",
-      "title_zh": "初始化应用导入",
-      "interface_type": "workflow",
-      "interface": "console.views.center_pool.app_import.EnterpriseAppImportInitView.post",
-      "code_paths": [
-        "console/views/center_pool/app_import.py",
-        "console/services/app_import_and_export_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/app_import_and_export_service_test.py",
-          "selector": "AppImportPreparationWorkflowTestCase.test_enterprise_import_init_creates_record_when_none_exists"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
       "id": "console.app-import.identity-collision",
       "title": "Resolve imported application identity collisions",
       "title_zh": "处理导入应用模板身份冲突",
@@ -850,6 +831,25 @@
         {
           "path": "console/tests/app_import_and_export_service_test.py",
           "selector": "AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_name_version_when_content_differs"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app-import.init",
+      "title": "Initialize application import",
+      "title_zh": "初始化应用导入",
+      "interface_type": "workflow",
+      "interface": "console.views.center_pool.app_import.EnterpriseAppImportInitView.post",
+      "code_paths": [
+        "console/views/center_pool/app_import.py",
+        "console/services/app_import_and_export_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_import_and_export_service_test.py",
+          "selector": "AppImportPreparationWorkflowTestCase.test_enterprise_import_init_creates_record_when_none_exists"
         }
       ],
       "test_type": "regression",
@@ -1818,6 +1818,24 @@
       "status": "active"
     },
     {
+      "id": "console.app-version.create-app-from-snapshot-invalid-name",
+      "title": "create_app_from_snapshot_version rejects illegal target app name",
+      "title_zh": "从快照版本创建应用时拒绝非法目标应用名",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-version.create-snapshot",
       "title": "Create app version snapshot",
       "title_zh": "创建应用版本快照",
@@ -2405,6 +2423,24 @@
       "status": "active"
     },
     {
+      "id": "console.app-version.target-app-name-schema",
+      "title": "create_app_from_snapshot_version tool exposes target app name constraints",
+      "title_zh": "create_app_from_snapshot_version 工具暴露目标应用名约束",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-version.view-diff",
       "title": "View app version diff details",
       "title_zh": "查看应用版本差异详情",
@@ -2651,6 +2687,24 @@
       "status": "active"
     },
     {
+      "id": "console.app.delete-with-resources",
+      "title": "Delete application along with components and attached resources",
+      "title_zh": "删除应用及其组件与关联资源",
+      "interface_type": "service_method",
+      "interface": "console.services.group_service.GroupService.delete_app_with_resources",
+      "code_paths": [
+        "console/services/group_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/group_service_test.py",
+          "selector": "GroupServiceDeleteAppWithResourcesTestCase"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
       "id": "console.app.detail",
       "title": "View app detail",
       "title_zh": "查看应用详情",
@@ -2810,6 +2864,24 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_query_app_monitor_filters_to_outer_services_when_requested"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app.restart-component-operation",
+      "title": "operate_app restart maps to batch action",
+      "title_zh": "operate_app 重启映射到批量操作",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.app.restart-component-operation]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action"
         }
       ],
       "test_type": "regression",
@@ -3351,6 +3423,51 @@
       "status": "active"
     },
     {
+      "id": "console.component-type.daemonset",
+      "title": "DaemonSet component type support",
+      "title_zh": "DaemonSet 组件类型支持",
+      "interface_type": "service_method",
+      "interface": "console.enum.component_enum.ComponentType",
+      "code_paths": [
+        "console/enum/component_enum.py",
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported"
+        },
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset"
+        },
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.autoscaler-invalid-metrics",
+      "title": "manage_component_autoscaler rejects incomplete metric before service call",
+      "title_zh": "manage_component_autoscaler 在调用服务前拒绝不完整指标",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.autoscaler-summary",
       "title": "View component autoscaler summary",
       "title_zh": "查看组件伸缩概览",
@@ -3741,6 +3858,24 @@
       "status": "active"
     },
     {
+      "id": "console.component.default-resource-spec",
+      "title": "Component creation tools expose default resource guidance",
+      "title_zh": "组件创建工具暴露默认资源规格指引",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.list_tools[console.component.default-resource-spec]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.delete",
       "title": "Delete component",
       "title_zh": "删除组件",
@@ -3754,6 +3889,29 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_delete_component_calls_app_manage_delete"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.delete-dependency-conflict",
+      "title": "Delete component returns structured dependency conflict reason",
+      "title_zh": "删除组件返回结构化依赖冲突原因",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict]",
+      "code_paths": [
+        "console/services/mcp_query_service.py",
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason"
+        },
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable"
         }
       ],
       "test_type": "regression",
@@ -4026,6 +4184,32 @@
       "status": "active"
     },
     {
+      "id": "console.component.extend-method-upsert",
+      "title": "Upsert component extend method by service version",
+      "title_zh": "按组件版本覆盖保存伸缩规则配置",
+      "interface_type": "workflow",
+      "interface": "console.repositories.app_config.ServiceExtendRepository",
+      "code_paths": [
+        "console/repositories/app_config.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_config_test.py",
+          "selector": "ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record"
+        },
+        {
+          "path": "console/tests/app_config_test.py",
+          "selector": "ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record"
+        },
+        {
+          "path": "console/tests/app_config_test.py",
+          "selector": "ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.horizontal-scale",
       "title": "Horizontally scale component",
       "title_zh": "水平伸缩组件",
@@ -4225,6 +4409,60 @@
       "status": "active"
     },
     {
+      "id": "console.component.port-batch-add",
+      "title": "manage_component_ports batch add delegates to batch service",
+      "title_zh": "manage_component_ports 批量新增委托给批量服务",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-add]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.port-batch-enable-inner",
+      "title": "manage_component_ports batch enable inner loads context once",
+      "title_zh": "manage_component_ports 批量开启内网端口只加载一次上下文",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.port-batch-enable-outer",
+      "title": "manage_component_ports batch enable outer accepts integer items",
+      "title_zh": "manage_component_ports 批量开启外网端口接受整数项",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.port-list",
       "title": "List component ports",
       "title_zh": "查询组件端口列表",
@@ -4390,32 +4628,6 @@
         {
           "path": "console/tests/app_config_test.py",
           "selector": "TenantServiceVolumnRepositoryTests.test_list_custom_volumes_treats_local_path_as_builtin_volume_type"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.extend-method-upsert",
-      "title": "Upsert component extend method by service version",
-      "title_zh": "按组件版本覆盖保存伸缩规则配置",
-      "interface_type": "workflow",
-      "interface": "console.repositories.app_config.ServiceExtendRepository",
-      "code_paths": [
-        "console/repositories/app_config.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/app_config_test.py",
-          "selector": "ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record"
-        },
-        {
-          "path": "console/tests/app_config_test.py",
-          "selector": "ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record"
-        },
-        {
-          "path": "console/tests/app_config_test.py",
-          "selector": "ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key"
         }
       ],
       "test_type": "regression",
@@ -4627,6 +4839,24 @@
         {
           "path": "console/tests/utils/validation_test.py",
           "selector": "EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.enterprise-config.custom-fields-disabled-bool",
+      "title": "get_custom_fields includes disabled bool fields",
+      "title_zh": "get_custom_fields 包含被禁用的布尔字段",
+      "interface_type": "service_method",
+      "interface": "console.services.config_service.EnterpriseConfigService.get_custom_fields",
+      "code_paths": [
+        "console/services/config_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/config_service_test.py",
+          "selector": "EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields"
         }
       ],
       "test_type": "regression",
@@ -4878,6 +5108,24 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.gateway.create-app-invalid-display-name",
+      "title": "create_app returns structured details for illegal app name",
+      "title_zh": "create_app 对非法应用名返回结构化错误详情",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name"
         }
       ],
       "test_type": "regression",
@@ -5467,6 +5715,24 @@
       "status": "active"
     },
     {
+      "id": "console.helm.daemonset-template",
+      "title": "Map Helm DaemonSet resource to component template",
+      "title_zh": "Helm DaemonSet 资源映射为组件模板",
+      "interface_type": "service_method",
+      "interface": "console.services.helm_app_yaml.HelmAppService.generate_template",
+      "code_paths": [
+        "console/services/helm_app_yaml.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.image.runner-detect",
       "title": "Detect runner images by their repository prefix",
       "title_zh": "根据仓库前缀识别 runner 镜像",
@@ -5557,6 +5823,36 @@
       "status": "active"
     },
     {
+      "id": "console.kubeblocks.backup-repo.ready-guard",
+      "title": "Guard KubeBlocks backup repo readiness before use",
+      "title_zh": "使用 KubeBlocks 备份仓库前校验就绪状态",
+      "interface_type": "service_method",
+      "interface": "console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use",
+      "code_paths": [
+        "console/services/kubeblocks_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/kubeblocks_backup_repo_test.py",
+          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo"
+        },
+        {
+          "path": "console/tests/kubeblocks_backup_repo_test.py",
+          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo"
+        },
+        {
+          "path": "console/tests/kubeblocks_backup_repo_test.py",
+          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo"
+        },
+        {
+          "path": "console/tests/kubeblocks_cluster_validation_test.py",
+          "selector": "KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.kubeblocks.backup-repo.team-create",
       "title": "Create team KubeBlocks backup repo",
       "title_zh": "创建团队 KubeBlocks 备份仓库",
@@ -5577,6 +5873,24 @@
         {
           "path": "console/tests/kubeblocks_backup_repo_test.py",
           "selector": "KubeBlocksBackupRepoServiceTests.test_create_backup_repo_rejects_existing_region_repo_name_even_if_deleted"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.kubeblocks.backup-repo.team-delete",
+      "title": "Delete team KubeBlocks backup repo",
+      "title_zh": "删除团队 KubeBlocks 备份仓库",
+      "interface_type": "service_method",
+      "interface": "console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo",
+      "code_paths": [
+        "console/services/kubeblocks_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/kubeblocks_backup_repo_test.py",
+          "selector": "KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use"
         }
       ],
       "test_type": "regression",
@@ -5621,54 +5935,6 @@
         {
           "path": "console/tests/kubeblocks_backup_repo_test.py",
           "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_belongs_to_team_rejects_other_team_repo"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.kubeblocks.backup-repo.ready-guard",
-      "title": "Guard KubeBlocks backup repo readiness before use",
-      "title_zh": "使用 KubeBlocks 备份仓库前校验就绪状态",
-      "interface_type": "service_method",
-      "interface": "console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use",
-      "code_paths": [
-        "console/services/kubeblocks_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/kubeblocks_backup_repo_test.py",
-          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo"
-        },
-        {
-          "path": "console/tests/kubeblocks_backup_repo_test.py",
-          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo"
-        },
-        {
-          "path": "console/tests/kubeblocks_backup_repo_test.py",
-          "selector": "KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo"
-        },
-        {
-          "path": "console/tests/kubeblocks_cluster_validation_test.py",
-          "selector": "KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.kubeblocks.backup-repo.team-delete",
-      "title": "Delete team KubeBlocks backup repo",
-      "title_zh": "删除团队 KubeBlocks 备份仓库",
-      "interface_type": "service_method",
-      "interface": "console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo",
-      "code_paths": [
-        "console/services/kubeblocks_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/kubeblocks_backup_repo_test.py",
-          "selector": "KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use"
         }
       ],
       "test_type": "regression",
@@ -5730,6 +5996,24 @@
       "status": "active"
     },
     {
+      "id": "console.market-app.create-template-scope-name",
+      "title": "Scope market app template name duplicate checks",
+      "title_zh": "按发布范围和团队检查应用市场模板重名",
+      "interface_type": "service_method",
+      "interface": "console.services.market_app_service.MarketAppService.create_rainbond_app",
+      "code_paths": [
+        "console/services/market_app_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/market_app_service_test.py",
+          "selector": "MarketAppServiceCreateRainbondAppTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.market-app.install-default-storage-class",
       "title": "Use platform default storage class for marketplace installs",
       "title_zh": "应用市场安装使用平台默认存储类",
@@ -5748,6 +6032,43 @@
         {
           "path": "console/tests/market_app_storage_test.py",
           "selector": "MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.market-app.restore-preserves-volume-capacity-on-storage-fallback",
+      "title": "Market restore preserves volume capacity when storage type falls back",
+      "title_zh": "市场恢复在存储类型回退时保留卷容量",
+      "interface_type": "service_method",
+      "interface": "console.services.market_app.new_components.NewComponents._template_to_volumes",
+      "code_paths": [
+        "console/services/market_app/new_components.py",
+        "console/services/app_config/volume_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/market_app_storage_test.py",
+          "selector": "MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.market-app.restore-volume-capacity-helper",
+      "title": "resolve_market_restore_volume_settings preserves capacity when storage type changes",
+      "title_zh": "resolve_market_restore_volume_settings 在存储类型变化时保留容量",
+      "interface_type": "service_method",
+      "interface": "console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings",
+      "code_paths": [
+        "console/services/app_config/volume_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/market_app_storage_test.py",
+          "selector": "MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes"
         }
       ],
       "test_type": "regression",
@@ -5803,24 +6124,6 @@
         {
           "path": "console/tests/market_app_service_test.py",
           "selector": "MarketAppServiceVMGuardTests"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.market-app.create-template-scope-name",
-      "title": "Scope market app template name duplicate checks",
-      "title_zh": "按发布范围和团队检查应用市场模板重名",
-      "interface_type": "service_method",
-      "interface": "console.services.market_app_service.MarketAppService.create_rainbond_app",
-      "code_paths": [
-        "console/services/market_app_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/market_app_service_test.py",
-          "selector": "MarketAppServiceCreateRainbondAppTests"
         }
       ],
       "test_type": "regression",
@@ -6079,6 +6382,24 @@
       "status": "active"
     },
     {
+      "id": "console.mcp.http-expired-jwt",
+      "title": "MCP HTTP endpoint returns 401 for expired JWT",
+      "title_zh": "MCP HTTP 接口对过期 JWT 返回 401",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.mcp_query.MCPQueryHTTPView.post",
+      "code_paths": [
+        "console/views/mcp_query.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_view_test.py",
+          "selector": "MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.mcp.http-initialize",
       "title": "Initialize MCP session over HTTP",
       "title_zh": "通过 HTTP 初始化 MCP 会话",
@@ -6133,6 +6454,28 @@
       "status": "active"
     },
     {
+      "id": "console.mcp.input-validation-contract",
+      "title": "MCP tools return clear invalid_input/not_found reasons",
+      "title_zh": "MCP 工具对缺参/查无组件返回清晰原因",
+      "interface_type": "service_method",
+      "interface": "console.services.mcp_query_service.call_tool",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input"
+        },
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPComponentContextErrorTests.test_unknown_component_returns_not_found"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.mcp.legacy-sse-endpoint",
       "title": "Open legacy SSE MCP endpoint",
       "title_zh": "打开兼容模式的 SSE MCP 端点",
@@ -6148,6 +6491,58 @@
         }
       ],
       "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.operation-event-ids",
+      "title": "MCP operate_app/upgrade_app return operation event ids",
+      "title_zh": "MCP operate_app/upgrade_app 返回操作事件 ID",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids]",
+      "code_paths": [
+        "console/services/mcp_query_service.py",
+        "console/services/upgrade_services.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_operation_event_ids_test.py"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.operation-failure-classifier",
+      "title": "MCP operation failure classifier",
+      "title_zh": "MCP 操作失败分类器",
+      "interface_type": "package_function",
+      "interface": "console.services.mcp_failure_classifier.classify_failure",
+      "code_paths": [
+        "console/services/mcp_failure_classifier.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_failure_classifier_test.py"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.operation-failure-context",
+      "title": "MCP get_operation_failure_context tool",
+      "title_zh": "MCP 操作失败上下文工具",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_failure_context_test.py"
+        }
+      ],
+      "test_type": "unit",
       "status": "active"
     },
     {
@@ -6203,6 +6598,28 @@
         {
           "path": "console/tests/mcp_query_view_test.py",
           "selector": "MCPQuerySSEViewTests.test_http_tool_error_includes_structured_validation_details"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.tool-error-fallback",
+      "title": "Return parseable error for any MCP tool failure",
+      "title_zh": "任意 MCP 工具失败均返回可解析错误",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc",
+      "code_paths": [
+        "console/views/mcp_query.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error"
+        },
+        {
+          "path": "console/tests/mcp_query_error_contract_test.py",
+          "selector": "MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message"
         }
       ],
       "test_type": "regression",
@@ -6664,6 +7081,60 @@
       "status": "active"
     },
     {
+      "id": "console.package-upload.local-path-create-schema",
+      "title": "create_component_from_local_package tool schema exposes server-side local path guidance",
+      "title_zh": "create_component_from_local_package 工具 schema 暴露服务端本地路径指引",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.package-upload.local-path-missing-details",
+      "title": "_normalize_local_path raises structured details when path missing",
+      "title_zh": "_normalize_local_path 在路径缺失时抛出结构化详情",
+      "interface_type": "service_method",
+      "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
+      "code_paths": [
+        "console/services/package_upload_tool_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/package_upload_tool_service_test.py",
+          "selector": "PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.package-upload.local-path-required-details",
+      "title": "_normalize_local_path raises structured details when path empty",
+      "title_zh": "_normalize_local_path 在路径为空时抛出结构化详情",
+      "interface_type": "service_method",
+      "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
+      "code_paths": [
+        "console/services/package_upload_tool_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/package_upload_tool_service_test.py",
+          "selector": "PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.package-upload.local-path-schema",
       "title": "Package Upload Local Path Schema",
       "title_zh": "Package Upload Local Path Schema",
@@ -6918,6 +7389,24 @@
         {
           "path": "console/tests/regionapibaseclient_test.py",
           "selector": "RegionApiBaseHttpClientTestCase.test_check_status_keeps_original_message_for_non_helm_conflicts"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.region-api.vm-snapshot-feature-gate-msg",
+      "title": "_check_status translates VM snapshot feature gate error to actionable msg_show",
+      "title_zh": "_check_status 将虚拟机快照功能门禁错误翻译为可操作提示",
+      "interface_type": "service_method",
+      "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
+      "code_paths": [
+        "www/apiclient/regionapibaseclient.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/regionapibaseclient_test.py",
+          "selector": "RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show"
         }
       ],
       "test_type": "regression",
@@ -7962,6 +8451,24 @@
       "status": "active"
     },
     {
+      "id": "console.test-manifest.ignore-worktrees",
+      "title": "Ignore nested worktree tests during manifest validation",
+      "title_zh": "测试清单校验忽略嵌套 worktree 测试",
+      "interface_type": "package_function",
+      "interface": "scripts.validate_test_manifest.collect_marked_tests",
+      "code_paths": [
+        "scripts/validate_test_manifest.py"
+      ],
+      "tests": [
+        {
+          "path": "scripts/validate_test_manifest_test.py",
+          "selector": "ValidateTestManifestTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.timeutil.current-date-str",
       "title": "Return the current date formatted with the default date format",
       "title_zh": "返回默认格式的当前日期字符串",
@@ -8366,6 +8873,24 @@
       "status": "active"
     },
     {
+      "id": "console.vm-root-disk-selected-storage-type",
+      "title": "update_check_app uses selected storage type for new VM root disk",
+      "title_zh": "update_check_app 为新建虚拟机根盘使用所选存储类型",
+      "interface_type": "service_method",
+      "interface": "console.services.app.AppService.update_check_app",
+      "code_paths": [
+        "console/services/app.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/vm_live_migration_storage_test.py",
+          "selector": "VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.vm-run.platform-runtime-guard",
       "title": "Reject VM create when VM platform is unhealthy",
       "title_zh": "虚拟机平台异常时禁止创建虚拟机组件",
@@ -8396,6 +8921,24 @@
         {
           "path": "console/tests/vm_live_migration_storage_test.py",
           "selector": "VMLiveMigrationStorageTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.vm-template-import.delete-abnormal-vm",
+      "title": "delete allows abnormal VM to skip the running guard",
+      "title_zh": "delete 允许异常状态虚拟机跳过运行中校验",
+      "interface_type": "workflow",
+      "interface": "console.services.app_actions.app_manage.AppManageService.delete",
+      "code_paths": [
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_manage_test.py",
+          "selector": "AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard"
         }
       ],
       "test_type": "regression",
@@ -8488,302 +9031,17 @@
       "status": "active"
     },
     {
-      "id": "rainbond-console.vm-run.disk-asset-create",
-      "title": "Reuse ready runtime image when creating vm from existing disk asset",
-      "title_zh": "从现有磁盘资产创建虚拟机时复用已就绪运行时镜像",
-      "interface_type": "view_endpoint",
-      "interface": "console.views.app_create.vm_run.VMRunCreateView.post",
-      "code_paths": [
-        "console/views/app_create/vm_run.py",
-        "console/services/vm_boot_source.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/vm_asset_instantiation_test.py",
-          "selector": "VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.tool-error-fallback",
-      "title": "Return parseable error for any MCP tool failure",
-      "title_zh": "任意 MCP 工具失败均返回可解析错误",
-      "interface_type": "view_endpoint",
-      "interface": "console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc",
-      "code_paths": [
-        "console/views/mcp_query.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error"
-        },
-        {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.delete-dependency-conflict",
-      "title": "Delete component returns structured dependency conflict reason",
-      "title_zh": "删除组件返回结构化依赖冲突原因",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict]",
-      "code_paths": [
-        "console/services/mcp_query_service.py",
-        "console/services/app_actions/app_manage.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason"
-        },
-        {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.input-validation-contract",
-      "title": "MCP tools return clear invalid_input/not_found reasons",
-      "title_zh": "MCP 工具对缺参/查无组件返回清晰原因",
+      "id": "rainbond-console.vm-export.asset-ready-storage-status",
+      "title": "VM asset readiness requires ready status and image url",
+      "title_zh": "虚拟机资产就绪需要 ready 状态与镜像地址",
       "interface_type": "service_method",
-      "interface": "console.services.mcp_query_service.call_tool",
+      "interface": "console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready",
       "code_paths": [
-        "console/services/mcp_query_service.py"
+        "console/services/virtual_machine.py"
       ],
       "tests": [
         {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input"
-        },
-        {
-          "path": "console/tests/mcp_query_error_contract_test.py",
-          "selector": "MCPComponentContextErrorTests.test_unknown_component_returns_not_found"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.app-version.create-app-from-snapshot-invalid-name",
-      "title": "create_app_from_snapshot_version rejects illegal target app name",
-      "title_zh": "从快照版本创建应用时拒绝非法目标应用名",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.app-version.target-app-name-schema",
-      "title": "create_app_from_snapshot_version tool exposes target app name constraints",
-      "title_zh": "create_app_from_snapshot_version 工具暴露目标应用名约束",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.app.restart-component-operation",
-      "title": "operate_app restart maps to batch action",
-      "title_zh": "operate_app 重启映射到批量操作",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.app.restart-component-operation]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.autoscaler-invalid-metrics",
-      "title": "manage_component_autoscaler rejects incomplete metric before service call",
-      "title_zh": "manage_component_autoscaler 在调用服务前拒绝不完整指标",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.default-resource-spec",
-      "title": "Component creation tools expose default resource guidance",
-      "title_zh": "组件创建工具暴露默认资源规格指引",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.list_tools[console.component.default-resource-spec]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.port-batch-add",
-      "title": "manage_component_ports batch add delegates to batch service",
-      "title_zh": "manage_component_ports 批量新增委托给批量服务",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-add]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.port-batch-enable-inner",
-      "title": "manage_component_ports batch enable inner loads context once",
-      "title_zh": "manage_component_ports 批量开启内网端口只加载一次上下文",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.component.port-batch-enable-outer",
-      "title": "manage_component_ports batch enable outer accepts integer items",
-      "title_zh": "manage_component_ports 批量开启外网端口接受整数项",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.gateway.create-app-invalid-display-name",
-      "title": "create_app returns structured details for illegal app name",
-      "title_zh": "create_app 对非法应用名返回结构化错误详情",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.package-upload.local-path-create-schema",
-      "title": "create_component_from_local_package tool schema exposes server-side local path guidance",
-      "title_zh": "create_component_from_local_package 工具 schema 暴露服务端本地路径指引",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_service_test.py",
-          "selector": "MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.http-expired-jwt",
-      "title": "MCP HTTP endpoint returns 401 for expired JWT",
-      "title_zh": "MCP HTTP 接口对过期 JWT 返回 401",
-      "interface_type": "view_endpoint",
-      "interface": "console.views.mcp_query.MCPQueryHTTPView.post",
-      "code_paths": [
-        "console/views/mcp_query.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_view_test.py",
-          "selector": "MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.vm-root-disk-selected-storage-type",
-      "title": "update_check_app uses selected storage type for new VM root disk",
-      "title_zh": "update_check_app 为新建虚拟机根盘使用所选存储类型",
-      "interface_type": "service_method",
-      "interface": "console.services.app.AppService.update_check_app",
-      "code_paths": [
-        "console/services/app.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/vm_live_migration_storage_test.py",
-          "selector": "VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk"
+          "path": "console/tests/vm_create_flow_regression_test.py"
         }
       ],
       "test_type": "regression",
@@ -8812,17 +9070,19 @@
       "status": "active"
     },
     {
-      "id": "rainbond-console.vm-export.asset-ready-storage-status",
-      "title": "VM asset readiness requires ready status and image url",
-      "title_zh": "虚拟机资产就绪需要 ready 状态与镜像地址",
-      "interface_type": "service_method",
-      "interface": "console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready",
+      "id": "rainbond-console.vm-run.disk-asset-create",
+      "title": "Reuse ready runtime image when creating vm from existing disk asset",
+      "title_zh": "从现有磁盘资产创建虚拟机时复用已就绪运行时镜像",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_create.vm_run.VMRunCreateView.post",
       "code_paths": [
-        "console/services/virtual_machine.py"
+        "console/views/app_create/vm_run.py",
+        "console/services/vm_boot_source.py"
       ],
       "tests": [
         {
-          "path": "console/tests/vm_create_flow_regression_test.py"
+          "path": "console/tests/vm_asset_instantiation_test.py",
+          "selector": "VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image"
         }
       ],
       "test_type": "regression",
@@ -8857,221 +9117,6 @@
       "tests": [
         {
           "path": "console/tests/vm_asset_instantiation_test.py"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.market-app.restore-preserves-volume-capacity-on-storage-fallback",
-      "title": "Market restore preserves volume capacity when storage type falls back",
-      "title_zh": "市场恢复在存储类型回退时保留卷容量",
-      "interface_type": "service_method",
-      "interface": "console.services.market_app.new_components.NewComponents._template_to_volumes",
-      "code_paths": [
-        "console/services/market_app/new_components.py",
-        "console/services/app_config/volume_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/market_app_storage_test.py",
-          "selector": "MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.market-app.restore-volume-capacity-helper",
-      "title": "resolve_market_restore_volume_settings preserves capacity when storage type changes",
-      "title_zh": "resolve_market_restore_volume_settings 在存储类型变化时保留容量",
-      "interface_type": "service_method",
-      "interface": "console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings",
-      "code_paths": [
-        "console/services/app_config/volume_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/market_app_storage_test.py",
-          "selector": "MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.package-upload.local-path-missing-details",
-      "title": "_normalize_local_path raises structured details when path missing",
-      "title_zh": "_normalize_local_path 在路径缺失时抛出结构化详情",
-      "interface_type": "service_method",
-      "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
-      "code_paths": [
-        "console/services/package_upload_tool_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/package_upload_tool_service_test.py",
-          "selector": "PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.package-upload.local-path-required-details",
-      "title": "_normalize_local_path raises structured details when path empty",
-      "title_zh": "_normalize_local_path 在路径为空时抛出结构化详情",
-      "interface_type": "service_method",
-      "interface": "console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path",
-      "code_paths": [
-        "console/services/package_upload_tool_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/package_upload_tool_service_test.py",
-          "selector": "PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.enterprise-config.custom-fields-disabled-bool",
-      "title": "get_custom_fields includes disabled bool fields",
-      "title_zh": "get_custom_fields 包含被禁用的布尔字段",
-      "interface_type": "service_method",
-      "interface": "console.services.config_service.EnterpriseConfigService.get_custom_fields",
-      "code_paths": [
-        "console/services/config_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/config_service_test.py",
-          "selector": "EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.region-api.vm-snapshot-feature-gate-msg",
-      "title": "_check_status translates VM snapshot feature gate error to actionable msg_show",
-      "title_zh": "_check_status 将虚拟机快照功能门禁错误翻译为可操作提示",
-      "interface_type": "service_method",
-      "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
-      "code_paths": [
-        "www/apiclient/regionapibaseclient.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/regionapibaseclient_test.py",
-          "selector": "RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.vm-template-import.delete-abnormal-vm",
-      "title": "delete allows abnormal VM to skip the running guard",
-      "title_zh": "delete 允许异常状态虚拟机跳过运行中校验",
-      "interface_type": "workflow",
-      "interface": "console.services.app_actions.app_manage.AppManageService.delete",
-      "code_paths": [
-        "console/services/app_actions/app_manage.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/app_manage_test.py",
-          "selector": "AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.operation-failure-classifier",
-      "title": "MCP operation failure classifier",
-      "title_zh": "MCP 操作失败分类器",
-      "interface_type": "package_function",
-      "interface": "console.services.mcp_failure_classifier.classify_failure",
-      "code_paths": [
-        "console/services/mcp_failure_classifier.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_failure_classifier_test.py"
-        }
-      ],
-      "test_type": "unit",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.operation-failure-context",
-      "title": "MCP get_operation_failure_context tool",
-      "title_zh": "MCP 操作失败上下文工具",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context]",
-      "code_paths": [
-        "console/services/mcp_query_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_failure_context_test.py"
-        }
-      ],
-      "test_type": "unit",
-      "status": "active"
-    },
-    {
-      "id": "console.mcp.operation-event-ids",
-      "title": "MCP operate_app/upgrade_app return operation event ids",
-      "title_zh": "MCP operate_app/upgrade_app 返回操作事件 ID",
-      "interface_type": "workflow",
-      "interface": "console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids]",
-      "code_paths": [
-        "console/services/mcp_query_service.py",
-        "console/services/upgrade_services.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/mcp_query_operation_event_ids_test.py"
-        }
-      ],
-      "test_type": "unit",
-      "status": "active"
-    },
-    {
-      "id": "console.app.delete-with-resources",
-      "title": "Delete application along with components and attached resources",
-      "title_zh": "删除应用及其组件与关联资源",
-      "interface_type": "service_method",
-      "interface": "console.services.group_service.GroupService.delete_app_with_resources",
-      "code_paths": [
-        "console/services/group_service.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/group_service_test.py",
-          "selector": "GroupServiceDeleteAppWithResourcesTestCase"
-        }
-      ],
-      "test_type": "unit",
-      "status": "active"
-    },
-    {
-      "id": "console.test-manifest.ignore-worktrees",
-      "title": "Ignore nested worktree tests during manifest validation",
-      "title_zh": "测试清单校验忽略嵌套 worktree 测试",
-      "interface_type": "package_function",
-      "interface": "scripts.validate_test_manifest.collect_marked_tests",
-      "code_paths": [
-        "scripts/validate_test_manifest.py"
-      ],
-      "tests": [
-        {
-          "path": "scripts/validate_test_manifest_test.py",
-          "selector": "ValidateTestManifestTests"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5768,6 +5768,24 @@
       "status": "active"
     },
     {
+      "id": "console.image-webhook.harbor-push-artifact",
+      "title": "Parse Harbor push artifact image webhooks",
+      "title_zh": "解析 Harbor 镜像推送 Webhook",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.webhook.parse_image_webhook_payload",
+      "code_paths": [
+        "console/views/webhook.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/webhook_test.py",
+          "selector": "ImageWebhookPayloadTestCase"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.image.python36-websocket-client",
       "title": "Console image Python 3.6 websocket-client compatibility",
       "title_zh": "Console 镜像 Python 3.6 websocket-client 兼容性",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -736,6 +736,23 @@
       "status": "active"
     },
     {
+      "id": "console.app-creator.full-permissions",
+      "title": "App creator full permissions",
+      "title_zh": "App creator full permissions",
+      "interface_type": "service_method",
+      "interface": "console.services.perm_services.UserKindPermService.get_user_perms",
+      "code_paths": [
+        "console/services/perm_services.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/perm_services_test.py"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-export.query-status",
       "title": "Query application export status",
       "title_zh": "查询应用导出状态",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -4572,6 +4572,32 @@
       "status": "active"
     },
     {
+      "id": "console.component.port-toggle-events",
+      "title": "Record component port toggle events",
+      "title_zh": "记录组件端口开关事件",
+      "interface_type": "service_method",
+      "interface": "console.services.app_config.port_service.AppPortService.manage_port",
+      "code_paths": [
+        "console/services/app_config/port_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.probe-summary",
       "title": "View component probe summary",
       "title_zh": "查看组件探针概览",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -310,6 +310,7 @@
 | console.helm.build | 构建 Helm 应用模板 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_helm_app_generates_template |
 | console.helm.check | 检查 Helm 应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result |
 | console.helm.daemonset-template | Helm DaemonSet 资源映射为组件模板 | active | regression | console.services.helm_app_yaml.HelmAppService.generate_template | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type |
+| console.image.python36-websocket-client | Console 镜像 Python 3.6 websocket-client 兼容性 | active | regression | requirements.txt | console/tests/dependency_compat_test.py::ConsoleImageDependencyCompatibilityTests |
 | console.image.runner-detect | 根据仓库前缀识别 runner 镜像 | active | regression | console.utils.runner_util.is_runner | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_runner |
 | console.image.slug-detect | 为非 docker 类语言识别基于 runner 的 slug 镜像 | active | regression | console.utils.slug_util.is_slug | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_slug |
 | console.init-cluster.prefer-latest-pending | 初始化时优先选择最新待处理集群 | active | regression | console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated | console/tests/init_cluster_test.py::ClusterRepositoryTests.test_get_rke_cluster_exclude_integrated_prefers_latest_pending_cluster |
@@ -395,6 +396,12 @@
 | console.pod.detail-kubeblocks | Pod Detail Kubeblocks | active | regression | console.services.mcp_query_service.call_tool[console.pod.detail-kubeblocks] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_pod_detail_uses_kubeblocks_endpoint_for_kubeblocks_component |
 | console.port-inner.env-sync-idempotent | Treat duplicate region env create as idempotent during inner port enable | active | regression | console.services.app_config.env_service.AppEnvVarService.add_service_env_var | console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_updates_region_when_env_already_exists<br>console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_retries_add_when_region_update_reports_record_not_found<br>console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_treats_second_add_conflict_as_success |
 | console.random.default-version | 生成默认随机版本标识 | active | regression | console.utils.randomutil.make_default_version | console/tests/utils/randomutil_test.py::RandomUtilTests.test_make_default_version |
+| console.realtime-proxy.http-forward | 实时代理 HTTP 转发 | active | regression | console.utils.realtime_proxy.proxy_http_request | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service |
+| console.realtime-proxy.internal-target-override | 实时代理内部目标覆盖 | active | regression | console.utils.realtime_proxy.build_region_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region |
+| console.realtime-proxy.region-target-url | 实时代理 Region 目标 URL | active | regression | console.utils.realtime_proxy.build_region_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http |
+| console.realtime-proxy.secure-websocket-url | 实时代理安全 WebSocket URL | active | regression | console.utils.realtime_proxy.build_console_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https |
+| console.realtime-proxy.upload-url | 实时代理上传 URL | active | regression | console.services.app_import_and_export_service.get_upload_package_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path |
+| console.realtime-proxy.websocket-url | 实时代理 WebSocket URL | active | regression | console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060 |
 | console.region-api.batch-create-error-bean | Region Api Batch Create Error Bean | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_preserves_batch_create_result_bean_for_coded_errors |
 | console.region-api.domain-conflict-msg | 将上游域名冲突保留为可操作的 409 错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_domain_conflict_as_conflict_error |
 | console.region-api.helm-resource-conflict-msg | 将 Helm 资源归属冲突转换为可操作错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_helm_ownership_conflict_to_actionable_msg_show |
@@ -3555,6 +3562,16 @@
 - 代码路径: `console/services/helm_app_yaml.py`
 - 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type`
 
+### Console 镜像 Python 3.6 websocket-client 兼容性
+
+- Capability ID: `console.image.python36-websocket-client`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `other`
+- 业务入口: `requirements.txt`
+- 代码路径: `Dockerfile`, `requirements.txt`
+- 测试路径: `console/tests/dependency_compat_test.py::ConsoleImageDependencyCompatibilityTests`
+
 ### 根据仓库前缀识别 runner 镜像
 
 - Capability ID: `console.image.runner-detect`
@@ -4404,6 +4421,66 @@
 - 业务入口: `console.utils.randomutil.make_default_version`
 - 代码路径: `console/utils/randomutil.py`
 - 测试路径: `console/tests/utils/randomutil_test.py::RandomUtilTests.test_make_default_version`
+
+### 实时代理 HTTP 转发
+
+- Capability ID: `console.realtime-proxy.http-forward`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.proxy_http_request`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service`
+
+### 实时代理内部目标覆盖
+
+- Capability ID: `console.realtime-proxy.internal-target-override`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_region_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region`
+
+### 实时代理 Region 目标 URL
+
+- Capability ID: `console.realtime-proxy.region-target-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_region_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http`
+
+### 实时代理安全 WebSocket URL
+
+- Capability ID: `console.realtime-proxy.secure-websocket-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_console_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https`
+
+### 实时代理上传 URL
+
+- Capability ID: `console.realtime-proxy.upload-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.get_upload_package_url`
+- 代码路径: `console/services/app_import_and_export_service.py`, `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path`
+
+### 实时代理 WebSocket URL
+
+- Capability ID: `console.realtime-proxy.websocket-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws`
+- 代码路径: `console/services/app_actions/app_log.py`, `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060`
 
 ### Region Api Batch Create Error Bean
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -44,6 +44,7 @@
 | console.app-config-group.get | 查看应用配置组详情 | active | regression | console.services.app_config_group.AppConfigGroupService.get_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_get_config_group_returns_built_response |
 | console.app-config-group.list | 查询应用配置组列表 | active | regression | console.services.app_config_group.AppConfigGroupService.list_config_groups | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_list_config_groups_returns_items_and_total |
 | console.app-config-group.update | 更新应用配置组 | active | regression | console.services.app_config_group.AppConfigGroupService.update_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_update_config_group_updates_remote_and_local_records |
+| console.app-creator.full-permissions | App creator full permissions | active | regression | console.services.perm_services.UserKindPermService.get_user_perms | console/tests/perm_services_test.py |
 | console.app-export.query-status | 查询应用导出状态 | active | regression | console.services.app_import_and_export_service.AppExportService.get_export_status | console/tests/app_import_and_export_service_test.py::AppExportServiceMetadataTestCase.test_get_export_status_updates_exporting_record_and_wraps_download_url |
 | console.app-import.abandon | 放弃应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.delete | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_delete_abandons_import |
 | console.app-import.create-dir | 创建导入目录 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.post | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_post_creates_import_dir |
@@ -893,6 +894,16 @@
 - 业务入口: `console.services.app_config_group.AppConfigGroupService.update_config_group`
 - 代码路径: `console/services/app_config_group.py`, `console/views/app_config_group.py`
 - 测试路径: `console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_update_config_group_updates_remote_and_local_records`
+
+### App creator full permissions
+
+- Capability ID: `console.app-creator.full-permissions`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.perm_services.UserKindPermService.get_user_perms`
+- 代码路径: `console/services/perm_services.py`
+- 测试路径: `console/tests/perm_services_test.py`
 
 ### 查询应用导出状态
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -48,9 +48,11 @@
 | console.app-import.abandon | 放弃应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.delete | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_delete_abandons_import |
 | console.app-import.create-dir | 创建导入目录 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.post | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_post_creates_import_dir |
 | console.app-import.delete-dir | 删除导入目录 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.delete | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_delete_removes_import_dir |
+| console.app-import.identity-collision | 处理导入应用模板身份冲突 | active | regression | console.services.app_import_and_export_service.AppImportService.__save_enterprise_import_info | console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_when_name_differs<br>console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_keeps_same_key_and_name_as_multiple_versions<br>console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_name_version_when_content_differs |
 | console.app-import.init | 初始化应用导入 | active | regression | console.views.center_pool.app_import.EnterpriseAppImportInitView.post | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_enterprise_import_init_creates_record_when_none_exists |
 | console.app-import.list-dir | 查询导入目录中的应用包 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.get | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_get_lists_imported_packages |
-| console.app-import.query-status | 查询应用导入状态 | active | regression | console.views.center_pool.app_import.CenterAppImportView.get | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status |
+| console.app-import.openapi-query-status | 查询 OpenAPI 应用导入状态 | active | regression | console.services.app_import_and_export_service.AppImportService.openapi_deploy_app_get_import_by_event_id | console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_openapi_deploy_app_get_import_by_event_id_skips_unchanged_status_save |
+| console.app-import.query-status | 查询应用导入状态 | active | regression | console.views.center_pool.app_import.CenterAppImportView.get | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status<br>console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_preserves_database_error_when_transaction_is_broken<br>console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_skips_unchanged_running_status_save<br>console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_saves_partial_success_once |
 | console.app-import.start | 开始应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.post | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_post_starts_app_import |
 | console.app-migration.cleanup-group-missing | 清理旧应用时拦截已删除的原组 | active | regression | console.views.center_pool.groupapp_migration.GroupAppsView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsMigrationCleanupTests.test_delete_rejects_missing_original_group |
 | console.app-migration.cleanup-group-required | 清理旧应用前必须提供原组 ID | active | regression | console.views.center_pool.groupapp_migration.GroupAppsView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsMigrationCleanupTests.test_delete_requires_group_id |
@@ -100,13 +102,14 @@
 | console.app-upgrade.rollback-records | App Upgrade Rollback Records | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.rollback-records] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_rollback_records_returns_items |
 | console.app-version.component-diff-details | 生成应用版本组件差异明细 | active | regression | console.services.app_version_service._build_component_diff_details | console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_added_removed_and_field_updates<br>console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_connect_envs_and_other_changes |
 | console.app-version.create-app-from-snapshot | App Version Create App From Snapshot | active | regression | console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_installs_hidden_template_into_new_app |
+| console.app-version.create-app-from-snapshot-invalid-name | 从快照版本创建应用时拒绝非法目标应用名 | active | regression | console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name |
 | console.app-version.create-snapshot | 创建应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotListView.post | console/tests/app_version_test.py::AppVersionSnapshotListViewPostTestCase<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_version_snapshot_calls_app_version_service |
 | console.app-version.delete-rollback-record | 删除应用版本回滚记录 | active | regression | console.views.app_version.AppVersionRollbackRecordDetailView.delete | console/tests/app_version_test.py::AppVersionRollbackRecordViewTestCase.test_delete_removes_rollback_record |
 | console.app-version.delete-snapshot | 删除应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotDetailView.delete | console/tests/app_version_test.py::AppVersionSnapshotDetailViewDeleteTestCase |
 | console.app-version.delete-snapshot-endpoint | 通过接口删除应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotDetailView.delete | console/tests/app_version_test.py::AppVersionSnapshotDetailViewDeleteTestCase.test_delete_returns_success_response |
 | console.app-version.diff-summary | 汇总应用版本差异 | active | regression | console.services.app_version_service._summarize_diff | console/tests/app_version_test.py::AppVersionServiceDiffSummaryTestCase.test_summarize_diff_keeps_real_component_changes |
 | console.app-version.hidden-template-cleanup | 清理应用版本隐藏模板记录 | active | regression | console.services.market_app.market_app_service.delete_rainbond_app_all_info_by_id | console/tests/app_version_test.py::AppVersionTemplateDeleteTestCase.test_delete_rainbond_app_all_info_by_id_cleans_snapshot_relation |
-| console.app-version.hidden-template-create | 创建应用版本隐藏模板 | active | regression | console.services.app_version_service.get_or_create_hidden_template | console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase.test_get_or_create_hidden_template_creates_hidden_app |
+| console.app-version.hidden-template-create | 创建应用版本隐藏模板 | active | regression | console.services.app_version_service.get_or_create_hidden_template | console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase |
 | console.app-version.overview | 查看应用版本概览 | active | regression | console.services.app_version_service.get_overview | console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_promotes_latest_successful_rollback_target_to_current_version<br>console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_keeps_latest_snapshot_as_current_version_when_newer_than_rollback<br>console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_promotes_partial_rollback_target_to_current_version<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_version_overview_returns_version_center_overview |
 | console.app-version.restore-builds | 回滚后生成构建任务 | active | regression | console.services.market_app.market_app.MarketApp._generate_builds | console/tests/app_version_test.py::MarketAppBuildGenerationTestCase.test_generate_builds_allows_components_without_source_metadata |
 | console.app-version.restore-component-without-source | 无来源信息时恢复组件 | active | regression | console.services.market_app.app_restore.AppRestore._create_component | console/tests/app_version_test.py::AppRestoreSnapshotCompatibilityTestCase.test_create_component_allows_snapshot_without_service_source |
@@ -131,6 +134,7 @@
 | console.app-version.snapshot-no-change | 无变更时跳过创建快照 | active | regression | console.views.app_version.AppVersionSnapshotListView.post | console/tests/app_version_test.py::AppVersionSnapshotListViewPostTestCase.test_post_returns_no_change_message_when_snapshot_not_created |
 | console.app-version.snapshot-share-image-fallback | App Version Snapshot Share Image Fallback | active | regression | console.services.app_version_service | console/tests/app_version_test.py::AppVersionServiceTemplateNormalizationTestCase.test_assemble_app_template_falls_back_to_image_when_share_image_missing |
 | console.app-version.snapshots | App Version Snapshots | active | regression | console.services.mcp_query_service.call_tool[console.app-version.snapshots] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_list_app_version_snapshots_returns_versions |
+| console.app-version.target-app-name-schema | create_app_from_snapshot_version 工具暴露目标应用名约束 | active | regression | console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints |
 | console.app-version.view-diff | 查看应用版本差异详情 | active | regression | console.services.app_version_service._build_component_diff_details | console/tests/app_version_test.py::AppVersionServiceDiffSummaryTestCase<br>console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase |
 | console.app.batch-component-operation | 批量操作应用组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_operate_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_calls_batch_operations |
 | console.app.check-yaml | 校验 YAML 创建应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_yaml_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_yaml_app_returns_compose_check_info |
@@ -144,6 +148,7 @@
 | console.app.delete | 删除应用及隐藏快照模板 | active | regression | console.services.group_service._delete_app | console/tests/group_service_test.py::GroupServiceDeleteAppTestCase |
 | console.app.delete-confirmation-guard | 阻止无效的应用删除确认 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_rejects_invalid_confirmation_token |
 | console.app.delete-with-confirmation | 确认后删除应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_requires_confirmation_then_delete |
+| console.app.delete-with-resources | 删除应用及其组件与关联资源 | active | unit | console.services.group_service.GroupService.delete_app_with_resources | console/tests/group_service_test.py::GroupServiceDeleteAppWithResourcesTestCase |
 | console.app.detail | 查看应用详情 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_app_detail] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_detail_returns_status_and_counts |
 | console.app.export-metadata | 生成应用导出元数据 | active | regression | console.services.app_import_and_export_service.AppExportService._AppExportService__get_app_metata | console/tests/app_import_and_export_service_test.py::AppExportServiceMetadataTestCase |
 | console.app.get-yaml-check-result | 查看 YAML 应用校验结果 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_yaml_app_check_result] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_yaml_app_check_result_returns_services |
@@ -153,6 +158,7 @@
 | console.app.monitor-range-default-step | 监控区间查询默认步长为 60 秒 | active | regression | console.services.mcp_query_service.query_app_monitor_range | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_range_defaults_step_to_60 |
 | console.app.monitor-summary | 查询应用监控概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_app_monitor] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_returns_monitor_items |
 | console.app.monitor-summary-outer-only | 应用监控概览仅统计对外端口组件 | active | regression | console.services.mcp_query_service.query_app_monitor | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_filters_to_outer_services_when_requested |
+| console.app.restart-component-operation | operate_app 重启映射到批量操作 | active | regression | console.services.mcp_query_service.call_tool[console.app.restart-component-operation] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action |
 | console.app.upgrade | 升级应用版本 | active | regression | console.services.mcp_query_service.call_tool[rainbond_upgrade_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_upgrade_app_calls_upgrade_service_and_returns_latest_items |
 | console.cache.capacity-guard | 内存缓存达到容量上限时拒绝或复用缓存槽位 | active | regression | console.utils.cache.Cache._memory_set | console/tests/utils/cache_test.py::CacheMemoryTests.test_memory_cache_refuses_new_key_when_full_without_expired_entries |
 | console.cache.expired-eviction | 在访问时清理已过期的内存缓存项 | active | regression | console.utils.cache.Cache._memory_get | console/tests/utils/cache_test.py::CacheMemoryTests.test_memory_cache_evicts_expired_entry_on_get |
@@ -180,6 +186,8 @@
 | console.cnb-build.preserve-supported-envs | 保留支持语言的 CNB 环境变量 | active | regression | console.utils.cnb_build.sanitize_build_env_dict_for_language | console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_static_build_envs_preserve_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_common_mirror_fields<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_known_node_versions |
 | console.cnb-build.reject-unsupported-language | 拒绝不支持 CNB 的构建语言 | active | regression | console.utils.cnb_build.is_cnb_language | console/tests/cnb_build_test.py::CNBLanguageDetectionTestCase.test_java_language_is_not_cnb<br>console/tests/cnb_build_test.py::CNBLanguageDetectionTestCase.test_dockerfile_node_language_is_not_cnb |
 | console.cnb-build.sanitize-unsupported-envs | 清理非支持语言中的陈旧 CNB 环境变量 | active | regression | console.utils.cnb_build.sanitize_build_env_dict_for_language | console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_stale_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_runtime_aliases_used_by_builder<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_non_cnb_languages_strip_stale_cnb_markers |
+| console.component-type.daemonset | DaemonSet 组件类型支持 | active | regression | console.enum.component_enum.ComponentType | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported<br>console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset<br>console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition |
+| console.component.autoscaler-invalid-metrics | manage_component_autoscaler 在调用服务前拒绝不完整指标 | active | regression | console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call |
 | console.component.autoscaler-summary | 查看组件伸缩概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_autoscaler] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_summary_returns_rules_and_records |
 | console.component.build | 检测成功后构建组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_component_builds_checked_component |
 | console.component.build-component-schema | Component Build Component Schema | active | regression | console.services.mcp_query_service.call_tool[console.component.build-component-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_build_component_tool_schema_exposes_build_info_guidance |
@@ -187,6 +195,7 @@
 | console.component.build-logs | Component Build Logs | active | regression | console.services.mcp_query_service.call_tool[console.component.build-logs] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_build_logs_returns_event_log_items |
 | console.component.build-source-get | Component Build Source Get | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-get] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_build_source_returns_sanitized_summary |
 | console.component.build-source-update | Component Build Source Update | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-update] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_updates_source_code_fields |
+| console.component.build-source-update-image-cmd | 构建源更新保留/设置镜像启动命令 | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-update-image-cmd] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_keeps_cmd_when_omitted_on_image_update<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_sets_cmd_and_syncs_docker_cmd |
 | console.component.change-image | 修改组件镜像 | active | regression | console.services.mcp_query_service.call_tool[rainbond_change_component_image] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_change_component_image_updates_service_fields |
 | console.component.check-result | 获取组件构建检测结果 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_check_result] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_check_result_saves_detection_result |
 | console.component.check-start | 启动组件检测 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_component_starts_check_flow |
@@ -200,7 +209,9 @@
 | console.component.create-from-source-generic-git | 通过通用 Git 源码创建组件 | active | regression | console.services.mcp_query_service.create_component_from_source | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_allows_generic_git_code_from |
 | console.component.create-from-source-guided | 通过引导式源码配置创建组件 | active | regression | console.services.mcp_query_service.create_component_from_source | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_calls_aggregated_source_service |
 | console.component.create-from-source-prefer-dockerfile | Component Create From Source Prefer Dockerfile | active | regression | console.services.mcp_query_service.call_tool[console.component.create-from-source-prefer-dockerfile] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_passes_prefer_dockerfile_flag |
+| console.component.default-resource-spec | 组件创建工具暴露默认资源规格指引 | active | regression | console.services.mcp_query_service.list_tools[console.component.default-resource-spec] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance |
 | console.component.delete | 删除组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_delete_component_calls_app_manage_delete |
+| console.component.delete-dependency-conflict | 删除组件返回结构化依赖冲突原因 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict] | console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason<br>console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable |
 | console.component.dependency-add | 添加组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_single_dependency_success<br>console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_single_dependency_requires_open_inner |
 | console.component.dependency-add-batch | 批量添加组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add-batch] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_batch_dependencies_success |
 | console.component.dependency-add-reverse | 添加反向组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add_reverse] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_reverse_dependencies_success |
@@ -215,6 +226,7 @@
 | console.component.env-update | 批量更新组件环境变量 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_envs#upsert] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_envs_upsert_only_uses_inner_envs |
 | console.component.env-upsert-single-item | Component Env Upsert Single Item | active | regression | console.services.mcp_query_service.call_tool[console.component.env-upsert-single-item] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_envs_upsert_accepts_single_item_shape |
 | console.component.events | 查询组件事件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_events] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_events_returns_paginated_events |
+| console.component.extend-method-upsert | 按组件版本覆盖保存伸缩规则配置 | active | regression | console.repositories.app_config.ServiceExtendRepository | console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key |
 | console.component.horizontal-scale | 水平伸缩组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_horizontal_scale_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_horizontal_scale_component_calls_app_manage_service |
 | console.component.list | 查看应用组件列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_components] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_components_uses_existing_service_repo_method |
 | console.component.logs | 查看组件日志 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_logs] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_logs_returns_component_logs |
@@ -226,6 +238,9 @@
 | console.component.operation-aliases | 规范化组件操作别名 | active | regression | console.services.mcp_query_service._normalize_component_operation | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_normalize_component_operation_aliases |
 | console.component.pods | Component Pods | active | regression | console.services.mcp_query_service.call_tool[console.component.pods] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_pods_returns_normalized_runtime_instances |
 | console.component.port-add-invalid-alias | Component Port Add Invalid Alias | active | regression | console.services.mcp_query_service.call_tool[console.component.port-add-invalid-alias] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_add_exposes_structured_alias_validation |
+| console.component.port-batch-add | manage_component_ports 批量新增委托给批量服务 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-add] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service |
+| console.component.port-batch-enable-inner | manage_component_ports 批量开启内网端口只加载一次上下文 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once |
+| console.component.port-batch-enable-outer | manage_component_ports 批量开启外网端口接受整数项 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items |
 | console.component.port-list | 查询组件端口列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_handle_component_ports#list] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_list_returns_ports |
 | console.component.port-open-inner | 开放组件内网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_inner] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_enable_inner_maps_to_open_inner |
 | console.component.port-open-outer-only | 仅开放组件公网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_outer_only] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_enable_outer_only_maps_to_only_open_outer |
@@ -233,12 +248,11 @@
 | console.component.port-summary | 查看组件端口概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_summary_delegates_to_port_handler |
 | console.component.probe-summary | 查看组件探针概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_probe] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_probe_summary_returns_probe_snapshot |
 | console.component.storage-create-mount | 创建组件共享存储挂载 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_mnt] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_mnt_batches_mounts |
-| console.component.storage-create-volume | 创建组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume |
+| console.component.storage-create-volume | 创建组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path |
 | console.component.storage-custom-volume-filter | 过滤组件自定义卷列表中的内置卷类型 | active | regression | console.repositories.app_config.TenantServiceVolumnRepository.list_custom_volumes | console/tests/app_config_test.py::TenantServiceVolumnRepositoryTests.test_list_custom_volumes_treats_local_path_as_builtin_volume_type |
-| console.component.extend-method-upsert | 按组件版本覆盖保存伸缩规则配置 | active | regression | console.repositories.app_config.ServiceExtendRepository | console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key |
 | console.component.storage-delete-mount | 删除组件共享存储挂载 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_mnt] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_mnt_removes_relation |
 | console.component.storage-delete-volume | 删除组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_volume_requires_force_branch<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_volume_success_branch |
-| console.component.storage-summary | 查看组件存储概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot |
+| console.component.storage-summary | 查看组件存储概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_summary_includes_config_file_volumes |
 | console.component.storage-update-capacity | Component Storage Update Capacity | active | regression | console.views.app_config.app_volume.AppVolumeManageView.put | console/tests/app_volume_view_test.py::AppVolumeManageViewTestCase.test_put_allows_updating_volume_capacity_without_path_change |
 | console.component.storage-update-volume-capacity | Component Storage Update Volume Capacity | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_update_volume_allows_capacity_change_without_path_change |
 | console.component.summary | 查看组件概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_summary] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_summary_returns_aggregated_info |
@@ -247,6 +261,7 @@
 | console.endpoint-address.reject-special-ranges | 拒绝 unspecified 和 loopback 的端点地址 | active | regression | console.utils.validation.validate_endpoint_address | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoint_address_rejects_special_ranges |
 | console.endpoint-list.normalize-scheme-port | 在多端点校验前规范化协议和端口 | active | regression | console.utils.validation.validate_endpoints_info | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_normalizes_scheme_and_port |
 | console.endpoint-list.reject-duplicate | 在多实例端点列表中拒绝重复地址 | active | regression | console.utils.validation.validate_endpoints_info | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses |
+| console.enterprise-config.custom-fields-disabled-bool | get_custom_fields 包含被禁用的布尔字段 | active | regression | console.services.config_service.EnterpriseConfigService.get_custom_fields | console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields |
 | console.enterprise-config.user-context | 解析企业配置服务用户上下文 | active | regression | console.services.config_service.EnterpriseConfigService.__init__ | console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_defaults_user_id_to_none<br>console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_keeps_explicit_user_id |
 | console.enterprise.region-component-list | 查看集群控制面组件列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_region_rbd_components] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_query_region_rbd_components_returns_components_for_enterprise_admin |
 | console.enterprise.region-create | 创建企业集群 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_region] | console/tests/mcp_query_service_test.py::MCPQueryServiceRegionMutationTests.test_create_region_executes_directly |
@@ -260,6 +275,7 @@
 | console.file-manage.region-request-timeout | 文件管理区域请求使用选定容器与更长超时 | active | regression | www.apiclient.regionapi.RegionInvokeApi.get_files | console/tests/file_manage_service_test.py::test_region_api_get_files_uses_container_name_and_longer_timeout |
 | console.file-manage.selected-container-forwarding | 列出文件管理内容时透传用户选择的容器名 | active | regression | console.services.group_service.GroupService.get_file_and_dir | console/tests/file_manage_service_test.py::test_get_file_and_dir_forwards_selected_container_name |
 | console.gateway.component-env-upsert-schema | Gateway Component Env Upsert Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.component-env-upsert-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance |
+| console.gateway.create-app-invalid-display-name | create_app 对非法应用名返回结构化错误详情 | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name |
 | console.gateway.create-app-k8s-name-schema | Gateway Create App K8s Name Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-k8s-name-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_tool_schema_exposes_k8s_app_constraints |
 | console.gateway.create-http-rule | 创建 HTTP 网关规则 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_http_returns_bound_rule |
 | console.gateway.create-tcp-rule | 创建 TCP 网关规则 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_tcp_returns_bound_rule |
@@ -291,17 +307,27 @@
 | console.helm-release.upgrade | 升级 Helm 发布并保存来源记录 | active | regression | console.views.team_resources.HelmReleaseDetailView.put | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_put_persists_upgrade_source_after_success |
 | console.helm.build | 构建 Helm 应用模板 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_helm_app_generates_template |
 | console.helm.check | 检查 Helm 应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result |
+| console.helm.daemonset-template | Helm DaemonSet 资源映射为组件模板 | active | regression | console.services.helm_app_yaml.HelmAppService.generate_template | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type |
 | console.image.runner-detect | 根据仓库前缀识别 runner 镜像 | active | regression | console.utils.runner_util.is_runner | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_runner |
 | console.image.slug-detect | 为非 docker 类语言识别基于 runner 的 slug 镜像 | active | regression | console.utils.slug_util.is_slug | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_slug |
 | console.init-cluster.prefer-latest-pending | 初始化时优先选择最新待处理集群 | active | regression | console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated | console/tests/init_cluster_test.py::ClusterRepositoryTests.test_get_rke_cluster_exclude_integrated_prefers_latest_pending_cluster |
 | console.init-cluster.recycle-empty-interconnected | 回收空白联通集群用于重新初始化 | active | regression | console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated | console/tests/init_cluster_test.py::ClusterRepositoryTests.test_get_rke_cluster_exclude_integrated_recycles_blank_cluster |
 | console.k8s-namespace.normalize-user-prefix | 将用户名规范化为合法的 Kubernetes 命名空间名 | active | regression | console.utils.validation.normalize_name_for_k8s_namespace | console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_normalize_name_for_k8s_namespace |
+| console.kubeblocks.backup-repo.ready-guard | 使用 KubeBlocks 备份仓库前校验就绪状态 | active | regression | console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo<br>console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message |
+| console.kubeblocks.backup-repo.team-create | 创建团队 KubeBlocks 备份仓库 | active | regression | console.services.kubeblocks_service.KubeBlocksService.create_backup_repo | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_prefixes_namespace_and_does_not_store_secret_values<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_defaults_to_prechecking_when_region_phase_is_empty<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_rejects_existing_region_repo_name_even_if_deleted |
+| console.kubeblocks.backup-repo.team-delete | 删除团队 KubeBlocks 备份仓库 | active | regression | console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use |
+| console.kubeblocks.backup-repo.team-list | 列出团队 KubeBlocks 备份仓库并合并实时状态 | active | regression | console.services.kubeblocks_service.KubeBlocksService.get_team_backup_repos | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_merges_live_status_from_region<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_keeps_failed_live_status<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_marks_missing_when_region_resource_disappears |
+| console.kubeblocks.backup-repo.team-ownership | 校验 KubeBlocks 备份仓库团队归属 | active | regression | console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_belongs_to_team | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_belongs_to_team_rejects_other_team_repo |
 | console.kubeblocks.cluster-resource-validation | 校验 KubeBlocks 集群资源请求 | active | regression | console.services.kubeblocks_service.KubeBlocksService.validate_cluster_params | console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksClusterValidationTests |
+| console.kubeblocks.create-credential-sync | 创建 KubeBlocks 组件时同步连接凭据 | active | regression | console.services.kubeblocks_service.KubeBlocksService.create_complete_kubeblocks_component | console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests |
 | console.lang-version.proxy-upload | 代理旧版语言包上传接口 | active | regression | console.views.enterprise.UploadLongVersion.post | console/tests/lang_version_proxy_test.py::UploadLongVersionProxyViewTests |
+| console.market-app.create-template-scope-name | 按发布范围和团队检查应用市场模板重名 | active | regression | console.services.market_app_service.MarketAppService.create_rainbond_app | console/tests/market_app_service_test.py::MarketAppServiceCreateRainbondAppTests |
 | console.market-app.install-default-storage-class | 应用市场安装使用平台默认存储类 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_default_volume_type_prefers_configured_storage_class<br>console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class |
+| console.market-app.restore-preserves-volume-capacity-on-storage-fallback | 市场恢复在存储类型回退时保留卷容量 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes |
+| console.market-app.restore-volume-capacity-helper | resolve_market_restore_volume_settings 在存储类型变化时保留容量 | active | regression | console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes |
 | console.market-app.upgrade-share-image-fallback | Market App Upgrade Share Image Fallback | active | regression | console.services.market_app.update_components | console/tests/market_app_update_components_test.py::MarketAppUpdateComponentsCompatibilityTests.test_create_update_components_falls_back_to_image_when_share_image_missing |
 | console.market-app.vm-disk-imports-from-template | 市场应用安装从 VM 模板生成磁盘导入配置 | active | regression | console.services.market_app.new_components.NewComponents._template_to_k8s_attributes | console/tests/market_app_update_components_test.py::MarketAppNewComponentsVMK8sAttrsTests.test_template_to_k8s_attributes_backfills_vm_runtime_attrs_from_vm_block |
-| console.market-app.vm-runtime-status-guard | 虚拟机平台异常时禁止安装虚拟机模板 | active | regression | console.services.market_app_service.MarketAppService.install_app | console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests.test_install_app_rejects_vm_template_when_vm_plugin_not_running |
+| console.market-app.vm-runtime-status-guard | 虚拟机平台异常时禁止安装虚拟机模板 | active | regression | console.services.market_app_service.MarketAppService.install_app | console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests |
 | console.market-client.auth-missing | 将 401 应用市场错误转换为缺少 token 的服务异常 | active | regression | console.utils.restful_client.apiException | console/tests/utils/restful_client_test.py::RestfulClientApiExceptionTests.test_api_exception_401 |
 | console.market-client.bad-request | 将通用 4xx 应用市场错误转换为参数错误响应 | active | regression | console.utils.restful_client.apiException | console/tests/utils/restful_client_test.py::RestfulClientApiExceptionTests.test_api_exception_generic_4xx |
 | console.market-client.default-host | 使用默认回退 host 创建应用市场客户端 | active | regression | console.utils.restful_client.get_market_client | console/tests/utils/restful_client_test.py::RestfulClientFactoryTests.test_get_market_client_uses_default_host |
@@ -316,13 +342,19 @@
 | console.market.install-app-model-cloud | Market Install App Model Cloud | active | regression | console.services.mcp_query_service.call_tool[console.market.install-app-model-cloud] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_install_app_model_for_cloud_calls_market_app_service |
 | console.market.local-app-models | Market Local App Models | active | regression | console.services.mcp_query_service.call_tool[console.market.local-app-models] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_local_app_models_returns_paginated_templates |
 | console.mcp.http-delete-session | 通过 HTTP 关闭 MCP 会话 | active | regression | console.views.mcp_query.MCPQueryHTTPView.delete | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_delete_accepts_valid_session_token |
+| console.mcp.http-expired-jwt | MCP HTTP 接口对过期 JWT 返回 401 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt |
 | console.mcp.http-initialize | 通过 HTTP 初始化 MCP 会话 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_initialize_returns_json_and_session_header |
 | console.mcp.http-tools-list-with-auth | Mcp Http Tools List With Auth | active | regression | console.views.mcp_query.MCPQueryHTTPView | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_tools_list_allows_authenticated_request_without_session_header |
 | console.mcp.http-tools-sse | 通过 HTTP 端点以 SSE 返回工具列表 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_can_return_sse_message_response |
+| console.mcp.input-validation-contract | MCP 工具对缺参/查无组件返回清晰原因 | active | regression | console.services.mcp_query_service.call_tool | console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input<br>console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_unknown_component_returns_not_found |
 | console.mcp.legacy-sse-endpoint | 打开兼容模式的 SSE MCP 端点 | active | regression | console.views.mcp_query.MCPQuerySSEView.get | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_get_returns_endpoint_event_for_legacy_sse_clients |
+| console.mcp.operation-event-ids | MCP operate_app/upgrade_app 返回操作事件 ID | active | unit | console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids] | console/tests/mcp_query_operation_event_ids_test.py |
+| console.mcp.operation-failure-classifier | MCP 操作失败分类器 | active | unit | console.services.mcp_failure_classifier.classify_failure | console/tests/mcp_failure_classifier_test.py |
+| console.mcp.operation-failure-context | MCP 操作失败上下文工具 | active | unit | console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context] | console/tests/mcp_query_failure_context_test.py |
 | console.mcp.post-message | 向 SSE 会话投递 MCP 消息 | active | regression | console.views.mcp_query.MCPQueryMessageView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_post_message_enqueues_initialize_response_on_sse_stream |
 | console.mcp.serialize-nested-sdk-models | MCP 响应中递归序列化嵌套 SDK 模型 | active | regression | console.services.mcp_query_service.MCPQueryService._serialize_model_item | console/tests/mcp_query_service_test.py::MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_recurses_into_dict_values<br>console/tests/mcp_query_service_test.py::MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_handles_object_with_nested_sdk_attribute |
 | console.mcp.structured-tool-error | Mcp Structured Tool Error | active | regression | console.views.mcp_query.MCPQueryHTTPView | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_tool_error_includes_structured_validation_details |
+| console.mcp.tool-error-fallback | 任意 MCP 工具失败均返回可解析错误 | active | regression | console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc | console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error<br>console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message |
 | console.ns-resource.batch-create | Ns Resource Batch Create | active | regression | console.views.team_resources | console/tests/team_resources_test.py::NsResourceDetailViewTestCase.test_post_preserves_partial_success_status_and_payload |
 | console.ns-resource.update | 通过 YAML 更新命名空间资源 | active | regression | console.views.team_resources.NsResourceDetailView.put | console/tests/team_resources_test.py::NsResourceDetailViewTestCase.test_put_accepts_yaml_media_type_and_forwards_raw_body<br>console/tests/team_resources_test.py::RegionInvokeApiNsResourceTestCase.test_put_tenant_ns_resource_preserves_custom_content_type |
 | console.oauth.instance-create | 创建 OAuth helper 实例并绑定服务与用户上下文 | active | regression | console.utils.oauth.oauth_types.get_oauth_instance | console/tests/utils/oauth_types_test.py::OAuthTypeTests.test_get_oauth_instance |
@@ -348,6 +380,9 @@
 | console.package-upload.init-flow | Package Upload Init Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_init_upload_creates_remote_dir_and_record |
 | console.package-upload.local-package | Package Upload Local Package | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.local-package] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_local_package_calls_upload_tool_service |
 | console.package-upload.local-package-flow | Package Upload Local Package Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_auto_create_component_from_local_path_runs_full_flow |
+| console.package-upload.local-path-create-schema | create_component_from_local_package 工具 schema 暴露服务端本地路径指引 | active | regression | console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance |
+| console.package-upload.local-path-missing-details | _normalize_local_path 在路径缺失时抛出结构化详情 | active | regression | console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing |
+| console.package-upload.local-path-required-details | _normalize_local_path 在路径为空时抛出结构化详情 | active | regression | console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty |
 | console.package-upload.local-path-schema | Package Upload Local Path Schema | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.local-path-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_upload_package_file_tool_schema_exposes_local_path_guidance |
 | console.package-upload.status | Package Upload Status | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.status] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_package_upload_status_delegates_to_upload_tool_service |
 | console.package-upload.status-flow | Package Upload Status Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_get_upload_status_reads_packages_and_updates_record |
@@ -362,6 +397,7 @@
 | console.region-api.domain-conflict-msg | 将上游域名冲突保留为可操作的 409 错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_domain_conflict_as_conflict_error |
 | console.region-api.helm-resource-conflict-msg | 将 Helm 资源归属冲突转换为可操作错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_helm_ownership_conflict_to_actionable_msg_show |
 | console.region-api.proxy-error-pass-through | 对非 Helm 冲突保留原始上游错误信息 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_original_message_for_non_helm_conflicts |
+| console.region-api.vm-snapshot-feature-gate-msg | _check_status 将虚拟机快照功能门禁错误翻译为可操作提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show |
 | console.request-args.bool-coercion | 将请求中的布尔参数从字符串或布尔值安全转换 | active | regression | console.utils.reqparse.bool_argument | console/tests/utils/reqparse_test.py::BoolArgumentTestCase |
 | console.request-args.bool-default-false | 缺失布尔查询参数时返回 false 默认值 | active | regression | console.utils.reqparse.parse_argument | console/tests/utils/reqparse_test.py::ParseArgumentTestCase.test_parse_argument_return_default_false_bool |
 | console.request-args.bool-default-true | 为布尔查询参数使用 true 默认值 | active | unit | console.utils.reqparse.parse_argument | console/tests/utils/reqparse_test.py::ParseArgumentTestCase.test_parse_argument_return_default_bool |
@@ -441,13 +477,19 @@
 | console.vm-asset.incomplete-service-cleanup-preserves-ready-assets | 删除未完成虚拟机组件时保留已就绪镜像资产 | active | regression | console.services.app_actions.app_manage.AppManageService._truncate_service | console/tests/app_manage_test.py::AppManageIncompleteVMCleanupTests.test_truncate_service_keeps_ready_uploaded_vm_asset |
 | console.vm-overview.vnc-url-plugin-fallback | 在缺少查询参数时从插件回填虚拟机概览 VNC 地址 | active | regression | console.views.app_overview.AppDetailView.get | console/tests/vm_detail_view_test.py::AppVMDetailViewTests.test_get_builds_vm_vnc_url_from_plugin_fallback_when_query_param_missing |
 | console.vm-profile.template-root-disk-fallback | VM profile falls back to template root disk metadata | active | regression | console.services.virtual_machine.VirtualMachineService.get_vm_profile | console/tests/virtual_machine_service_test.py::VirtualMachineServiceTests.test_get_vm_profile_falls_back_to_template_root_disk_metadata_when_asset_missing |
+| console.vm-root-disk-selected-storage-type | update_check_app 为新建虚拟机根盘使用所选存储类型 | active | regression | console.services.app.AppService.update_check_app | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk |
 | console.vm-run.platform-runtime-guard | 虚拟机平台异常时禁止创建虚拟机组件 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_create_rejects_when_vm_plugin_not_running |
 | console.vm-storage-any-access-mode | 允许虚拟机使用任意访问模式的存储 | active | regression | console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests |
+| console.vm-template-import.delete-abnormal-vm | delete 允许异常状态虚拟机跳过运行中校验 | active | regression | console.services.app_actions.app_manage.AppManageService.delete | console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard |
 | console.vm-template-import.delete-restoring-vm | Allow deleting restoring VM components | active | regression | console.services.app_actions.app_manage.AppManageService.delete | console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests |
 | console.vm-template-import.restore-operation-record | VM template import restore operation record exposes progress | active | unit | console.services.app_actions.app_log.AppEventService.build_vm_restore_event | console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_exposes_progress_and_importer_logs<br>console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_marks_success_after_import_finishes |
 | rainbond-console.vm-disks.container-disk-cdrom | VM disk layout accepts container disk CD-ROM media | active | regression | console.services.virtual_machine.VirtualMachineService.validate_vm_disk_layout | console/tests/vm_create_flow_regression_test.py::VMCreateFlowRegressionUnitTests.test_validate_vm_disk_layout_accepts_container_disk_cdrom<br>console/tests/vm_create_flow_regression_test.py::VMCreateFlowRegressionUnitTests.test_validate_vm_disk_layout_rejects_container_disk_without_image |
 | rainbond-console.vm-disks.iso-installer-compat | 当 VM 运行时提示不完整时仍为 ISO 虚拟机磁盘列表补出安装光盘 | active | regression | console.services.virtual_machine.VirtualMachineService.list_vm_disks | console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_get_vm_runtime_config_includes_boot_source_format<br>console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_list_vm_disks_falls_back_to_asset_format_for_legacy_iso_vm_without_runtime_hint |
+| rainbond-console.vm-export.asset-ready-storage-status | 虚拟机资产就绪需要 ready 状态与镜像地址 | active | regression | console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready | console/tests/vm_create_flow_regression_test.py |
+| rainbond-console.vm-live-migration-unique-disk-path | resolve_vm_volume_path 为虚拟机热迁移分配唯一磁盘路径 | active | regression | console.services.app_config.volume_service.AppVolumeService.resolve_vm_volume_path | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_allocates_unique_disk_suffix_for_duplicate_vm_device_path<br>console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_keeps_existing_path_when_editing_same_vm_device_type |
 | rainbond-console.vm-run.disk-asset-create | 从现有磁盘资产创建虚拟机时复用已就绪运行时镜像 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image |
+| rainbond-console.vm-run.vm-export-ignore-stale-boot-mode | resolve_vm_boot_mode 对 Windows ISO 忽略过期资产启动模式 | active | regression | console.services.virtual_machine.VirtualMachineService.resolve_vm_boot_mode | console/tests/vm_create_flow_regression_test.py |
+| rainbond-console.vm-run.vm-export-multi-disk-create | 虚拟机运行创建支持多磁盘资产实例化 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py |
 
 ## 详情
 
@@ -891,6 +933,16 @@
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_delete_removes_import_dir`
 
+### 处理导入应用模板身份冲突
+
+- Capability ID: `console.app-import.identity-collision`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.AppImportService.__save_enterprise_import_info`
+- 代码路径: `console/services/app_import_and_export_service.py`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_when_name_differs`, `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_keeps_same_key_and_name_as_multiple_versions`, `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_name_version_when_content_differs`
+
 ### 初始化应用导入
 
 - Capability ID: `console.app-import.init`
@@ -911,6 +963,16 @@
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_get_lists_imported_packages`
 
+### 查询 OpenAPI 应用导入状态
+
+- Capability ID: `console.app-import.openapi-query-status`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.AppImportService.openapi_deploy_app_get_import_by_event_id`
+- 代码路径: `console/services/app_import_and_export_service.py`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_openapi_deploy_app_get_import_by_event_id_skips_unchanged_status_save`
+
 ### 查询应用导入状态
 
 - Capability ID: `console.app-import.query-status`
@@ -919,7 +981,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.views.center_pool.app_import.CenterAppImportView.get`
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
-- 测试路径: `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status`, `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_preserves_database_error_when_transaction_is_broken`, `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_skips_unchanged_running_status_save`, `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_saves_partial_success_once`
 
 ### 开始应用导入
 
@@ -1411,6 +1473,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_installs_hidden_template_into_new_app`
 
+### 从快照版本创建应用时拒绝非法目标应用名
+
+- Capability ID: `console.app-version.create-app-from-snapshot-invalid-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name`
+
 ### 创建应用版本快照
 
 - Capability ID: `console.app-version.create-snapshot`
@@ -1479,7 +1551,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.app_version_service.get_or_create_hidden_template`
 - 代码路径: `console/services/app_version_service.py`
-- 测试路径: `console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase.test_get_or_create_hidden_template_creates_hidden_app`
+- 测试路径: `console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase`
 
 ### 查看应用版本概览
 
@@ -1721,6 +1793,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_list_app_version_snapshots_returns_versions`
 
+### create_app_from_snapshot_version 工具暴露目标应用名约束
+
+- Capability ID: `console.app-version.target-app-name-schema`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints`
+
 ### 查看应用版本差异详情
 
 - Capability ID: `console.app-version.view-diff`
@@ -1851,6 +1933,16 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/group_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_requires_confirmation_then_delete`
 
+### 删除应用及其组件与关联资源
+
+- Capability ID: `console.app.delete-with-resources`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `service_method`
+- 业务入口: `console.services.group_service.GroupService.delete_app_with_resources`
+- 代码路径: `console/services/group_service.py`
+- 测试路径: `console/tests/group_service_test.py::GroupServiceDeleteAppWithResourcesTestCase`
+
 ### 查看应用详情
 
 - Capability ID: `console.app.detail`
@@ -1940,6 +2032,16 @@
 - 业务入口: `console.services.mcp_query_service.query_app_monitor`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_filters_to_outer_services_when_requested`
+
+### operate_app 重启映射到批量操作
+
+- Capability ID: `console.app.restart-component-operation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.app.restart-component-operation]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action`
 
 ### 升级应用版本
 
@@ -2211,6 +2313,26 @@
 - 代码路径: `console/utils/cnb_build.py`
 - 测试路径: `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_stale_cnb_markers`, `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_runtime_aliases_used_by_builder`, `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_non_cnb_languages_strip_stale_cnb_markers`
 
+### DaemonSet 组件类型支持
+
+- Capability ID: `console.component-type.daemonset`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.enum.component_enum.ComponentType`
+- 代码路径: `console/enum/component_enum.py`, `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported`, `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset`, `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition`
+
+### manage_component_autoscaler 在调用服务前拒绝不完整指标
+
+- Capability ID: `console.component.autoscaler-invalid-metrics`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call`
+
 ### 查看组件伸缩概览
 
 - Capability ID: `console.component.autoscaler-summary`
@@ -2280,6 +2402,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[console.component.build-source-update]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_updates_source_code_fields`
+
+### 构建源更新保留/设置镜像启动命令
+
+- Capability ID: `console.component.build-source-update-image-cmd`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.build-source-update-image-cmd]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_keeps_cmd_when_omitted_on_image_update`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_sets_cmd_and_syncs_docker_cmd`
 
 ### 修改组件镜像
 
@@ -2411,6 +2543,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_passes_prefer_dockerfile_flag`
 
+### 组件创建工具暴露默认资源规格指引
+
+- Capability ID: `console.component.default-resource-spec`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.component.default-resource-spec]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance`
+
 ### 删除组件
 
 - Capability ID: `console.component.delete`
@@ -2420,6 +2562,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_delete_component]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_manage.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_delete_component_calls_app_manage_delete`
+
+### 删除组件返回结构化依赖冲突原因
+
+- Capability ID: `console.component.delete-dependency-conflict`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict]`
+- 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason`, `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable`
 
 ### 添加组件依赖
 
@@ -2561,6 +2713,16 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_log.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_events_returns_paginated_events`
 
+### 按组件版本覆盖保存伸缩规则配置
+
+- Capability ID: `console.component.extend-method-upsert`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.repositories.app_config.ServiceExtendRepository`
+- 代码路径: `console/repositories/app_config.py`
+- 测试路径: `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key`
+
 ### 水平伸缩组件
 
 - Capability ID: `console.component.horizontal-scale`
@@ -2671,6 +2833,36 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_add_exposes_structured_alias_validation`
 
+### manage_component_ports 批量新增委托给批量服务
+
+- Capability ID: `console.component.port-batch-add`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-add]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service`
+
+### manage_component_ports 批量开启内网端口只加载一次上下文
+
+- Capability ID: `console.component.port-batch-enable-inner`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once`
+
+### manage_component_ports 批量开启外网端口接受整数项
+
+- Capability ID: `console.component.port-batch-enable-outer`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items`
+
 ### 查询组件端口列表
 
 - Capability ID: `console.component.port-list`
@@ -2749,7 +2941,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_config/volume_service.py`
-- 测试路径: `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume`
+- 测试路径: `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume`, `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path`
 
 ### 过滤组件自定义卷列表中的内置卷类型
 
@@ -2760,16 +2952,6 @@
 - 业务入口: `console.repositories.app_config.TenantServiceVolumnRepository.list_custom_volumes`
 - 代码路径: `console/repositories/app_config.py`
 - 测试路径: `console/tests/app_config_test.py::TenantServiceVolumnRepositoryTests.test_list_custom_volumes_treats_local_path_as_builtin_volume_type`
-
-### 按组件版本覆盖保存伸缩规则配置
-
-- Capability ID: `console.component.extend-method-upsert`
-- 状态: `active`
-- 测试类型: `regression`
-- 接口类型: `workflow`
-- 业务入口: `console.repositories.app_config.ServiceExtendRepository`
-- 代码路径: `console/repositories/app_config.py`
-- 测试路径: `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key`
 
 ### 删除组件共享存储挂载
 
@@ -2799,7 +2981,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_manage_component_storage]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_config/volume_service.py`, `console/services/app_config/mnt_service.py`
-- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot`, `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_summary_includes_config_file_volumes`
 
 ### Component Storage Update Capacity
 
@@ -2880,6 +3062,16 @@
 - 业务入口: `console.utils.validation.validate_endpoints_info`
 - 代码路径: `console/utils/validation.py`
 - 测试路径: `console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses`
+
+### get_custom_fields 包含被禁用的布尔字段
+
+- Capability ID: `console.enterprise-config.custom-fields-disabled-bool`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.config_service.EnterpriseConfigService.get_custom_fields`
+- 代码路径: `console/services/config_service.py`
+- 测试路径: `console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields`
 
 ### 解析企业配置服务用户上下文
 
@@ -3010,6 +3202,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[console.gateway.component-env-upsert-schema]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance`
+
+### create_app 对非法应用名返回结构化错误详情
+
+- Capability ID: `console.gateway.create-app-invalid-display-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name`
 
 ### Gateway Create App K8s Name Schema
 
@@ -3321,6 +3523,16 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/helm_app.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result`
 
+### Helm DaemonSet 资源映射为组件模板
+
+- Capability ID: `console.helm.daemonset-template`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.helm_app_yaml.HelmAppService.generate_template`
+- 代码路径: `console/services/helm_app_yaml.py`
+- 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type`
+
 ### 根据仓库前缀识别 runner 镜像
 
 - Capability ID: `console.image.runner-detect`
@@ -3371,6 +3583,56 @@
 - 代码路径: `console/utils/validation.py`
 - 测试路径: `console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_normalize_name_for_k8s_namespace`
 
+### 使用 KubeBlocks 备份仓库前校验就绪状态
+
+- Capability ID: `console.kubeblocks.backup-repo.ready-guard`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo`, `console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message`
+
+### 创建团队 KubeBlocks 备份仓库
+
+- Capability ID: `console.kubeblocks.backup-repo.team-create`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.create_backup_repo`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_prefixes_namespace_and_does_not_store_secret_values`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_defaults_to_prechecking_when_region_phase_is_empty`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_rejects_existing_region_repo_name_even_if_deleted`
+
+### 删除团队 KubeBlocks 备份仓库
+
+- Capability ID: `console.kubeblocks.backup-repo.team-delete`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use`
+
+### 列出团队 KubeBlocks 备份仓库并合并实时状态
+
+- Capability ID: `console.kubeblocks.backup-repo.team-list`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.get_team_backup_repos`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_merges_live_status_from_region`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_keeps_failed_live_status`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_marks_missing_when_region_resource_disappears`
+
+### 校验 KubeBlocks 备份仓库团队归属
+
+- Capability ID: `console.kubeblocks.backup-repo.team-ownership`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_belongs_to_team`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_belongs_to_team_rejects_other_team_repo`
+
 ### 校验 KubeBlocks 集群资源请求
 
 - Capability ID: `console.kubeblocks.cluster-resource-validation`
@@ -3401,6 +3663,16 @@
 - 代码路径: `console/views/enterprise.py`, `console/urls/__init__.py`
 - 测试路径: `console/tests/lang_version_proxy_test.py::UploadLongVersionProxyViewTests`
 
+### 按发布范围和团队检查应用市场模板重名
+
+- Capability ID: `console.market-app.create-template-scope-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.market_app_service.MarketAppService.create_rainbond_app`
+- 代码路径: `console/services/market_app_service.py`
+- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceCreateRainbondAppTests`
+
 ### 应用市场安装使用平台默认存储类
 
 - Capability ID: `console.market-app.install-default-storage-class`
@@ -3410,6 +3682,26 @@
 - 业务入口: `console.services.market_app.new_components.NewComponents._template_to_volumes`
 - 代码路径: `console/services/app_config/volume_service.py`, `console/services/market_app/new_components.py`, `console/services/market_app_service.py`
 - 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_default_volume_type_prefers_configured_storage_class`, `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class`
+
+### 市场恢复在存储类型回退时保留卷容量
+
+- Capability ID: `console.market-app.restore-preserves-volume-capacity-on-storage-fallback`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.market_app.new_components.NewComponents._template_to_volumes`
+- 代码路径: `console/services/market_app/new_components.py`, `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes`
+
+### resolve_market_restore_volume_settings 在存储类型变化时保留容量
+
+- Capability ID: `console.market-app.restore-volume-capacity-helper`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings`
+- 代码路径: `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes`
 
 ### Market App Upgrade Share Image Fallback
 
@@ -3438,8 +3730,8 @@
 - 测试类型: `regression`
 - 接口类型: `service_method`
 - 业务入口: `console.services.market_app_service.MarketAppService.install_app`
-- 代码路径: `console/services/market_app_service.py`
-- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests.test_install_app_rejects_vm_template_when_vm_plugin_not_running`
+- 代码路径: `console/services/market_app_service.py`, `console/services/app_version_service.py`
+- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests`
 
 ### 将 401 应用市场错误转换为缺少 token 的服务异常
 
@@ -3581,6 +3873,16 @@
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_delete_accepts_valid_session_token`
 
+### MCP HTTP 接口对过期 JWT 返回 401
+
+- Capability ID: `console.mcp.http-expired-jwt`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.mcp_query.MCPQueryHTTPView.post`
+- 代码路径: `console/views/mcp_query.py`
+- 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt`
+
 ### 通过 HTTP 初始化 MCP 会话
 
 - Capability ID: `console.mcp.http-initialize`
@@ -3611,6 +3913,16 @@
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_can_return_sse_message_response`
 
+### MCP 工具对缺参/查无组件返回清晰原因
+
+- Capability ID: `console.mcp.input-validation-contract`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.mcp_query_service.call_tool`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input`, `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_unknown_component_returns_not_found`
+
 ### 打开兼容模式的 SSE MCP 端点
 
 - Capability ID: `console.mcp.legacy-sse-endpoint`
@@ -3620,6 +3932,36 @@
 - 业务入口: `console.views.mcp_query.MCPQuerySSEView.get`
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_get_returns_endpoint_event_for_legacy_sse_clients`
+
+### MCP operate_app/upgrade_app 返回操作事件 ID
+
+- Capability ID: `console.mcp.operation-event-ids`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids]`
+- 代码路径: `console/services/mcp_query_service.py`, `console/services/upgrade_services.py`
+- 测试路径: `console/tests/mcp_query_operation_event_ids_test.py`
+
+### MCP 操作失败分类器
+
+- Capability ID: `console.mcp.operation-failure-classifier`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `package_function`
+- 业务入口: `console.services.mcp_failure_classifier.classify_failure`
+- 代码路径: `console/services/mcp_failure_classifier.py`
+- 测试路径: `console/tests/mcp_failure_classifier_test.py`
+
+### MCP 操作失败上下文工具
+
+- Capability ID: `console.mcp.operation-failure-context`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_failure_context_test.py`
 
 ### 向 SSE 会话投递 MCP 消息
 
@@ -3650,6 +3992,16 @@
 - 业务入口: `console.views.mcp_query.MCPQueryHTTPView`
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_tool_error_includes_structured_validation_details`
+
+### 任意 MCP 工具失败均返回可解析错误
+
+- Capability ID: `console.mcp.tool-error-fallback`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc`
+- 代码路径: `console/views/mcp_query.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error`, `console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message`
 
 ### Ns Resource Batch Create
 
@@ -3901,6 +4253,36 @@
 - 代码路径: `console/services/package_upload_tool_service.py`
 - 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_auto_create_component_from_local_path_runs_full_flow`
 
+### create_component_from_local_package 工具 schema 暴露服务端本地路径指引
+
+- Capability ID: `console.package-upload.local-path-create-schema`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance`
+
+### _normalize_local_path 在路径缺失时抛出结构化详情
+
+- Capability ID: `console.package-upload.local-path-missing-details`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path`
+- 代码路径: `console/services/package_upload_tool_service.py`
+- 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing`
+
+### _normalize_local_path 在路径为空时抛出结构化详情
+
+- Capability ID: `console.package-upload.local-path-required-details`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path`
+- 代码路径: `console/services/package_upload_tool_service.py`
+- 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty`
+
 ### Package Upload Local Path Schema
 
 - Capability ID: `console.package-upload.local-path-schema`
@@ -4040,6 +4422,16 @@
 - 业务入口: `www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status`
 - 代码路径: `www/apiclient/regionapibaseclient.py`
 - 测试路径: `console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_original_message_for_non_helm_conflicts`
+
+### _check_status 将虚拟机快照功能门禁错误翻译为可操作提示
+
+- Capability ID: `console.region-api.vm-snapshot-feature-gate-msg`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status`
+- 代码路径: `www/apiclient/regionapibaseclient.py`
+- 测试路径: `console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show`
 
 ### 将请求中的布尔参数从字符串或布尔值安全转换
 
@@ -4831,6 +5223,16 @@
 - 代码路径: `console/services/virtual_machine.py`
 - 测试路径: `console/tests/virtual_machine_service_test.py::VirtualMachineServiceTests.test_get_vm_profile_falls_back_to_template_root_disk_metadata_when_asset_missing`
 
+### update_check_app 为新建虚拟机根盘使用所选存储类型
+
+- Capability ID: `console.vm-root-disk-selected-storage-type`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app.AppService.update_check_app`
+- 代码路径: `console/services/app.py`
+- 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk`
+
 ### 虚拟机平台异常时禁止创建虚拟机组件
 
 - Capability ID: `console.vm-run.platform-runtime-guard`
@@ -4850,6 +5252,16 @@
 - 业务入口: `console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings`
 - 代码路径: `console/services/app_config/volume_service.py`
 - 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests`
+
+### delete 允许异常状态虚拟机跳过运行中校验
+
+- Capability ID: `console.vm-template-import.delete-abnormal-vm`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.app_actions.app_manage.AppManageService.delete`
+- 代码路径: `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard`
 
 ### Allow deleting restoring VM components
 
@@ -4891,6 +5303,26 @@
 - 代码路径: `console/services/virtual_machine.py`
 - 测试路径: `console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_get_vm_runtime_config_includes_boot_source_format`, `console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_list_vm_disks_falls_back_to_asset_format_for_legacy_iso_vm_without_runtime_hint`
 
+### 虚拟机资产就绪需要 ready 状态与镜像地址
+
+- Capability ID: `rainbond-console.vm-export.asset-ready-storage-status`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready`
+- 代码路径: `console/services/virtual_machine.py`
+- 测试路径: `console/tests/vm_create_flow_regression_test.py`
+
+### resolve_vm_volume_path 为虚拟机热迁移分配唯一磁盘路径
+
+- Capability ID: `rainbond-console.vm-live-migration-unique-disk-path`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.volume_service.AppVolumeService.resolve_vm_volume_path`
+- 代码路径: `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_allocates_unique_disk_suffix_for_duplicate_vm_device_path`, `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_keeps_existing_path_when_editing_same_vm_device_type`
+
 ### 从现有磁盘资产创建虚拟机时复用已就绪运行时镜像
 
 - Capability ID: `rainbond-console.vm-run.disk-asset-create`
@@ -4900,3 +5332,23 @@
 - 业务入口: `console.views.app_create.vm_run.VMRunCreateView.post`
 - 代码路径: `console/views/app_create/vm_run.py`, `console/services/vm_boot_source.py`
 - 测试路径: `console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image`
+
+### resolve_vm_boot_mode 对 Windows ISO 忽略过期资产启动模式
+
+- Capability ID: `rainbond-console.vm-run.vm-export-ignore-stale-boot-mode`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.virtual_machine.VirtualMachineService.resolve_vm_boot_mode`
+- 代码路径: `console/services/virtual_machine.py`
+- 测试路径: `console/tests/vm_create_flow_regression_test.py`
+
+### 虚拟机运行创建支持多磁盘资产实例化
+
+- Capability ID: `rainbond-console.vm-run.vm-export-multi-disk-create`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.app_create.vm_run.VMRunCreateView.post`
+- 代码路径: `console/views/app_create/vm_run.py`
+- 测试路径: `console/tests/vm_asset_instantiation_test.py`

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -8,6 +8,7 @@
 | console.app-backup.custom-volume-guard | 组件使用自定义存储时阻止备份 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupView.post | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_post_rejects_custom_volume_usage |
 | console.app-backup.delete | 删除应用备份 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_delete_removes_group_backup |
 | console.app-backup.delete-id-required | 删除应用备份前必须提供备份 ID | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_delete_requires_backup_id |
+| console.app-backup.delete-in-progress | 备份进行中时阻止删除该备份记录 | active | regression | console.services.backup_service.GroupAppBackupService.delete_group_backup_by_backup_id | console/tests/backup_service_test.py::GroupAppBackupServiceDeleteInProgressTests |
 | console.app-backup.delete-status-lookup-failure | 删除备份时状态查询失败返回错误 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_delete_returns_error_when_status_lookup_fails |
 | console.app-backup.export | 导出应用备份 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupTransferWorkflowTests.test_export_returns_attachment_response |
 | console.app-backup.export-failure | 应用备份导出失败时返回错误 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupExportView.get | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupTransferWorkflowTests.test_export_returns_error_when_service_fails |
@@ -39,19 +40,24 @@
 | console.app-backup.region-app-scope | 按当前 region 应用范围限制备份组件 | active | regression | console.services.backup_service.GroupAppBackupService._get_effective_group_services | console/tests/backup_service_test.py::GroupAppBackupServiceScopeTests |
 | console.app-backup.state-service-guard | 有状态组件未关闭时阻止备份 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupView.post | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_post_rejects_running_stateful_services |
 | console.app-backup.status-sanitize | 隐藏备份状态中的内部服务端信息 | active | regression | console.views.center_pool.groupapp_backup.GroupAppsBackupStatusView.get | console/tests/groupapp_backup_migration_test.py::GroupAppsBackupStatusViewWorkflowTests.test_get_returns_backup_status_list_without_internal_server_info |
+| console.app-backup.version-check | 备份版本与平台版本不一致时阻止恢复 | active | regression | console.services.backup_data_service.PlatformDataBackupServices.version_than | console/tests/backup_data_service_version_than_test.py::VersionThanTests |
 | console.app-config-group.create | 创建应用配置组 | active | regression | console.services.app_config_group.AppConfigGroupService.create_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_create_config_group_creates_remote_and_local_records |
 | console.app-config-group.delete | 删除应用配置组 | active | regression | console.services.app_config_group.AppConfigGroupService.delete_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_delete_config_group_deletes_remote_and_local_records |
 | console.app-config-group.get | 查看应用配置组详情 | active | regression | console.services.app_config_group.AppConfigGroupService.get_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_get_config_group_returns_built_response |
 | console.app-config-group.list | 查询应用配置组列表 | active | regression | console.services.app_config_group.AppConfigGroupService.list_config_groups | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_list_config_groups_returns_items_and_total |
 | console.app-config-group.update | 更新应用配置组 | active | regression | console.services.app_config_group.AppConfigGroupService.update_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_update_config_group_updates_remote_and_local_records |
+| console.app-creator.full-permissions | App creator full permissions | active | regression | console.services.perm_services.UserKindPermService.get_user_perms | console/tests/perm_services_test.py |
 | console.app-export.query-status | 查询应用导出状态 | active | regression | console.services.app_import_and_export_service.AppExportService.get_export_status | console/tests/app_import_and_export_service_test.py::AppExportServiceMetadataTestCase.test_get_export_status_updates_exporting_record_and_wraps_download_url |
 | console.app-import.abandon | 放弃应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.delete | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_delete_abandons_import |
 | console.app-import.create-dir | 创建导入目录 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.post | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_post_creates_import_dir |
 | console.app-import.delete-dir | 删除导入目录 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.delete | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_delete_removes_import_dir |
+| console.app-import.identity-collision | 处理导入应用模板身份冲突 | active | regression | console.services.app_import_and_export_service.AppImportService.__save_enterprise_import_info | console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_when_name_differs<br>console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_keeps_same_key_and_name_as_multiple_versions<br>console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_name_version_when_content_differs |
 | console.app-import.init | 初始化应用导入 | active | regression | console.views.center_pool.app_import.EnterpriseAppImportInitView.post | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_enterprise_import_init_creates_record_when_none_exists |
 | console.app-import.list-dir | 查询导入目录中的应用包 | active | regression | console.views.center_pool.app_import.CenterAppTarballDirView.get | console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_get_lists_imported_packages |
-| console.app-import.query-status | 查询应用导入状态 | active | regression | console.views.center_pool.app_import.CenterAppImportView.get | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status |
+| console.app-import.openapi-query-status | 查询 OpenAPI 应用导入状态 | active | regression | console.services.app_import_and_export_service.AppImportService.openapi_deploy_app_get_import_by_event_id | console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_openapi_deploy_app_get_import_by_event_id_skips_unchanged_status_save |
+| console.app-import.query-status | 查询应用导入状态 | active | regression | console.views.center_pool.app_import.CenterAppImportView.get | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status<br>console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_preserves_database_error_when_transaction_is_broken<br>console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_skips_unchanged_running_status_save<br>console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_saves_partial_success_once |
 | console.app-import.start | 开始应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.post | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_post_starts_app_import |
+| console.app-migrate.port-bind-failure-visible | 端口绑定失败时记录并返回，且不跳过后续端口 | active | regression | console.services.groupapp_recovery.groupapps_migrate.GroupappsMigrateService.__save_port | console/tests/groupapps_migrate_save_port_test.py::SavePortHttpFailureVisibleTest.test_first_port_failure_does_not_skip_second_and_is_reported |
 | console.app-migration.cleanup-group-missing | 清理旧应用时拦截已删除的原组 | active | regression | console.views.center_pool.groupapp_migration.GroupAppsView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsMigrationCleanupTests.test_delete_rejects_missing_original_group |
 | console.app-migration.cleanup-group-required | 清理旧应用前必须提供原组 ID | active | regression | console.views.center_pool.groupapp_migration.GroupAppsView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsMigrationCleanupTests.test_delete_requires_group_id |
 | console.app-migration.cleanup-new-group-required | 清理旧应用前必须提供恢复后的组 ID | active | regression | console.views.center_pool.groupapp_migration.GroupAppsView.delete | console/tests/groupapp_backup_migration_test.py::GroupAppsMigrationCleanupTests.test_delete_requires_new_group_id |
@@ -83,6 +89,7 @@
 | console.app-status.list-closed-with-undeploy-components | 当组件为关闭或未部署时将列表应用状态聚合为关闭 | active | regression | console.services.group_service.GroupService._add_component_status_to_apps | console/tests/group_service_test.py::GroupServiceAppStatusAggregationTests.test_add_component_status_to_apps_marks_closed_when_components_are_closed_or_undeploy |
 | console.app-status.partial-abnormal-mixed-components | 将运行中与异常混合组件识别为部分异常 | active | regression | console.services.topological_services.TopologicalService.get_app_status | console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_mixed_abnormal_components_make_app_partially_abnormal |
 | console.app-status.partial-abnormal-some-abnormal | 将 some_abnormal 组件识别为部分异常 | active | regression | console.services.topological_services.TopologicalService.get_app_status | console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_some_abnormal_component_makes_app_partially_abnormal |
+| console.app-status.region-status-typeddict | 归一化集群应用状态返回（AppStatus TypedDict 落地） | active | regression | console.services.group_service.GroupService.get_app_status | console/tests/group_app_status_typeddict_test.py::GroupAppStatusTypedDictTest |
 | console.app-status.vm-import-building-is-starting | VM import building components keep app starting | active | unit | console.services.topological_services.TopologicalService.get_app_status | console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_building_components_make_app_starting |
 | console.app-status.vm-import-restoring-is-starting | VM import restoring components keep app starting | active | unit | console.services.topological_services.TopologicalService.get_app_status | console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_restoring_components_make_app_starting |
 | console.app-status.waiting-is-starting | 将 waiting 组件识别为应用启动中 | active | regression | console.services.topological_services.TopologicalService.get_app_status | console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_waiting_components_make_app_starting |
@@ -100,13 +107,14 @@
 | console.app-upgrade.rollback-records | App Upgrade Rollback Records | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.rollback-records] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_rollback_records_returns_items |
 | console.app-version.component-diff-details | 生成应用版本组件差异明细 | active | regression | console.services.app_version_service._build_component_diff_details | console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_added_removed_and_field_updates<br>console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_connect_envs_and_other_changes |
 | console.app-version.create-app-from-snapshot | App Version Create App From Snapshot | active | regression | console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_installs_hidden_template_into_new_app |
+| console.app-version.create-app-from-snapshot-invalid-name | 从快照版本创建应用时拒绝非法目标应用名 | active | regression | console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name |
 | console.app-version.create-snapshot | 创建应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotListView.post | console/tests/app_version_test.py::AppVersionSnapshotListViewPostTestCase<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_version_snapshot_calls_app_version_service |
 | console.app-version.delete-rollback-record | 删除应用版本回滚记录 | active | regression | console.views.app_version.AppVersionRollbackRecordDetailView.delete | console/tests/app_version_test.py::AppVersionRollbackRecordViewTestCase.test_delete_removes_rollback_record |
 | console.app-version.delete-snapshot | 删除应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotDetailView.delete | console/tests/app_version_test.py::AppVersionSnapshotDetailViewDeleteTestCase |
 | console.app-version.delete-snapshot-endpoint | 通过接口删除应用版本快照 | active | regression | console.views.app_version.AppVersionSnapshotDetailView.delete | console/tests/app_version_test.py::AppVersionSnapshotDetailViewDeleteTestCase.test_delete_returns_success_response |
 | console.app-version.diff-summary | 汇总应用版本差异 | active | regression | console.services.app_version_service._summarize_diff | console/tests/app_version_test.py::AppVersionServiceDiffSummaryTestCase.test_summarize_diff_keeps_real_component_changes |
 | console.app-version.hidden-template-cleanup | 清理应用版本隐藏模板记录 | active | regression | console.services.market_app.market_app_service.delete_rainbond_app_all_info_by_id | console/tests/app_version_test.py::AppVersionTemplateDeleteTestCase.test_delete_rainbond_app_all_info_by_id_cleans_snapshot_relation |
-| console.app-version.hidden-template-create | 创建应用版本隐藏模板 | active | regression | console.services.app_version_service.get_or_create_hidden_template | console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase.test_get_or_create_hidden_template_creates_hidden_app |
+| console.app-version.hidden-template-create | 创建应用版本隐藏模板 | active | regression | console.services.app_version_service.get_or_create_hidden_template | console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase |
 | console.app-version.overview | 查看应用版本概览 | active | regression | console.services.app_version_service.get_overview | console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_promotes_latest_successful_rollback_target_to_current_version<br>console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_keeps_latest_snapshot_as_current_version_when_newer_than_rollback<br>console/tests/app_version_test.py::AppVersionServiceOverviewTestCase.test_get_overview_promotes_partial_rollback_target_to_current_version<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_version_overview_returns_version_center_overview |
 | console.app-version.restore-builds | 回滚后生成构建任务 | active | regression | console.services.market_app.market_app.MarketApp._generate_builds | console/tests/app_version_test.py::MarketAppBuildGenerationTestCase.test_generate_builds_allows_components_without_source_metadata |
 | console.app-version.restore-component-without-source | 无来源信息时恢复组件 | active | regression | console.services.market_app.app_restore.AppRestore._create_component | console/tests/app_version_test.py::AppRestoreSnapshotCompatibilityTestCase.test_create_component_allows_snapshot_without_service_source |
@@ -131,6 +139,7 @@
 | console.app-version.snapshot-no-change | 无变更时跳过创建快照 | active | regression | console.views.app_version.AppVersionSnapshotListView.post | console/tests/app_version_test.py::AppVersionSnapshotListViewPostTestCase.test_post_returns_no_change_message_when_snapshot_not_created |
 | console.app-version.snapshot-share-image-fallback | App Version Snapshot Share Image Fallback | active | regression | console.services.app_version_service | console/tests/app_version_test.py::AppVersionServiceTemplateNormalizationTestCase.test_assemble_app_template_falls_back_to_image_when_share_image_missing |
 | console.app-version.snapshots | App Version Snapshots | active | regression | console.services.mcp_query_service.call_tool[console.app-version.snapshots] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_list_app_version_snapshots_returns_versions |
+| console.app-version.target-app-name-schema | create_app_from_snapshot_version 工具暴露目标应用名约束 | active | regression | console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints |
 | console.app-version.view-diff | 查看应用版本差异详情 | active | regression | console.services.app_version_service._build_component_diff_details | console/tests/app_version_test.py::AppVersionServiceDiffSummaryTestCase<br>console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase |
 | console.app.batch-component-operation | 批量操作应用组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_operate_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_calls_batch_operations |
 | console.app.check-yaml | 校验 YAML 创建应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_yaml_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_yaml_app_returns_compose_check_info |
@@ -144,6 +153,7 @@
 | console.app.delete | 删除应用及隐藏快照模板 | active | regression | console.services.group_service._delete_app | console/tests/group_service_test.py::GroupServiceDeleteAppTestCase |
 | console.app.delete-confirmation-guard | 阻止无效的应用删除确认 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_rejects_invalid_confirmation_token |
 | console.app.delete-with-confirmation | 确认后删除应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_requires_confirmation_then_delete |
+| console.app.delete-with-resources | 删除应用及其组件与关联资源 | active | unit | console.services.group_service.GroupService.delete_app_with_resources | console/tests/group_service_test.py::GroupServiceDeleteAppWithResourcesTestCase |
 | console.app.detail | 查看应用详情 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_app_detail] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_detail_returns_status_and_counts |
 | console.app.export-metadata | 生成应用导出元数据 | active | regression | console.services.app_import_and_export_service.AppExportService._AppExportService__get_app_metata | console/tests/app_import_and_export_service_test.py::AppExportServiceMetadataTestCase |
 | console.app.get-yaml-check-result | 查看 YAML 应用校验结果 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_yaml_app_check_result] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_yaml_app_check_result_returns_services |
@@ -153,7 +163,9 @@
 | console.app.monitor-range-default-step | 监控区间查询默认步长为 60 秒 | active | regression | console.services.mcp_query_service.query_app_monitor_range | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_range_defaults_step_to_60 |
 | console.app.monitor-summary | 查询应用监控概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_app_monitor] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_returns_monitor_items |
 | console.app.monitor-summary-outer-only | 应用监控概览仅统计对外端口组件 | active | regression | console.services.mcp_query_service.query_app_monitor | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_filters_to_outer_services_when_requested |
+| console.app.restart-component-operation | operate_app 重启映射到批量操作 | active | regression | console.services.mcp_query_service.call_tool[console.app.restart-component-operation] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action |
 | console.app.upgrade | 升级应用版本 | active | regression | console.services.mcp_query_service.call_tool[rainbond_upgrade_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_upgrade_app_calls_upgrade_service_and_returns_latest_items |
+| console.auth.get-user-no-legacy-middleware | 解析会话用户时不访问已废弃的 MIDDLEWARE_CLASSES | active | regression | console.services.auth.get_user | console/tests/auth_get_user_test.py::GetUserNoLegacyMiddlewareTests.test_returns_user_without_touching_middleware_classes<br>console/tests/auth_get_user_test.py::GetUserNoLegacyMiddlewareTests.test_returns_anonymous_user_when_no_session |
 | console.cache.capacity-guard | 内存缓存达到容量上限时拒绝或复用缓存槽位 | active | regression | console.utils.cache.Cache._memory_set | console/tests/utils/cache_test.py::CacheMemoryTests.test_memory_cache_refuses_new_key_when_full_without_expired_entries |
 | console.cache.expired-eviction | 在访问时清理已过期的内存缓存项 | active | regression | console.utils.cache.Cache._memory_get | console/tests/utils/cache_test.py::CacheMemoryTests.test_memory_cache_evicts_expired_entry_on_get |
 | console.cache.expired-eviction-count | 返回清理过期缓存时移除的条目数量 | active | regression | console.utils.cache.Cache._remove_expired_key | console/tests/utils/cache_test.py::CacheMemoryTests.test_remove_expired_key_returns_removed_count |
@@ -180,6 +192,8 @@
 | console.cnb-build.preserve-supported-envs | 保留支持语言的 CNB 环境变量 | active | regression | console.utils.cnb_build.sanitize_build_env_dict_for_language | console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_static_build_envs_preserve_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_common_mirror_fields<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_node_build_envs_preserve_known_node_versions |
 | console.cnb-build.reject-unsupported-language | 拒绝不支持 CNB 的构建语言 | active | regression | console.utils.cnb_build.is_cnb_language | console/tests/cnb_build_test.py::CNBLanguageDetectionTestCase.test_java_language_is_not_cnb<br>console/tests/cnb_build_test.py::CNBLanguageDetectionTestCase.test_dockerfile_node_language_is_not_cnb |
 | console.cnb-build.sanitize-unsupported-envs | 清理非支持语言中的陈旧 CNB 环境变量 | active | regression | console.utils.cnb_build.sanitize_build_env_dict_for_language | console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_stale_cnb_markers<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_runtime_aliases_used_by_builder<br>console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_non_cnb_languages_strip_stale_cnb_markers |
+| console.component-type.daemonset | DaemonSet 组件类型支持 | active | regression | console.enum.component_enum.ComponentType | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported<br>console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset<br>console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition |
+| console.component.autoscaler-invalid-metrics | manage_component_autoscaler 在调用服务前拒绝不完整指标 | active | regression | console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call |
 | console.component.autoscaler-summary | 查看组件伸缩概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_autoscaler] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_summary_returns_rules_and_records |
 | console.component.build | 检测成功后构建组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_component_builds_checked_component |
 | console.component.build-component-schema | Component Build Component Schema | active | regression | console.services.mcp_query_service.call_tool[console.component.build-component-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_build_component_tool_schema_exposes_build_info_guidance |
@@ -187,6 +201,7 @@
 | console.component.build-logs | Component Build Logs | active | regression | console.services.mcp_query_service.call_tool[console.component.build-logs] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_build_logs_returns_event_log_items |
 | console.component.build-source-get | Component Build Source Get | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-get] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_build_source_returns_sanitized_summary |
 | console.component.build-source-update | Component Build Source Update | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-update] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_updates_source_code_fields |
+| console.component.build-source-update-image-cmd | 构建源更新保留/设置镜像启动命令 | active | regression | console.services.mcp_query_service.call_tool[console.component.build-source-update-image-cmd] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_keeps_cmd_when_omitted_on_image_update<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_sets_cmd_and_syncs_docker_cmd |
 | console.component.change-image | 修改组件镜像 | active | regression | console.services.mcp_query_service.call_tool[rainbond_change_component_image] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_change_component_image_updates_service_fields |
 | console.component.check-result | 获取组件构建检测结果 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_check_result] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_check_result_saves_detection_result |
 | console.component.check-start | 启动组件检测 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_component_starts_check_flow |
@@ -200,7 +215,9 @@
 | console.component.create-from-source-generic-git | 通过通用 Git 源码创建组件 | active | regression | console.services.mcp_query_service.create_component_from_source | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_allows_generic_git_code_from |
 | console.component.create-from-source-guided | 通过引导式源码配置创建组件 | active | regression | console.services.mcp_query_service.create_component_from_source | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_calls_aggregated_source_service |
 | console.component.create-from-source-prefer-dockerfile | Component Create From Source Prefer Dockerfile | active | regression | console.services.mcp_query_service.call_tool[console.component.create-from-source-prefer-dockerfile] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_passes_prefer_dockerfile_flag |
+| console.component.default-resource-spec | 组件创建工具暴露默认资源规格指引 | active | regression | console.services.mcp_query_service.list_tools[console.component.default-resource-spec] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance |
 | console.component.delete | 删除组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_delete_component_calls_app_manage_delete |
+| console.component.delete-dependency-conflict | 删除组件返回结构化依赖冲突原因 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict] | console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason<br>console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable |
 | console.component.dependency-add | 添加组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_single_dependency_success<br>console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_single_dependency_requires_open_inner |
 | console.component.dependency-add-batch | 批量添加组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add-batch] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_batch_dependencies_success |
 | console.component.dependency-add-reverse | 添加反向组件依赖 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_dependency#add_reverse] | console/tests/mcp_query_dependency_ops_test.py::MCPQueryDependencyOpsTests.test_add_reverse_dependencies_success |
@@ -215,6 +232,7 @@
 | console.component.env-update | 批量更新组件环境变量 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_envs#upsert] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_envs_upsert_only_uses_inner_envs |
 | console.component.env-upsert-single-item | Component Env Upsert Single Item | active | regression | console.services.mcp_query_service.call_tool[console.component.env-upsert-single-item] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_envs_upsert_accepts_single_item_shape |
 | console.component.events | 查询组件事件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_events] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_events_returns_paginated_events |
+| console.component.extend-method-upsert | 按组件版本覆盖保存伸缩规则配置 | active | regression | console.repositories.app_config.ServiceExtendRepository | console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key |
 | console.component.horizontal-scale | 水平伸缩组件 | active | regression | console.services.mcp_query_service.call_tool[rainbond_horizontal_scale_component] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_horizontal_scale_component_calls_app_manage_service |
 | console.component.list | 查看应用组件列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_components] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_components_uses_existing_service_repo_method |
 | console.component.logs | 查看组件日志 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_logs] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_logs_returns_component_logs |
@@ -226,19 +244,22 @@
 | console.component.operation-aliases | 规范化组件操作别名 | active | regression | console.services.mcp_query_service._normalize_component_operation | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_normalize_component_operation_aliases |
 | console.component.pods | Component Pods | active | regression | console.services.mcp_query_service.call_tool[console.component.pods] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_pods_returns_normalized_runtime_instances |
 | console.component.port-add-invalid-alias | Component Port Add Invalid Alias | active | regression | console.services.mcp_query_service.call_tool[console.component.port-add-invalid-alias] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_add_exposes_structured_alias_validation |
+| console.component.port-batch-add | manage_component_ports 批量新增委托给批量服务 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-add] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service |
+| console.component.port-batch-enable-inner | manage_component_ports 批量开启内网端口只加载一次上下文 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once |
+| console.component.port-batch-enable-outer | manage_component_ports 批量开启外网端口接受整数项 | active | regression | console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items |
 | console.component.port-list | 查询组件端口列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_handle_component_ports#list] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_list_returns_ports |
 | console.component.port-open-inner | 开放组件内网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_inner] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_enable_inner_maps_to_open_inner |
 | console.component.port-open-outer-only | 仅开放组件公网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_outer_only] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_enable_outer_only_maps_to_only_open_outer |
 | console.component.port-open-public | 打开组件公网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_handle_component_ports] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_alias_action_maps_to_standard_action |
 | console.component.port-summary | 查看组件端口概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_summary_delegates_to_port_handler |
+| console.component.port-toggle-events | 记录组件端口开关事件 | active | regression | console.services.app_config.port_service.AppPortService.manage_port | console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path |
 | console.component.probe-summary | 查看组件探针概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_probe] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_probe_summary_returns_probe_snapshot |
 | console.component.storage-create-mount | 创建组件共享存储挂载 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_mnt] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_mnt_batches_mounts |
-| console.component.storage-create-volume | 创建组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume |
+| console.component.storage-create-volume | 创建组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path |
 | console.component.storage-custom-volume-filter | 过滤组件自定义卷列表中的内置卷类型 | active | regression | console.repositories.app_config.TenantServiceVolumnRepository.list_custom_volumes | console/tests/app_config_test.py::TenantServiceVolumnRepositoryTests.test_list_custom_volumes_treats_local_path_as_builtin_volume_type |
-| console.component.extend-method-upsert | 按组件版本覆盖保存伸缩规则配置 | active | regression | console.repositories.app_config.ServiceExtendRepository | console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record<br>console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key |
 | console.component.storage-delete-mount | 删除组件共享存储挂载 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_mnt] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_mnt_removes_relation |
 | console.component.storage-delete-volume | 删除组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#delete_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_volume_requires_force_branch<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_delete_volume_success_branch |
-| console.component.storage-summary | 查看组件存储概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot |
+| console.component.storage-summary | 查看组件存储概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_summary_includes_config_file_volumes |
 | console.component.storage-update-capacity | Component Storage Update Capacity | active | regression | console.views.app_config.app_volume.AppVolumeManageView.put | console/tests/app_volume_view_test.py::AppVolumeManageViewTestCase.test_put_allows_updating_volume_capacity_without_path_change |
 | console.component.storage-update-volume-capacity | Component Storage Update Volume Capacity | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_update_volume_allows_capacity_change_without_path_change |
 | console.component.summary | 查看组件概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_summary] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_summary_returns_aggregated_info |
@@ -247,9 +268,12 @@
 | console.endpoint-address.reject-special-ranges | 拒绝 unspecified 和 loopback 的端点地址 | active | regression | console.utils.validation.validate_endpoint_address | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoint_address_rejects_special_ranges |
 | console.endpoint-list.normalize-scheme-port | 在多端点校验前规范化协议和端口 | active | regression | console.utils.validation.validate_endpoints_info | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_normalizes_scheme_and_port |
 | console.endpoint-list.reject-duplicate | 在多实例端点列表中拒绝重复地址 | active | regression | console.utils.validation.validate_endpoints_info | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses |
+| console.enterprise-config.custom-fields-disabled-bool | get_custom_fields 包含被禁用的布尔字段 | active | regression | console.services.config_service.EnterpriseConfigService.get_custom_fields | console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields |
 | console.enterprise-config.user-context | 解析企业配置服务用户上下文 | active | regression | console.services.config_service.EnterpriseConfigService.__init__ | console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_defaults_user_id_to_none<br>console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_keeps_explicit_user_id |
+| console.enterprise.bind-market-token-decode | 解码云市绑定企业的认证信息 | active | regression | console.views.enterprise_active.BindMarketEnterpriseOptimizAccessTokenView.post | console/tests/bind_market_token_decode_test.py::BindMarketTokenDecodeTest.test_market_info_is_base64_decoded |
 | console.enterprise.region-component-list | 查看集群控制面组件列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_region_rbd_components] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_query_region_rbd_components_returns_components_for_enterprise_admin |
 | console.enterprise.region-create | 创建企业集群 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_region] | console/tests/mcp_query_service_test.py::MCPQueryServiceRegionMutationTests.test_create_region_executes_directly |
+| console.enterprise.region-dashboard-not-found | 集群仪表盘目标缺失时返回 404 | active | regression | console.views.enterprise.EnterpriseRegionDashboard.dispatch | console/tests/enterprise_region_dashboard_notfound_test.py::EnterpriseRegionDashboardNotFoundTest.test_missing_region_returns_clean_404 |
 | console.enterprise.region-delete | 删除企业集群 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_region] | console/tests/mcp_query_service_test.py::MCPQueryServiceRegionMutationTests.test_delete_region_executes_directly |
 | console.enterprise.region-detail | 查看企业集群详情 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_region_detail] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_get_region_detail_returns_region_data |
 | console.enterprise.region-list | 查看企业集群列表 | active | regression | console.services.mcp_query_service.call_tool[rainbond_query_regions] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_query_regions_requires_enterprise_admin<br>console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_query_regions_returns_paginated_regions_for_enterprise_admin<br>console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_query_regions_rejects_cross_enterprise_access_for_enterprise_admin |
@@ -260,6 +284,7 @@
 | console.file-manage.region-request-timeout | 文件管理区域请求使用选定容器与更长超时 | active | regression | www.apiclient.regionapi.RegionInvokeApi.get_files | console/tests/file_manage_service_test.py::test_region_api_get_files_uses_container_name_and_longer_timeout |
 | console.file-manage.selected-container-forwarding | 列出文件管理内容时透传用户选择的容器名 | active | regression | console.services.group_service.GroupService.get_file_and_dir | console/tests/file_manage_service_test.py::test_get_file_and_dir_forwards_selected_container_name |
 | console.gateway.component-env-upsert-schema | Gateway Component Env Upsert Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.component-env-upsert-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance |
+| console.gateway.create-app-invalid-display-name | create_app 对非法应用名返回结构化错误详情 | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name |
 | console.gateway.create-app-k8s-name-schema | Gateway Create App K8s Name Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-k8s-name-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_tool_schema_exposes_k8s_app_constraints |
 | console.gateway.create-http-rule | 创建 HTTP 网关规则 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_http_returns_bound_rule |
 | console.gateway.create-tcp-rule | 创建 TCP 网关规则 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_gateway_rules] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_tcp_returns_bound_rule |
@@ -279,6 +304,7 @@
 | console.gateway.tcp-third-party-guard | 第三方组件不支持 TCP 网关策略时拦截创建 | active | regression | console.services.mcp_query_service.create_gateway_rules[tcp] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_tcp_rejects_invalid_third_party_component |
 | console.gray-release.update-route-query-params | Gray Release Update Route Query Params | active | regression | console.services.gray_release_service.GrayReleaseService.update_route | console/tests/gray_release_service_test.py::GrayReleaseRouteUpdateTests.test_update_apisix_route_weights_keeps_service_alias_and_port_in_query |
 | console.gray-release.update-route-query-uses-original-port | Gray Release Update Route Query Uses Original Port | active | regression | console.services.gray_release_service.GrayReleaseService.update_route | console/tests/gray_release_service_light_test.py::GrayReleaseRouteUpdateLightTests.test_update_route_query_uses_original_service_port_when_ports_differ |
+| console.groupcopy.package-build-guard | 上传软件包组件禁止快速复制 | active | regression | console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata | console/tests/groupcopy_service_test.py::GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build |
 | console.helm-release.delete | 删除 Helm 发布并清理来源记录 | active | regression | console.views.team_resources.HelmReleaseDetailView.delete | console/tests/team_resources_test.py::HelmReleasesViewTestCase |
 | console.helm-release.detail | 查看 Helm 发布详情 | active | regression | console.views.team_resources.HelmReleaseDetailView.get | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_get_enriches_helm_release_detail_with_source_info |
 | console.helm-release.history | 查看 Helm 发布历史 | active | regression | console.views.team_resources.HelmReleaseHistoryView.get | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_get_uses_team_namespace_for_helm_release_history |
@@ -291,17 +317,30 @@
 | console.helm-release.upgrade | 升级 Helm 发布并保存来源记录 | active | regression | console.views.team_resources.HelmReleaseDetailView.put | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_put_persists_upgrade_source_after_success |
 | console.helm.build | 构建 Helm 应用模板 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_helm_app_generates_template |
 | console.helm.check | 检查 Helm 应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result |
+| console.helm.daemonset-template | Helm DaemonSet 资源映射为组件模板 | active | regression | console.services.helm_app_yaml.HelmAppService.generate_template | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type |
+| console.image-webhook.harbor-push-artifact | 解析 Harbor 镜像推送 Webhook | active | regression | console.views.webhook.parse_image_webhook_payload | console/tests/webhook_test.py::ImageWebhookPayloadTestCase |
+| console.image.python36-websocket-client | Console 镜像 Python 3.6 websocket-client 兼容性 | active | regression | requirements.txt | console/tests/dependency_compat_test.py::ConsoleImageDependencyCompatibilityTests |
 | console.image.runner-detect | 根据仓库前缀识别 runner 镜像 | active | regression | console.utils.runner_util.is_runner | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_runner |
 | console.image.slug-detect | 为非 docker 类语言识别基于 runner 的 slug 镜像 | active | regression | console.utils.slug_util.is_slug | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_slug |
 | console.init-cluster.prefer-latest-pending | 初始化时优先选择最新待处理集群 | active | regression | console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated | console/tests/init_cluster_test.py::ClusterRepositoryTests.test_get_rke_cluster_exclude_integrated_prefers_latest_pending_cluster |
 | console.init-cluster.recycle-empty-interconnected | 回收空白联通集群用于重新初始化 | active | regression | console.repositories.init_cluster.Cluster.get_rke_cluster_exclude_integrated | console/tests/init_cluster_test.py::ClusterRepositoryTests.test_get_rke_cluster_exclude_integrated_recycles_blank_cluster |
 | console.k8s-namespace.normalize-user-prefix | 将用户名规范化为合法的 Kubernetes 命名空间名 | active | regression | console.utils.validation.normalize_name_for_k8s_namespace | console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_normalize_name_for_k8s_namespace |
+| console.kubeblocks.app-resource-statistics | KubeBlocks 集群请求携带 app id 以支持资源统计 | active | regression | console.services.kubeblocks_service.KubeBlocksService._build_cluster_request | console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_build_cluster_request_includes_app_id_for_resource_statistics |
+| console.kubeblocks.backup-repo.ready-guard | 使用 KubeBlocks 备份仓库前校验就绪状态 | active | regression | console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo<br>console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message |
+| console.kubeblocks.backup-repo.team-create | 创建团队 KubeBlocks 备份仓库 | active | regression | console.services.kubeblocks_service.KubeBlocksService.create_backup_repo | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_prefixes_namespace_and_does_not_store_secret_values<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_defaults_to_prechecking_when_region_phase_is_empty<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_rejects_existing_region_repo_name_even_if_deleted |
+| console.kubeblocks.backup-repo.team-delete | 删除团队 KubeBlocks 备份仓库 | active | regression | console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use |
+| console.kubeblocks.backup-repo.team-list | 列出团队 KubeBlocks 备份仓库并合并实时状态 | active | regression | console.services.kubeblocks_service.KubeBlocksService.get_team_backup_repos | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_merges_live_status_from_region<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_keeps_failed_live_status<br>console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_marks_missing_when_region_resource_disappears |
+| console.kubeblocks.backup-repo.team-ownership | 校验 KubeBlocks 备份仓库团队归属 | active | regression | console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_belongs_to_team | console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_belongs_to_team_rejects_other_team_repo |
 | console.kubeblocks.cluster-resource-validation | 校验 KubeBlocks 集群资源请求 | active | regression | console.services.kubeblocks_service.KubeBlocksService.validate_cluster_params | console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksClusterValidationTests |
+| console.kubeblocks.create-credential-sync | 创建 KubeBlocks 组件时同步连接凭据 | active | regression | console.services.kubeblocks_service.KubeBlocksService.create_complete_kubeblocks_component | console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests |
 | console.lang-version.proxy-upload | 代理旧版语言包上传接口 | active | regression | console.views.enterprise.UploadLongVersion.post | console/tests/lang_version_proxy_test.py::UploadLongVersionProxyViewTests |
+| console.market-app.create-template-scope-name | 按发布范围和团队检查应用市场模板重名 | active | regression | console.services.market_app_service.MarketAppService.create_rainbond_app | console/tests/market_app_service_test.py::MarketAppServiceCreateRainbondAppTests |
 | console.market-app.install-default-storage-class | 应用市场安装使用平台默认存储类 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_default_volume_type_prefers_configured_storage_class<br>console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class |
+| console.market-app.restore-preserves-volume-capacity-on-storage-fallback | 市场恢复在存储类型回退时保留卷容量 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes |
+| console.market-app.restore-volume-capacity-helper | resolve_market_restore_volume_settings 在存储类型变化时保留容量 | active | regression | console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes |
 | console.market-app.upgrade-share-image-fallback | Market App Upgrade Share Image Fallback | active | regression | console.services.market_app.update_components | console/tests/market_app_update_components_test.py::MarketAppUpdateComponentsCompatibilityTests.test_create_update_components_falls_back_to_image_when_share_image_missing |
 | console.market-app.vm-disk-imports-from-template | 市场应用安装从 VM 模板生成磁盘导入配置 | active | regression | console.services.market_app.new_components.NewComponents._template_to_k8s_attributes | console/tests/market_app_update_components_test.py::MarketAppNewComponentsVMK8sAttrsTests.test_template_to_k8s_attributes_backfills_vm_runtime_attrs_from_vm_block |
-| console.market-app.vm-runtime-status-guard | 虚拟机平台异常时禁止安装虚拟机模板 | active | regression | console.services.market_app_service.MarketAppService.install_app | console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests.test_install_app_rejects_vm_template_when_vm_plugin_not_running |
+| console.market-app.vm-runtime-status-guard | 虚拟机平台异常时禁止安装虚拟机模板 | active | regression | console.services.market_app_service.MarketAppService.install_app | console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests |
 | console.market-client.auth-missing | 将 401 应用市场错误转换为缺少 token 的服务异常 | active | regression | console.utils.restful_client.apiException | console/tests/utils/restful_client_test.py::RestfulClientApiExceptionTests.test_api_exception_401 |
 | console.market-client.bad-request | 将通用 4xx 应用市场错误转换为参数错误响应 | active | regression | console.utils.restful_client.apiException | console/tests/utils/restful_client_test.py::RestfulClientApiExceptionTests.test_api_exception_generic_4xx |
 | console.market-client.default-host | 使用默认回退 host 创建应用市场客户端 | active | regression | console.utils.restful_client.get_market_client | console/tests/utils/restful_client_test.py::RestfulClientFactoryTests.test_get_market_client_uses_default_host |
@@ -316,13 +355,19 @@
 | console.market.install-app-model-cloud | Market Install App Model Cloud | active | regression | console.services.mcp_query_service.call_tool[console.market.install-app-model-cloud] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_install_app_model_for_cloud_calls_market_app_service |
 | console.market.local-app-models | Market Local App Models | active | regression | console.services.mcp_query_service.call_tool[console.market.local-app-models] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_local_app_models_returns_paginated_templates |
 | console.mcp.http-delete-session | 通过 HTTP 关闭 MCP 会话 | active | regression | console.views.mcp_query.MCPQueryHTTPView.delete | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_delete_accepts_valid_session_token |
+| console.mcp.http-expired-jwt | MCP HTTP 接口对过期 JWT 返回 401 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt |
 | console.mcp.http-initialize | 通过 HTTP 初始化 MCP 会话 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_initialize_returns_json_and_session_header |
 | console.mcp.http-tools-list-with-auth | Mcp Http Tools List With Auth | active | regression | console.views.mcp_query.MCPQueryHTTPView | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_tools_list_allows_authenticated_request_without_session_header |
 | console.mcp.http-tools-sse | 通过 HTTP 端点以 SSE 返回工具列表 | active | regression | console.views.mcp_query.MCPQueryHTTPView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_can_return_sse_message_response |
+| console.mcp.input-validation-contract | MCP 工具对缺参/查无组件返回清晰原因 | active | regression | console.services.mcp_query_service.call_tool | console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input<br>console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_unknown_component_returns_not_found |
 | console.mcp.legacy-sse-endpoint | 打开兼容模式的 SSE MCP 端点 | active | regression | console.views.mcp_query.MCPQuerySSEView.get | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_get_returns_endpoint_event_for_legacy_sse_clients |
+| console.mcp.operation-event-ids | MCP operate_app/upgrade_app 返回操作事件 ID | active | unit | console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids] | console/tests/mcp_query_operation_event_ids_test.py |
+| console.mcp.operation-failure-classifier | MCP 操作失败分类器 | active | unit | console.services.mcp_failure_classifier.classify_failure | console/tests/mcp_failure_classifier_test.py |
+| console.mcp.operation-failure-context | MCP 操作失败上下文工具 | active | unit | console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context] | console/tests/mcp_query_failure_context_test.py |
 | console.mcp.post-message | 向 SSE 会话投递 MCP 消息 | active | regression | console.views.mcp_query.MCPQueryMessageView.post | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_post_message_enqueues_initialize_response_on_sse_stream |
 | console.mcp.serialize-nested-sdk-models | MCP 响应中递归序列化嵌套 SDK 模型 | active | regression | console.services.mcp_query_service.MCPQueryService._serialize_model_item | console/tests/mcp_query_service_test.py::MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_recurses_into_dict_values<br>console/tests/mcp_query_service_test.py::MCPQueryServiceSerializeModelItemTests.test_serialize_model_item_handles_object_with_nested_sdk_attribute |
 | console.mcp.structured-tool-error | Mcp Structured Tool Error | active | regression | console.views.mcp_query.MCPQueryHTTPView | console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_tool_error_includes_structured_validation_details |
+| console.mcp.tool-error-fallback | 任意 MCP 工具失败均返回可解析错误 | active | regression | console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc | console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error<br>console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message |
 | console.ns-resource.batch-create | Ns Resource Batch Create | active | regression | console.views.team_resources | console/tests/team_resources_test.py::NsResourceDetailViewTestCase.test_post_preserves_partial_success_status_and_payload |
 | console.ns-resource.update | 通过 YAML 更新命名空间资源 | active | regression | console.views.team_resources.NsResourceDetailView.put | console/tests/team_resources_test.py::NsResourceDetailViewTestCase.test_put_accepts_yaml_media_type_and_forwards_raw_body<br>console/tests/team_resources_test.py::RegionInvokeApiNsResourceTestCase.test_put_tenant_ns_resource_preserves_custom_content_type |
 | console.oauth.instance-create | 创建 OAuth helper 实例并绑定服务与用户上下文 | active | regression | console.utils.oauth.oauth_types.get_oauth_instance | console/tests/utils/oauth_types_test.py::OAuthTypeTests.test_get_oauth_instance |
@@ -348,20 +393,40 @@
 | console.package-upload.init-flow | Package Upload Init Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_init_upload_creates_remote_dir_and_record |
 | console.package-upload.local-package | Package Upload Local Package | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.local-package] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_local_package_calls_upload_tool_service |
 | console.package-upload.local-package-flow | Package Upload Local Package Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_auto_create_component_from_local_path_runs_full_flow |
+| console.package-upload.local-path-create-schema | create_component_from_local_package 工具 schema 暴露服务端本地路径指引 | active | regression | console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance |
+| console.package-upload.local-path-missing-details | _normalize_local_path 在路径缺失时抛出结构化详情 | active | regression | console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing |
+| console.package-upload.local-path-required-details | _normalize_local_path 在路径为空时抛出结构化详情 | active | regression | console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty |
 | console.package-upload.local-path-schema | Package Upload Local Path Schema | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.local-path-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_upload_package_file_tool_schema_exposes_local_path_guidance |
 | console.package-upload.status | Package Upload Status | active | regression | console.services.mcp_query_service.call_tool[console.package-upload.status] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_package_upload_status_delegates_to_upload_tool_service |
 | console.package-upload.status-flow | Package Upload Status Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_get_upload_status_reads_packages_and_updates_record |
 | console.package-upload.upload-flow | Package Upload Upload Flow | active | regression | console.services.package_upload_tool_service | console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_upload_package_uploads_archive_and_returns_status |
 | console.platform-plugin.vm-access-url-fallback | 从前端组件访问地址回填官方虚拟机插件访问前缀 | active | regression | console.services.plugin_service.RainbondPluginService.list_plugins | console/tests/rbd_plugin_service_test.py::RainbondPluginServiceTests.test_official_vm_plugin_uses_frontend_component_access_url_when_region_urls_missing |
 | console.platform-plugin.vm-runtime-status-guard | 校验虚拟机平台插件运行状态 | active | regression | console.services.platform_plugin_service.PlatformPluginService.ensure_vm_plugin_running | console/tests/platform_plugin_service_test.py::PlatformPluginServiceTests.test_ensure_vm_plugin_running_rejects_non_running_status |
+| console.plugin.delete-by-sid | 按组件 ID 删除其全部插件关联 | active | regression | console.repositories.plugin.service_plugin_repo.AppPluginRelationRepo.delete_by_sid | console/tests/service_plugin_repo_delete_by_sid_test.py::DeleteBySidTest.test_delete_by_sid_deletes_matching_relations |
+| console.plugin.downstream-port-config | 下游端口配置从 ORM 模型对象读取目标组件属性 | active | regression | console.services.plugin.app_plugin.AppPluginService.create_plugin_cfg_4marketsvc | console/tests/app_plugin_downstream_port_test.py::CreatePluginCfg4MarketsvcDownstreamPortTest.test_downstream_port_reads_dest_service_attributes |
 | console.pod.detail | Pod Detail | active | regression | console.services.mcp_query_service.call_tool[console.pod.detail] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_pod_detail_returns_runtime_diagnostics |
 | console.pod.detail-kubeblocks | Pod Detail Kubeblocks | active | regression | console.services.mcp_query_service.call_tool[console.pod.detail-kubeblocks] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_pod_detail_uses_kubeblocks_endpoint_for_kubeblocks_component |
 | console.port-inner.env-sync-idempotent | Treat duplicate region env create as idempotent during inner port enable | active | regression | console.services.app_config.env_service.AppEnvVarService.add_service_env_var | console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_updates_region_when_env_already_exists<br>console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_retries_add_when_region_update_reports_record_not_found<br>console/tests/env_service_region_idempotency_test.py::EnvServiceRegionIdempotencyTests.test_add_service_env_var_treats_second_add_conflict_as_success |
 | console.random.default-version | 生成默认随机版本标识 | active | regression | console.utils.randomutil.make_default_version | console/tests/utils/randomutil_test.py::RandomUtilTests.test_make_default_version |
+| console.realtime-proxy.docker-console-subprotocol | Docker 控制台后端使用 webtty 子协议 | active | regression | console.utils.realtime_proxy._backend_websocket_subprotocols | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_backend_uses_webtty_subprotocol |
+| console.realtime-proxy.docker-console-user-activity | Docker 控制台活动跟踪在用户输入时刷新 | active | regression | console.utils.realtime_proxy.DockerConsoleActivityTracker | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_activity_tracker_refreshes_on_user_input |
+| console.realtime-proxy.docker-console-user-idle-timeout | Docker 控制台活动跟踪忽略 webtty 心跳 | active | regression | console.utils.realtime_proxy.DockerConsoleActivityTracker | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_activity_tracker_ignores_webtty_ping |
+| console.realtime-proxy.forward-client-subprotocols | 转发客户端请求的 websocket 子协议 | active | regression | console.utils.realtime_proxy._backend_websocket_subprotocols | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_proxy_keeps_client_requested_subprotocols |
+| console.realtime-proxy.http-forward | 实时代理 HTTP 转发 | active | regression | console.utils.realtime_proxy.proxy_http_request | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service |
+| console.realtime-proxy.internal-target-override | 实时代理内部目标覆盖 | active | regression | console.utils.realtime_proxy.build_region_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region |
+| console.realtime-proxy.multipart-upload-forward | 实时代理重建分片上传请求 | active | regression | console.utils.realtime_proxy.build_multipart_payload | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_rebuilds_multipart_upload_for_app_import |
+| console.realtime-proxy.non-terminal-no-user-idle-timeout | 非终端实时代理不触发用户空闲超时 | active | regression | console.utils.realtime_proxy.DockerConsoleActivityTracker | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_non_docker_console_activity_tracker_never_user_idle_expires |
+| console.realtime-proxy.region-target-url | 实时代理 Region 目标 URL | active | regression | console.utils.realtime_proxy.build_region_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http |
+| console.realtime-proxy.secure-websocket-url | 实时代理安全 WebSocket URL | active | regression | console.utils.realtime_proxy.build_console_realtime_proxy_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https |
+| console.realtime-proxy.upload-url | 实时代理上传 URL | active | regression | console.services.app_import_and_export_service.get_upload_package_url | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path |
+| console.realtime-proxy.websocket-idle-timeout | 后端 websocket 使用短读超时检测空闲 | active | regression | console.utils.realtime_proxy.open_backend_websocket | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_backend_websocket_uses_short_read_timeout_for_idle_checks |
+| console.realtime-proxy.websocket-url | 实时代理 WebSocket URL | active | regression | console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws | console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060 |
 | console.region-api.batch-create-error-bean | Region Api Batch Create Error Bean | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_preserves_batch_create_result_bean_for_coded_errors |
 | console.region-api.domain-conflict-msg | 将上游域名冲突保留为可操作的 409 错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_domain_conflict_as_conflict_error |
 | console.region-api.helm-resource-conflict-msg | 将 Helm 资源归属冲突转换为可操作错误提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_helm_ownership_conflict_to_actionable_msg_show |
 | console.region-api.proxy-error-pass-through | 对非 Helm 冲突保留原始上游错误信息 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_original_message_for_non_helm_conflicts |
+| console.region-api.vm-snapshot-feature-gate-msg | _check_status 将虚拟机快照功能门禁错误翻译为可操作提示 | active | regression | www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status | console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show |
+| console.region.update-region-config | 依据配置项是否存在选择更新或新增数据中心配置 | active | regression | console.services.region_services.RegionService.update_region_config | console/tests/region_config_update_test.py::UpdateRegionConfigTest.test_update_when_config_exists_passes_dict_value<br>console/tests/region_config_update_test.py::UpdateRegionConfigTest.test_add_when_config_missing_passes_json_string_and_desc |
 | console.request-args.bool-coercion | 将请求中的布尔参数从字符串或布尔值安全转换 | active | regression | console.utils.reqparse.bool_argument | console/tests/utils/reqparse_test.py::BoolArgumentTestCase |
 | console.request-args.bool-default-false | 缺失布尔查询参数时返回 false 默认值 | active | regression | console.utils.reqparse.parse_argument | console/tests/utils/reqparse_test.py::ParseArgumentTestCase.test_parse_argument_return_default_false_bool |
 | console.request-args.bool-default-true | 为布尔查询参数使用 true 默认值 | active | unit | console.utils.reqparse.parse_argument | console/tests/utils/reqparse_test.py::ParseArgumentTestCase.test_parse_argument_return_default_bool |
@@ -418,6 +483,7 @@
 | console.source-component.normalize-git-url | 为 Git 地址追加一次子目录参数 | active | regression | console.services.source_component_service.normalize_git_url | console/tests/source_component_service_test.py::SourceComponentServiceTests.test_normalize_git_url_appends_subdirectory_once |
 | console.source-component.prefer-dockerfile | Source Component Prefer Dockerfile | active | regression | console.services.source_component_service | console/tests/source_component_service_test.py::SourceComponentServiceTests.test_auto_create_component_prefers_dockerfile_when_requested |
 | console.source-component.prefer-dockerfile-from-dockerfiles-flag | Source Component Prefer Dockerfile From Dockerfiles Flag | active | regression | console.services.source_component_service | console/tests/source_component_service_test.py::SourceComponentServiceTests.test_auto_create_component_prefers_dockerfile_when_dockerfiles_exist |
+| console.team.create-invalid-namespace | 创建团队时拒绝非法命名空间 | active | regression | console.views.team.AddTeamView.post | console/tests/add_team_namespace_validation_test.py::AddTeamInvalidNamespaceTest.test_invalid_namespace_raises_qualified_name_error_not_typeerror |
 | console.test-manifest.ignore-worktrees | 测试清单校验忽略嵌套 worktree 测试 | active | regression | scripts.validate_test_manifest.collect_marked_tests | scripts/validate_test_manifest_test.py::ValidateTestManifestTests |
 | console.timeutil.current-date-str | 返回默认格式的当前日期字符串 | active | regression | console.utils.timeutil.current_time_to_str | console/tests/utils/timeutil_test.py::TimeUtilTests.test_current_time_to_str |
 | console.timeutil.current-time | 返回当前 datetime 对象 | active | regression | console.utils.timeutil.current_time | console/tests/utils/timeutil_test.py::TimeUtilTests.test_current_time |
@@ -429,7 +495,10 @@
 | console.url.path-legal | 校验路径是否满足 URL 路径合法性规则 | active | regression | console.utils.urlutil.is_path_legal | console/tests/utils/urlutil_test.py::UrlUtilTests.test_is_path_legal |
 | console.url.query-build | 根据基础路径和参数构建 GET URL | active | regression | console.utils.urlutil.set_get_url | console/tests/utils/urlutil_test.py::UrlUtilTests.test_set_get_url |
 | console.url.query-empty | 即使没有查询参数也能构建 GET URL | active | regression | console.utils.urlutil.set_get_url | console/tests/utils/urlutil_test.py::UrlUtilTests.test_set_get_url_with_empty_params |
+| console.user.access-token-delete-log | 删除访问令牌时记录令牌备注 | active | regression | console.views.user_accesstoken.UserAccessTokenRUDView.delete | console/tests/user_accesstoken_delete_log_test.py::UserAccessTokenDeleteLogTest.test_delete_logs_token_note_without_nameerror |
 | console.user.current-profile | 查看当前用户身份信息 | active | regression | console.services.mcp_query_service.get_current_user | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_get_current_user_returns_identity_and_enterprise_admin_flag |
+| console.user.favorite-delete-log | 删除收藏视图时记录收藏名称 | active | regression | console.views.user_operation.UserFavoriteUDView.delete | console/tests/user_favorite_delete_log_test.py::UserFavoriteDeleteLogTest |
+| console.user.get-users-by-ids | 通过用户仓储按用户 ID 列表批量查询用户 | active | regression | console.services.user_services.UserService.get_users_by_user_ids | console/tests/user_services_get_by_ids_test.py::GetUsersByUserIdsTest.test_delegates_to_repo_get_by_user_ids |
 | console.validation.display-name | 校验用户展示名称的中英文数字与连接符规则 | active | regression | console.utils.validation.validate_name | console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_validate_name |
 | console.validation.k8s-qualified-name | 校验 Kubernetes 合法资源名称格式 | active | regression | console.utils.validation.is_qualified_name | console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_is_qualified_name |
 | console.version.compare | 比较语义化风格的版本字符串 | active | regression | console.utils.version.compare_version | console/tests/utils/version_test.py::VersionUtilsTests.test_compare_version |
@@ -441,13 +510,25 @@
 | console.vm-asset.incomplete-service-cleanup-preserves-ready-assets | 删除未完成虚拟机组件时保留已就绪镜像资产 | active | regression | console.services.app_actions.app_manage.AppManageService._truncate_service | console/tests/app_manage_test.py::AppManageIncompleteVMCleanupTests.test_truncate_service_keeps_ready_uploaded_vm_asset |
 | console.vm-overview.vnc-url-plugin-fallback | 在缺少查询参数时从插件回填虚拟机概览 VNC 地址 | active | regression | console.views.app_overview.AppDetailView.get | console/tests/vm_detail_view_test.py::AppVMDetailViewTests.test_get_builds_vm_vnc_url_from_plugin_fallback_when_query_param_missing |
 | console.vm-profile.template-root-disk-fallback | VM profile falls back to template root disk metadata | active | regression | console.services.virtual_machine.VirtualMachineService.get_vm_profile | console/tests/virtual_machine_service_test.py::VirtualMachineServiceTests.test_get_vm_profile_falls_back_to_template_root_disk_metadata_when_asset_missing |
+| console.vm-root-disk-selected-storage-type | update_check_app 为新建虚拟机根盘使用所选存储类型 | active | regression | console.services.app.AppService.update_check_app | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk |
 | console.vm-run.platform-runtime-guard | 虚拟机平台异常时禁止创建虚拟机组件 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_create_rejects_when_vm_plugin_not_running |
 | console.vm-storage-any-access-mode | 允许虚拟机使用任意访问模式的存储 | active | regression | console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests |
+| console.vm-template-import.delete-abnormal-vm | delete 允许异常状态虚拟机跳过运行中校验 | active | regression | console.services.app_actions.app_manage.AppManageService.delete | console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard |
 | console.vm-template-import.delete-restoring-vm | Allow deleting restoring VM components | active | regression | console.services.app_actions.app_manage.AppManageService.delete | console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests |
 | console.vm-template-import.restore-operation-record | VM template import restore operation record exposes progress | active | unit | console.services.app_actions.app_log.AppEventService.build_vm_restore_event | console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_exposes_progress_and_importer_logs<br>console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_marks_success_after_import_finishes |
+| openapi.app-service.team-not-found | 应用关联的团队不存在时返回404错误 | active | regression | openapi.services.app_service.AppService.get_app_services_and_status | console/tests/openapi_app_service_team_not_found_test.py::AppServiceTeamNotFoundTest |
+| openapi.app.create-third-component-deploy-key | OpenAPI 创建第三方 api 组件时生成密钥 | active | regression | openapi.views.apps.apps.CreateThirdComponentView.post | console/tests/openapi_third_component_deploy_repo_test.py::ThirdComponentDeployRepoTest.test_deploy_repo_is_the_singleton_not_the_module |
+| openapi.app.team-apps-close | OpenAPI 关闭团队全部应用 | active | regression | openapi.views.apps.apps.TeamAppsCloseView.post | console/tests/openapi_team_apps_close_test.py::TeamAppsCloseTest.test_post_unpacks_three_return_values_from_batch_action |
+| openapi.base.team-not-initialized-in-region | 团队未在该集群中初始化时返回409错误 | active | regression | openapi.views.base.TeamAPIView.initial | console/tests/openapi_base_team_region_init_test.py::TeamAPIViewRegionInitTest |
+| openapi.enterprise.service-overview | OpenAPI 企业组件状态总览 | active | regression | openapi.views.enterprise_view.ServiceOverview.get | console/tests/openapi_service_overview_import_test.py::ServiceOverviewImportTest.test_service_overview_singleton_is_resolvable |
+| openapi.team.delete-error-propagation | OpenAPI 删除团队时正确透出业务异常 | active | regression | openapi.views.team_view.TeamInfo.delete | console/tests/openapi_team_delete_except_test.py::TeamDeleteExceptTest.test_service_error_propagates_instead_of_typeerror |
 | rainbond-console.vm-disks.container-disk-cdrom | VM disk layout accepts container disk CD-ROM media | active | regression | console.services.virtual_machine.VirtualMachineService.validate_vm_disk_layout | console/tests/vm_create_flow_regression_test.py::VMCreateFlowRegressionUnitTests.test_validate_vm_disk_layout_accepts_container_disk_cdrom<br>console/tests/vm_create_flow_regression_test.py::VMCreateFlowRegressionUnitTests.test_validate_vm_disk_layout_rejects_container_disk_without_image |
 | rainbond-console.vm-disks.iso-installer-compat | 当 VM 运行时提示不完整时仍为 ISO 虚拟机磁盘列表补出安装光盘 | active | regression | console.services.virtual_machine.VirtualMachineService.list_vm_disks | console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_get_vm_runtime_config_includes_boot_source_format<br>console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_list_vm_disks_falls_back_to_asset_format_for_legacy_iso_vm_without_runtime_hint |
+| rainbond-console.vm-export.asset-ready-storage-status | 虚拟机资产就绪需要 ready 状态与镜像地址 | active | regression | console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready | console/tests/vm_create_flow_regression_test.py |
+| rainbond-console.vm-live-migration-unique-disk-path | resolve_vm_volume_path 为虚拟机热迁移分配唯一磁盘路径 | active | regression | console.services.app_config.volume_service.AppVolumeService.resolve_vm_volume_path | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_allocates_unique_disk_suffix_for_duplicate_vm_device_path<br>console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_keeps_existing_path_when_editing_same_vm_device_type |
 | rainbond-console.vm-run.disk-asset-create | 从现有磁盘资产创建虚拟机时复用已就绪运行时镜像 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image |
+| rainbond-console.vm-run.vm-export-ignore-stale-boot-mode | resolve_vm_boot_mode 对 Windows ISO 忽略过期资产启动模式 | active | regression | console.services.virtual_machine.VirtualMachineService.resolve_vm_boot_mode | console/tests/vm_create_flow_regression_test.py |
+| rainbond-console.vm-run.vm-export-multi-disk-create | 虚拟机运行创建支持多磁盘资产实例化 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py |
 
 ## 详情
 
@@ -490,6 +571,16 @@
 - 业务入口: `console.views.center_pool.groupapp_backup.GroupAppsBackupView.delete`
 - 代码路径: `console/views/center_pool/groupapp_backup.py`
 - 测试路径: `console/tests/groupapp_backup_migration_test.py::GroupAppsBackupViewWorkflowTests.test_delete_requires_backup_id`
+
+### 备份进行中时阻止删除该备份记录
+
+- Capability ID: `console.app-backup.delete-in-progress`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.backup_service.GroupAppBackupService.delete_group_backup_by_backup_id`
+- 代码路径: `console/services/backup_service.py`
+- 测试路径: `console/tests/backup_service_test.py::GroupAppBackupServiceDeleteInProgressTests`
 
 ### 删除备份时状态查询失败返回错误
 
@@ -801,6 +892,16 @@
 - 代码路径: `console/views/center_pool/groupapp_backup.py`
 - 测试路径: `console/tests/groupapp_backup_migration_test.py::GroupAppsBackupStatusViewWorkflowTests.test_get_returns_backup_status_list_without_internal_server_info`
 
+### 备份版本与平台版本不一致时阻止恢复
+
+- Capability ID: `console.app-backup.version-check`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.backup_data_service.PlatformDataBackupServices.version_than`
+- 代码路径: `console/services/backup_data_service.py`
+- 测试路径: `console/tests/backup_data_service_version_than_test.py::VersionThanTests`
+
 ### 创建应用配置组
 
 - Capability ID: `console.app-config-group.create`
@@ -851,6 +952,16 @@
 - 代码路径: `console/services/app_config_group.py`, `console/views/app_config_group.py`
 - 测试路径: `console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_update_config_group_updates_remote_and_local_records`
 
+### App creator full permissions
+
+- Capability ID: `console.app-creator.full-permissions`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.perm_services.UserKindPermService.get_user_perms`
+- 代码路径: `console/services/perm_services.py`
+- 测试路径: `console/tests/perm_services_test.py`
+
 ### 查询应用导出状态
 
 - Capability ID: `console.app-export.query-status`
@@ -891,6 +1002,16 @@
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_delete_removes_import_dir`
 
+### 处理导入应用模板身份冲突
+
+- Capability ID: `console.app-import.identity-collision`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.AppImportService.__save_enterprise_import_info`
+- 代码路径: `console/services/app_import_and_export_service.py`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_when_name_differs`, `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_keeps_same_key_and_name_as_multiple_versions`, `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_splits_same_key_name_version_when_content_differs`
+
 ### 初始化应用导入
 
 - Capability ID: `console.app-import.init`
@@ -911,6 +1032,16 @@
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportPreparationWorkflowTestCase.test_tarball_dir_get_lists_imported_packages`
 
+### 查询 OpenAPI 应用导入状态
+
+- Capability ID: `console.app-import.openapi-query-status`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.AppImportService.openapi_deploy_app_get_import_by_event_id`
+- 代码路径: `console/services/app_import_and_export_service.py`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_openapi_deploy_app_get_import_by_event_id_skips_unchanged_status_save`
+
 ### 查询应用导入状态
 
 - Capability ID: `console.app-import.query-status`
@@ -919,7 +1050,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.views.center_pool.app_import.CenterAppImportView.get`
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
-- 测试路径: `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status`
+- 测试路径: `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_returns_import_status`, `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_get_preserves_database_error_when_transaction_is_broken`, `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_skips_unchanged_running_status_save`, `console/tests/app_import_and_export_service_test.py::AppImportStatusUpdateTestCase.test_get_and_update_import_by_event_id_saves_partial_success_once`
 
 ### 开始应用导入
 
@@ -930,6 +1061,16 @@
 - 业务入口: `console.views.center_pool.app_import.CenterAppImportView.post`
 - 代码路径: `console/views/center_pool/app_import.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_post_starts_app_import`
+
+### 端口绑定失败时记录并返回，且不跳过后续端口
+
+- Capability ID: `console.app-migrate.port-bind-failure-visible`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.groupapp_recovery.groupapps_migrate.GroupappsMigrateService.__save_port`
+- 代码路径: `console/services/groupapp_recovery/groupapps_migrate.py`
+- 测试路径: `console/tests/groupapps_migrate_save_port_test.py::SavePortHttpFailureVisibleTest.test_first_port_failure_does_not_skip_second_and_is_reported`
 
 ### 清理旧应用时拦截已删除的原组
 
@@ -1241,6 +1382,16 @@
 - 代码路径: `console/services/topological_services.py`
 - 测试路径: `console/tests/topological_service_test.py::TopologicalServiceAppStatusTests.test_some_abnormal_component_makes_app_partially_abnormal`
 
+### 归一化集群应用状态返回（AppStatus TypedDict 落地）
+
+- Capability ID: `console.app-status.region-status-typeddict`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.group_service.GroupService.get_app_status`
+- 代码路径: `console/services/group_service.py`, `www/apiclient/regionapi.py`, `www/apiclient/region_types.py`
+- 测试路径: `console/tests/group_app_status_typeddict_test.py::GroupAppStatusTypedDictTest`
+
 ### VM import building components keep app starting
 
 - Capability ID: `console.app-status.vm-import-building-is-starting`
@@ -1411,6 +1562,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_installs_hidden_template_into_new_app`
 
+### 从快照版本创建应用时拒绝非法目标应用名
+
+- Capability ID: `console.app-version.create-app-from-snapshot-invalid-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.app-version.create-app-from-snapshot-invalid-name]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name`
+
 ### 创建应用版本快照
 
 - Capability ID: `console.app-version.create-snapshot`
@@ -1479,7 +1640,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.app_version_service.get_or_create_hidden_template`
 - 代码路径: `console/services/app_version_service.py`
-- 测试路径: `console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase.test_get_or_create_hidden_template_creates_hidden_app`
+- 测试路径: `console/tests/app_version_test.py::AppVersionServiceHiddenTemplateTestCase`
 
 ### 查看应用版本概览
 
@@ -1721,6 +1882,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_list_app_version_snapshots_returns_versions`
 
+### create_app_from_snapshot_version 工具暴露目标应用名约束
+
+- Capability ID: `console.app-version.target-app-name-schema`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.app-version.target-app-name-schema]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_from_snapshot_version_tool_exposes_target_app_name_constraints`
+
 ### 查看应用版本差异详情
 
 - Capability ID: `console.app-version.view-diff`
@@ -1851,6 +2022,16 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/group_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_requires_confirmation_then_delete`
 
+### 删除应用及其组件与关联资源
+
+- Capability ID: `console.app.delete-with-resources`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `service_method`
+- 业务入口: `console.services.group_service.GroupService.delete_app_with_resources`
+- 代码路径: `console/services/group_service.py`
+- 测试路径: `console/tests/group_service_test.py::GroupServiceDeleteAppWithResourcesTestCase`
+
 ### 查看应用详情
 
 - Capability ID: `console.app.detail`
@@ -1941,6 +2122,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_monitor_filters_to_outer_services_when_requested`
 
+### operate_app 重启映射到批量操作
+
+- Capability ID: `console.app.restart-component-operation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.app.restart-component-operation]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_operate_app_restart_calls_batch_action`
+
 ### 升级应用版本
 
 - Capability ID: `console.app.upgrade`
@@ -1950,6 +2141,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_upgrade_app]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/upgrade_services.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_upgrade_app_calls_upgrade_service_and_returns_latest_items`
+
+### 解析会话用户时不访问已废弃的 MIDDLEWARE_CLASSES
+
+- Capability ID: `console.auth.get-user-no-legacy-middleware`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.auth.get_user`
+- 代码路径: `console/services/auth/__init__.py`
+- 测试路径: `console/tests/auth_get_user_test.py::GetUserNoLegacyMiddlewareTests.test_returns_user_without_touching_middleware_classes`, `console/tests/auth_get_user_test.py::GetUserNoLegacyMiddlewareTests.test_returns_anonymous_user_when_no_session`
 
 ### 内存缓存达到容量上限时拒绝或复用缓存槽位
 
@@ -2211,6 +2412,26 @@
 - 代码路径: `console/utils/cnb_build.py`
 - 测试路径: `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_stale_cnb_markers`, `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_java_build_envs_strip_runtime_aliases_used_by_builder`, `console/tests/cnb_build_test.py::BuildEnvSanitizeTestCase.test_non_cnb_languages_strip_stale_cnb_markers`
 
+### DaemonSet 组件类型支持
+
+- Capability ID: `console.component-type.daemonset`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.enum.component_enum.ComponentType`
+- 代码路径: `console/enum/component_enum.py`, `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_daemonset_component_type_is_supported`, `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_extend_method_name_supports_daemonset`, `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_change_service_type_blocks_daemonset_transition`
+
+### manage_component_autoscaler 在调用服务前拒绝不完整指标
+
+- Capability ID: `console.component.autoscaler-invalid-metrics`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.autoscaler-invalid-metrics]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_autoscaler_create_rejects_incomplete_metric_before_service_call`
+
 ### 查看组件伸缩概览
 
 - Capability ID: `console.component.autoscaler-summary`
@@ -2280,6 +2501,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[console.component.build-source-update]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_updates_source_code_fields`
+
+### 构建源更新保留/设置镜像启动命令
+
+- Capability ID: `console.component.build-source-update-image-cmd`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.build-source-update-image-cmd]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_keeps_cmd_when_omitted_on_image_update`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_update_component_build_source_sets_cmd_and_syncs_docker_cmd`
 
 ### 修改组件镜像
 
@@ -2411,6 +2642,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_component_from_source_passes_prefer_dockerfile_flag`
 
+### 组件创建工具暴露默认资源规格指引
+
+- Capability ID: `console.component.default-resource-spec`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.component.default-resource-spec]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_component_creation_tools_expose_default_resource_guidance`
+
 ### 删除组件
 
 - Capability ID: `console.component.delete`
@@ -2420,6 +2661,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_delete_component]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_manage.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_delete_component_calls_app_manage_delete`
+
+### 删除组件返回结构化依赖冲突原因
+
+- Capability ID: `console.component.delete-dependency-conflict`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[rainbond_delete_component#conflict]`
+- 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_dependency_conflict_returns_structured_reason`, `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_delete_component_running_conflict_is_non_retryable`
 
 ### 添加组件依赖
 
@@ -2561,6 +2812,16 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_actions/app_log.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_events_returns_paginated_events`
 
+### 按组件版本覆盖保存伸缩规则配置
+
+- Capability ID: `console.component.extend-method-upsert`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.repositories.app_config.ServiceExtendRepository`
+- 代码路径: `console/repositories/app_config.py`
+- 测试路径: `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key`
+
 ### 水平伸缩组件
 
 - Capability ID: `console.component.horizontal-scale`
@@ -2671,6 +2932,36 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_add_exposes_structured_alias_validation`
 
+### manage_component_ports 批量新增委托给批量服务
+
+- Capability ID: `console.component.port-batch-add`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-add]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_add_delegates_to_batch_service`
+
+### manage_component_ports 批量开启内网端口只加载一次上下文
+
+- Capability ID: `console.component.port-batch-enable-inner`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-enable-inner]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_inner_loads_context_once`
+
+### manage_component_ports 批量开启外网端口接受整数项
+
+- Capability ID: `console.component.port-batch-enable-outer`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.component.port-batch-enable-outer]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_batch_enable_outer_accepts_integer_items`
+
 ### 查询组件端口列表
 
 - Capability ID: `console.component.port-list`
@@ -2721,6 +3012,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_summary_delegates_to_port_handler`
 
+### 记录组件端口开关事件
+
+- Capability ID: `console.component.port-toggle-events`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.port_service.AppPortService.manage_port`
+- 代码路径: `console/services/app_config/port_service.py`
+- 测试路径: `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path`
+
 ### 查看组件探针概览
 
 - Capability ID: `console.component.probe-summary`
@@ -2749,7 +3050,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_config/volume_service.py`
-- 测试路径: `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume`
+- 测试路径: `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume`, `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path`
 
 ### 过滤组件自定义卷列表中的内置卷类型
 
@@ -2760,16 +3061,6 @@
 - 业务入口: `console.repositories.app_config.TenantServiceVolumnRepository.list_custom_volumes`
 - 代码路径: `console/repositories/app_config.py`
 - 测试路径: `console/tests/app_config_test.py::TenantServiceVolumnRepositoryTests.test_list_custom_volumes_treats_local_path_as_builtin_volume_type`
-
-### 按组件版本覆盖保存伸缩规则配置
-
-- Capability ID: `console.component.extend-method-upsert`
-- 状态: `active`
-- 测试类型: `regression`
-- 接口类型: `workflow`
-- 业务入口: `console.repositories.app_config.ServiceExtendRepository`
-- 代码路径: `console/repositories/app_config.py`
-- 测试路径: `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_create_extend_method_replaces_existing_version_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_get_extend_method_by_service_uses_latest_record`, `console/tests/app_config_test.py::ServiceExtendRepositoryTests.test_bulk_create_or_update_replaces_existing_version_records_by_business_key`
 
 ### 删除组件共享存储挂载
 
@@ -2799,7 +3090,7 @@
 - 接口类型: `workflow`
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_manage_component_storage]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/app_config/volume_service.py`, `console/services/app_config/mnt_service.py`
-- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_storage_summary_returns_storage_snapshot`, `console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_summary_includes_config_file_volumes`
 
 ### Component Storage Update Capacity
 
@@ -2881,6 +3172,16 @@
 - 代码路径: `console/utils/validation.py`
 - 测试路径: `console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses`
 
+### get_custom_fields 包含被禁用的布尔字段
+
+- Capability ID: `console.enterprise-config.custom-fields-disabled-bool`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.config_service.EnterpriseConfigService.get_custom_fields`
+- 代码路径: `console/services/config_service.py`
+- 测试路径: `console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_get_custom_fields_includes_disabled_bool_fields`
+
 ### 解析企业配置服务用户上下文
 
 - Capability ID: `console.enterprise-config.user-context`
@@ -2890,6 +3191,16 @@
 - 业务入口: `console.services.config_service.EnterpriseConfigService.__init__`
 - 代码路径: `console/services/config_service.py`
 - 测试路径: `console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_defaults_user_id_to_none`, `console/tests/config_service_test.py::EnterpriseConfigServiceTests.test_enterprise_config_service_keeps_explicit_user_id`
+
+### 解码云市绑定企业的认证信息
+
+- Capability ID: `console.enterprise.bind-market-token-decode`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.enterprise_active.BindMarketEnterpriseOptimizAccessTokenView.post`
+- 代码路径: `console/views/enterprise_active.py`
+- 测试路径: `console/tests/bind_market_token_decode_test.py::BindMarketTokenDecodeTest.test_market_info_is_base64_decoded`
 
 ### 查看集群控制面组件列表
 
@@ -2910,6 +3221,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_create_region]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceRegionMutationTests.test_create_region_executes_directly`
+
+### 集群仪表盘目标缺失时返回 404
+
+- Capability ID: `console.enterprise.region-dashboard-not-found`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.enterprise.EnterpriseRegionDashboard.dispatch`
+- 代码路径: `console/views/enterprise.py`
+- 测试路径: `console/tests/enterprise_region_dashboard_notfound_test.py::EnterpriseRegionDashboardNotFoundTest.test_missing_region_returns_clean_404`
 
 ### 删除企业集群
 
@@ -3010,6 +3331,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[console.gateway.component-env-upsert-schema]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance`
+
+### create_app 对非法应用名返回结构化错误详情
+
+- Capability ID: `console.gateway.create-app-invalid-display-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name`
 
 ### Gateway Create App K8s Name Schema
 
@@ -3201,6 +3532,16 @@
 - 代码路径: `console/services/gray_release_service.py`
 - 测试路径: `console/tests/gray_release_service_light_test.py::GrayReleaseRouteUpdateLightTests.test_update_route_query_uses_original_service_port_when_ports_differ`
 
+### 上传软件包组件禁止快速复制
+
+- Capability ID: `console.groupcopy.package-build-guard`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata`
+- 代码路径: `console/services/groupcopy_service.py`
+- 测试路径: `console/tests/groupcopy_service_test.py::GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build`
+
 ### 删除 Helm 发布并清理来源记录
 
 - Capability ID: `console.helm-release.delete`
@@ -3321,6 +3662,36 @@
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/helm_app.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result`
 
+### Helm DaemonSet 资源映射为组件模板
+
+- Capability ID: `console.helm.daemonset-template`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.helm_app_yaml.HelmAppService.generate_template`
+- 代码路径: `console/services/helm_app_yaml.py`
+- 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type`
+
+### 解析 Harbor 镜像推送 Webhook
+
+- Capability ID: `console.image-webhook.harbor-push-artifact`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.webhook.parse_image_webhook_payload`
+- 代码路径: `console/views/webhook.py`
+- 测试路径: `console/tests/webhook_test.py::ImageWebhookPayloadTestCase`
+
+### Console 镜像 Python 3.6 websocket-client 兼容性
+
+- Capability ID: `console.image.python36-websocket-client`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `other`
+- 业务入口: `requirements.txt`
+- 代码路径: `Dockerfile`, `requirements.txt`
+- 测试路径: `console/tests/dependency_compat_test.py::ConsoleImageDependencyCompatibilityTests`
+
 ### 根据仓库前缀识别 runner 镜像
 
 - Capability ID: `console.image.runner-detect`
@@ -3371,6 +3742,66 @@
 - 代码路径: `console/utils/validation.py`
 - 测试路径: `console/tests/utils/validation_test.py::NamespaceNormalizationTests.test_normalize_name_for_k8s_namespace`
 
+### KubeBlocks 集群请求携带 app id 以支持资源统计
+
+- Capability ID: `console.kubeblocks.app-resource-statistics`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService._build_cluster_request`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_build_cluster_request_includes_app_id_for_resource_statistics`
+
+### 使用 KubeBlocks 备份仓库前校验就绪状态
+
+- Capability ID: `console.kubeblocks.backup-repo.ready-guard`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_ready_for_use`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_prechecking_repo`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_accepts_ready_repo`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_ready_for_use_rejects_missing_live_repo`, `console/tests/kubeblocks_cluster_validation_test.py::KubeBlocksCreateFlowTests.test_create_cluster_returns_backup_repo_not_ready_message`
+
+### 创建团队 KubeBlocks 备份仓库
+
+- Capability ID: `console.kubeblocks.backup-repo.team-create`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.create_backup_repo`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_prefixes_namespace_and_does_not_store_secret_values`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_defaults_to_prechecking_when_region_phase_is_empty`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_create_backup_repo_rejects_existing_region_repo_name_even_if_deleted`
+
+### 删除团队 KubeBlocks 备份仓库
+
+- Capability ID: `console.kubeblocks.backup-repo.team-delete`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.delete_backup_repo`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_delete_backup_repo_shows_clear_message_when_in_use`
+
+### 列出团队 KubeBlocks 备份仓库并合并实时状态
+
+- Capability ID: `console.kubeblocks.backup-repo.team-list`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.get_team_backup_repos`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_merges_live_status_from_region`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_keeps_failed_live_status`, `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_list_backup_repos_marks_missing_when_region_resource_disappears`
+
+### 校验 KubeBlocks 备份仓库团队归属
+
+- Capability ID: `console.kubeblocks.backup-repo.team-ownership`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.kubeblocks_service.KubeBlocksService.ensure_backup_repo_belongs_to_team`
+- 代码路径: `console/services/kubeblocks_service.py`
+- 测试路径: `console/tests/kubeblocks_backup_repo_test.py::KubeBlocksBackupRepoServiceTests.test_ensure_backup_repo_belongs_to_team_rejects_other_team_repo`
+
 ### 校验 KubeBlocks 集群资源请求
 
 - Capability ID: `console.kubeblocks.cluster-resource-validation`
@@ -3401,6 +3832,16 @@
 - 代码路径: `console/views/enterprise.py`, `console/urls/__init__.py`
 - 测试路径: `console/tests/lang_version_proxy_test.py::UploadLongVersionProxyViewTests`
 
+### 按发布范围和团队检查应用市场模板重名
+
+- Capability ID: `console.market-app.create-template-scope-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.market_app_service.MarketAppService.create_rainbond_app`
+- 代码路径: `console/services/market_app_service.py`
+- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceCreateRainbondAppTests`
+
 ### 应用市场安装使用平台默认存储类
 
 - Capability ID: `console.market-app.install-default-storage-class`
@@ -3410,6 +3851,26 @@
 - 业务入口: `console.services.market_app.new_components.NewComponents._template_to_volumes`
 - 代码路径: `console/services/app_config/volume_service.py`, `console/services/market_app/new_components.py`, `console/services/market_app_service.py`
 - 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_default_volume_type_prefers_configured_storage_class`, `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class`
+
+### 市场恢复在存储类型回退时保留卷容量
+
+- Capability ID: `console.market-app.restore-preserves-volume-capacity-on-storage-fallback`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.market_app.new_components.NewComponents._template_to_volumes`
+- 代码路径: `console/services/market_app/new_components.py`, `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes`
+
+### resolve_market_restore_volume_settings 在存储类型变化时保留容量
+
+- Capability ID: `console.market-app.restore-volume-capacity-helper`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings`
+- 代码路径: `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes`
 
 ### Market App Upgrade Share Image Fallback
 
@@ -3438,8 +3899,8 @@
 - 测试类型: `regression`
 - 接口类型: `service_method`
 - 业务入口: `console.services.market_app_service.MarketAppService.install_app`
-- 代码路径: `console/services/market_app_service.py`
-- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests.test_install_app_rejects_vm_template_when_vm_plugin_not_running`
+- 代码路径: `console/services/market_app_service.py`, `console/services/app_version_service.py`
+- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceVMGuardTests`
 
 ### 将 401 应用市场错误转换为缺少 token 的服务异常
 
@@ -3581,6 +4042,16 @@
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_delete_accepts_valid_session_token`
 
+### MCP HTTP 接口对过期 JWT 返回 401
+
+- Capability ID: `console.mcp.http-expired-jwt`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.mcp_query.MCPQueryHTTPView.post`
+- 代码路径: `console/views/mcp_query.py`
+- 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_returns_401_for_expired_jwt`
+
 ### 通过 HTTP 初始化 MCP 会话
 
 - Capability ID: `console.mcp.http-initialize`
@@ -3611,6 +4082,16 @@
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_post_can_return_sse_message_response`
 
+### MCP 工具对缺参/查无组件返回清晰原因
+
+- Capability ID: `console.mcp.input-validation-contract`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.mcp_query_service.call_tool`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_missing_service_id_returns_invalid_input`, `console/tests/mcp_query_error_contract_test.py::MCPComponentContextErrorTests.test_unknown_component_returns_not_found`
+
 ### 打开兼容模式的 SSE MCP 端点
 
 - Capability ID: `console.mcp.legacy-sse-endpoint`
@@ -3620,6 +4101,36 @@
 - 业务入口: `console.views.mcp_query.MCPQuerySSEView.get`
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_get_returns_endpoint_event_for_legacy_sse_clients`
+
+### MCP operate_app/upgrade_app 返回操作事件 ID
+
+- Capability ID: `console.mcp.operation-event-ids`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.mcp.operation-event-ids]`
+- 代码路径: `console/services/mcp_query_service.py`, `console/services/upgrade_services.py`
+- 测试路径: `console/tests/mcp_query_operation_event_ids_test.py`
+
+### MCP 操作失败分类器
+
+- Capability ID: `console.mcp.operation-failure-classifier`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `package_function`
+- 业务入口: `console.services.mcp_failure_classifier.classify_failure`
+- 代码路径: `console/services/mcp_failure_classifier.py`
+- 测试路径: `console/tests/mcp_failure_classifier_test.py`
+
+### MCP 操作失败上下文工具
+
+- Capability ID: `console.mcp.operation-failure-context`
+- 状态: `active`
+- 测试类型: `unit`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.mcp.operation-failure-context]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_failure_context_test.py`
 
 ### 向 SSE 会话投递 MCP 消息
 
@@ -3650,6 +4161,16 @@
 - 业务入口: `console.views.mcp_query.MCPQueryHTTPView`
 - 代码路径: `console/views/mcp_query.py`
 - 测试路径: `console/tests/mcp_query_view_test.py::MCPQuerySSEViewTests.test_http_tool_error_includes_structured_validation_details`
+
+### 任意 MCP 工具失败均返回可解析错误
+
+- Capability ID: `console.mcp.tool-error-fallback`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.mcp_query.MCPQueryRPCMixin._dispatch_rpc`
+- 代码路径: `console/views/mcp_query.py`
+- 测试路径: `console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_generic_tool_exception_is_returned_as_parseable_error`, `console/tests/mcp_query_error_contract_test.py::MCPToolErrorDispatchTests.test_region_style_exception_maps_status_and_extracts_message`
 
 ### Ns Resource Batch Create
 
@@ -3901,6 +4422,36 @@
 - 代码路径: `console/services/package_upload_tool_service.py`
 - 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_auto_create_component_from_local_path_runs_full_flow`
 
+### create_component_from_local_package 工具 schema 暴露服务端本地路径指引
+
+- Capability ID: `console.package-upload.local-path-create-schema`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.list_tools[console.package-upload.local-path-create-schema]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_component_from_local_package_tool_schema_exposes_server_side_local_path_guidance`
+
+### _normalize_local_path 在路径缺失时抛出结构化详情
+
+- Capability ID: `console.package-upload.local-path-missing-details`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path`
+- 代码路径: `console/services/package_upload_tool_service.py`
+- 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_missing`
+
+### _normalize_local_path 在路径为空时抛出结构化详情
+
+- Capability ID: `console.package-upload.local-path-required-details`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.package_upload_tool_service.PackageUploadToolService._normalize_local_path`
+- 代码路径: `console/services/package_upload_tool_service.py`
+- 测试路径: `console/tests/package_upload_tool_service_test.py::PackageUploadToolServiceTests.test_normalize_local_path_raises_structured_details_when_path_empty`
+
 ### Package Upload Local Path Schema
 
 - Capability ID: `console.package-upload.local-path-schema`
@@ -3961,6 +4512,26 @@
 - 代码路径: `console/services/platform_plugin_service.py`
 - 测试路径: `console/tests/platform_plugin_service_test.py::PlatformPluginServiceTests.test_ensure_vm_plugin_running_rejects_non_running_status`
 
+### 按组件 ID 删除其全部插件关联
+
+- Capability ID: `console.plugin.delete-by-sid`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `dao_method`
+- 业务入口: `console.repositories.plugin.service_plugin_repo.AppPluginRelationRepo.delete_by_sid`
+- 代码路径: `console/repositories/plugin/service_plugin_repo.py`
+- 测试路径: `console/tests/service_plugin_repo_delete_by_sid_test.py::DeleteBySidTest.test_delete_by_sid_deletes_matching_relations`
+
+### 下游端口配置从 ORM 模型对象读取目标组件属性
+
+- Capability ID: `console.plugin.downstream-port-config`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.plugin.app_plugin.AppPluginService.create_plugin_cfg_4marketsvc`
+- 代码路径: `console/services/plugin/app_plugin.py`
+- 测试路径: `console/tests/app_plugin_downstream_port_test.py::CreatePluginCfg4MarketsvcDownstreamPortTest.test_downstream_port_reads_dest_service_attributes`
+
 ### Pod Detail
 
 - Capability ID: `console.pod.detail`
@@ -4001,6 +4572,136 @@
 - 代码路径: `console/utils/randomutil.py`
 - 测试路径: `console/tests/utils/randomutil_test.py::RandomUtilTests.test_make_default_version`
 
+### Docker 控制台后端使用 webtty 子协议
+
+- Capability ID: `console.realtime-proxy.docker-console-subprotocol`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy._backend_websocket_subprotocols`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_backend_uses_webtty_subprotocol`
+
+### Docker 控制台活动跟踪在用户输入时刷新
+
+- Capability ID: `console.realtime-proxy.docker-console-user-activity`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.DockerConsoleActivityTracker`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_activity_tracker_refreshes_on_user_input`
+
+### Docker 控制台活动跟踪忽略 webtty 心跳
+
+- Capability ID: `console.realtime-proxy.docker-console-user-idle-timeout`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.DockerConsoleActivityTracker`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_docker_console_activity_tracker_ignores_webtty_ping`
+
+### 转发客户端请求的 websocket 子协议
+
+- Capability ID: `console.realtime-proxy.forward-client-subprotocols`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy._backend_websocket_subprotocols`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_proxy_keeps_client_requested_subprotocols`
+
+### 实时代理 HTTP 转发
+
+- Capability ID: `console.realtime-proxy.http-forward`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.proxy_http_request`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_forwards_upload_request_to_region_websocket_service`
+
+### 实时代理内部目标覆盖
+
+- Capability ID: `console.realtime-proxy.internal-target-override`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_region_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_prefers_internal_override_for_builtin_region`
+
+### 实时代理重建分片上传请求
+
+- Capability ID: `console.realtime-proxy.multipart-upload-forward`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_multipart_payload`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_http_proxy_rebuilds_multipart_upload_for_app_import`
+
+### 非终端实时代理不触发用户空闲超时
+
+- Capability ID: `console.realtime-proxy.non-terminal-no-user-idle-timeout`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.DockerConsoleActivityTracker`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_non_docker_console_activity_tracker_never_user_idle_expires`
+
+### 实时代理 Region 目标 URL
+
+- Capability ID: `console.realtime-proxy.region-target-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_region_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_region_proxy_target_keeps_region_websocket_host_for_http`
+
+### 实时代理安全 WebSocket URL
+
+- Capability ID: `console.realtime-proxy.secure-websocket-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.build_console_realtime_proxy_url`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_console_proxy_url_uses_wss_when_request_is_https`
+
+### 实时代理上传 URL
+
+- Capability ID: `console.realtime-proxy.upload-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_import_and_export_service.get_upload_package_url`
+- 代码路径: `console/services/app_import_and_export_service.py`, `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_upload_package_url_returns_console_proxy_path`
+
+### 后端 websocket 使用短读超时检测空闲
+
+- Capability ID: `console.realtime-proxy.websocket-idle-timeout`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `console.utils.realtime_proxy.open_backend_websocket`
+- 代码路径: `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_backend_websocket_uses_short_read_timeout_for_idle_checks`
+
+### 实时代理 WebSocket URL
+
+- Capability ID: `console.realtime-proxy.websocket-url`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_actions.app_log.AppWebSocketService.get_event_log_ws`
+- 代码路径: `console/services/app_actions/app_log.py`, `console/utils/realtime_proxy.py`
+- 测试路径: `console/tests/realtime_proxy_url_test.py::RealtimeProxyUrlTests.test_websocket_service_returns_console_proxy_url_without_6060`
+
 ### Region Api Batch Create Error Bean
 
 - Capability ID: `console.region-api.batch-create-error-bean`
@@ -4040,6 +4741,26 @@
 - 业务入口: `www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status`
 - 代码路径: `www/apiclient/regionapibaseclient.py`
 - 测试路径: `console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_keeps_original_message_for_non_helm_conflicts`
+
+### _check_status 将虚拟机快照功能门禁错误翻译为可操作提示
+
+- Capability ID: `console.region-api.vm-snapshot-feature-gate-msg`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status`
+- 代码路径: `www/apiclient/regionapibaseclient.py`
+- 测试路径: `console/tests/regionapibaseclient_test.py::RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show`
+
+### 依据配置项是否存在选择更新或新增数据中心配置
+
+- Capability ID: `console.region.update-region-config`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.region_services.RegionService.update_region_config`
+- 代码路径: `console/services/region_services.py`
+- 测试路径: `console/tests/region_config_update_test.py::UpdateRegionConfigTest.test_update_when_config_exists_passes_dict_value`, `console/tests/region_config_update_test.py::UpdateRegionConfigTest.test_add_when_config_missing_passes_json_string_and_desc`
 
 ### 将请求中的布尔参数从字符串或布尔值安全转换
 
@@ -4601,6 +5322,16 @@
 - 代码路径: `console/services/source_component_service.py`
 - 测试路径: `console/tests/source_component_service_test.py::SourceComponentServiceTests.test_auto_create_component_prefers_dockerfile_when_dockerfiles_exist`
 
+### 创建团队时拒绝非法命名空间
+
+- Capability ID: `console.team.create-invalid-namespace`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.team.AddTeamView.post`
+- 代码路径: `console/views/team.py`
+- 测试路径: `console/tests/add_team_namespace_validation_test.py::AddTeamInvalidNamespaceTest.test_invalid_namespace_raises_qualified_name_error_not_typeerror`
+
 ### 测试清单校验忽略嵌套 worktree 测试
 
 - Capability ID: `console.test-manifest.ignore-worktrees`
@@ -4711,6 +5442,16 @@
 - 代码路径: `console/utils/urlutil.py`
 - 测试路径: `console/tests/utils/urlutil_test.py::UrlUtilTests.test_set_get_url_with_empty_params`
 
+### 删除访问令牌时记录令牌备注
+
+- Capability ID: `console.user.access-token-delete-log`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.user_accesstoken.UserAccessTokenRUDView.delete`
+- 代码路径: `console/views/user_accesstoken.py`
+- 测试路径: `console/tests/user_accesstoken_delete_log_test.py::UserAccessTokenDeleteLogTest.test_delete_logs_token_note_without_nameerror`
+
 ### 查看当前用户身份信息
 
 - Capability ID: `console.user.current-profile`
@@ -4720,6 +5461,26 @@
 - 业务入口: `console.services.mcp_query_service.get_current_user`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_get_current_user_returns_identity_and_enterprise_admin_flag`
+
+### 删除收藏视图时记录收藏名称
+
+- Capability ID: `console.user.favorite-delete-log`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.user_operation.UserFavoriteUDView.delete`
+- 代码路径: `console/views/user_operation.py`
+- 测试路径: `console/tests/user_favorite_delete_log_test.py::UserFavoriteDeleteLogTest`
+
+### 通过用户仓储按用户 ID 列表批量查询用户
+
+- Capability ID: `console.user.get-users-by-ids`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.user_services.UserService.get_users_by_user_ids`
+- 代码路径: `console/services/user_services.py`, `console/repositories/user_repo.py`
+- 测试路径: `console/tests/user_services_get_by_ids_test.py::GetUsersByUserIdsTest.test_delegates_to_repo_get_by_user_ids`
 
 ### 校验用户展示名称的中英文数字与连接符规则
 
@@ -4831,6 +5592,16 @@
 - 代码路径: `console/services/virtual_machine.py`
 - 测试路径: `console/tests/virtual_machine_service_test.py::VirtualMachineServiceTests.test_get_vm_profile_falls_back_to_template_root_disk_metadata_when_asset_missing`
 
+### update_check_app 为新建虚拟机根盘使用所选存储类型
+
+- Capability ID: `console.vm-root-disk-selected-storage-type`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app.AppService.update_check_app`
+- 代码路径: `console/services/app.py`
+- 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk`
+
 ### 虚拟机平台异常时禁止创建虚拟机组件
 
 - Capability ID: `console.vm-run.platform-runtime-guard`
@@ -4850,6 +5621,16 @@
 - 业务入口: `console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings`
 - 代码路径: `console/services/app_config/volume_service.py`
 - 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests`
+
+### delete 允许异常状态虚拟机跳过运行中校验
+
+- Capability ID: `console.vm-template-import.delete-abnormal-vm`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.app_actions.app_manage.AppManageService.delete`
+- 代码路径: `console/services/app_actions/app_manage.py`
+- 测试路径: `console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard`
 
 ### Allow deleting restoring VM components
 
@@ -4871,6 +5652,66 @@
 - 代码路径: `console/services/app_actions/app_log.py`, `console/services/app.py`, `console/views/app_event.py`
 - 测试路径: `console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_exposes_progress_and_importer_logs`, `console/tests/vm_profile_runtime_status_test.py::VMRestoreEventTests.test_build_vm_restore_event_marks_success_after_import_finishes`
 
+### 应用关联的团队不存在时返回404错误
+
+- Capability ID: `openapi.app-service.team-not-found`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `openapi.services.app_service.AppService.get_app_services_and_status`
+- 代码路径: `openapi/services/app_service.py`
+- 测试路径: `console/tests/openapi_app_service_team_not_found_test.py::AppServiceTeamNotFoundTest`
+
+### OpenAPI 创建第三方 api 组件时生成密钥
+
+- Capability ID: `openapi.app.create-third-component-deploy-key`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `openapi.views.apps.apps.CreateThirdComponentView.post`
+- 代码路径: `openapi/views/apps/apps.py`, `console/repositories/deploy_repo.py`
+- 测试路径: `console/tests/openapi_third_component_deploy_repo_test.py::ThirdComponentDeployRepoTest.test_deploy_repo_is_the_singleton_not_the_module`
+
+### OpenAPI 关闭团队全部应用
+
+- Capability ID: `openapi.app.team-apps-close`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `openapi.views.apps.apps.TeamAppsCloseView.post`
+- 代码路径: `openapi/views/apps/apps.py`
+- 测试路径: `console/tests/openapi_team_apps_close_test.py::TeamAppsCloseTest.test_post_unpacks_three_return_values_from_batch_action`
+
+### 团队未在该集群中初始化时返回409错误
+
+- Capability ID: `openapi.base.team-not-initialized-in-region`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `openapi.views.base.TeamAPIView.initial`
+- 代码路径: `openapi/views/base.py`, `openapi/views/exceptions.py`
+- 测试路径: `console/tests/openapi_base_team_region_init_test.py::TeamAPIViewRegionInitTest`
+
+### OpenAPI 企业组件状态总览
+
+- Capability ID: `openapi.enterprise.service-overview`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `openapi.views.enterprise_view.ServiceOverview.get`
+- 代码路径: `openapi/views/enterprise_view.py`, `console/services/service_overview.py`
+- 测试路径: `console/tests/openapi_service_overview_import_test.py::ServiceOverviewImportTest.test_service_overview_singleton_is_resolvable`
+
+### OpenAPI 删除团队时正确透出业务异常
+
+- Capability ID: `openapi.team.delete-error-propagation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `openapi.views.team_view.TeamInfo.delete`
+- 代码路径: `openapi/views/team_view.py`
+- 测试路径: `console/tests/openapi_team_delete_except_test.py::TeamDeleteExceptTest.test_service_error_propagates_instead_of_typeerror`
+
 ### VM disk layout accepts container disk CD-ROM media
 
 - Capability ID: `rainbond-console.vm-disks.container-disk-cdrom`
@@ -4891,6 +5732,26 @@
 - 代码路径: `console/services/virtual_machine.py`
 - 测试路径: `console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_get_vm_runtime_config_includes_boot_source_format`, `console/tests/vm_disk_installer_compat_test.py::VMInstallerMediaCompatUnitTests.test_list_vm_disks_falls_back_to_asset_format_for_legacy_iso_vm_without_runtime_hint`
 
+### 虚拟机资产就绪需要 ready 状态与镜像地址
+
+- Capability ID: `rainbond-console.vm-export.asset-ready-storage-status`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.virtual_machine.VirtualMachineService.is_vm_asset_ready`
+- 代码路径: `console/services/virtual_machine.py`
+- 测试路径: `console/tests/vm_create_flow_regression_test.py`
+
+### resolve_vm_volume_path 为虚拟机热迁移分配唯一磁盘路径
+
+- Capability ID: `rainbond-console.vm-live-migration-unique-disk-path`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.volume_service.AppVolumeService.resolve_vm_volume_path`
+- 代码路径: `console/services/app_config/volume_service.py`
+- 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_allocates_unique_disk_suffix_for_duplicate_vm_device_path`, `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_resolve_vm_volume_path_keeps_existing_path_when_editing_same_vm_device_type`
+
 ### 从现有磁盘资产创建虚拟机时复用已就绪运行时镜像
 
 - Capability ID: `rainbond-console.vm-run.disk-asset-create`
@@ -4900,3 +5761,23 @@
 - 业务入口: `console.views.app_create.vm_run.VMRunCreateView.post`
 - 代码路径: `console/views/app_create/vm_run.py`, `console/services/vm_boot_source.py`
 - 测试路径: `console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests::test_vm_run_create_from_existing_disk_asset_reuses_ready_runtime_image`
+
+### resolve_vm_boot_mode 对 Windows ISO 忽略过期资产启动模式
+
+- Capability ID: `rainbond-console.vm-run.vm-export-ignore-stale-boot-mode`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.virtual_machine.VirtualMachineService.resolve_vm_boot_mode`
+- 代码路径: `console/services/virtual_machine.py`
+- 测试路径: `console/tests/vm_create_flow_regression_test.py`
+
+### 虚拟机运行创建支持多磁盘资产实例化
+
+- Capability ID: `rainbond-console.vm-run.vm-export-multi-disk-create`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.app_create.vm_run.VMRunCreateView.post`
+- 代码路径: `console/views/app_create/vm_run.py`
+- 测试路径: `console/tests/vm_asset_instantiation_test.py`

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -295,6 +295,7 @@
 | console.gateway.tcp-third-party-guard | 第三方组件不支持 TCP 网关策略时拦截创建 | active | regression | console.services.mcp_query_service.create_gateway_rules[tcp] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_gateway_rules_tcp_rejects_invalid_third_party_component |
 | console.gray-release.update-route-query-params | Gray Release Update Route Query Params | active | regression | console.services.gray_release_service.GrayReleaseService.update_route | console/tests/gray_release_service_test.py::GrayReleaseRouteUpdateTests.test_update_apisix_route_weights_keeps_service_alias_and_port_in_query |
 | console.gray-release.update-route-query-uses-original-port | Gray Release Update Route Query Uses Original Port | active | regression | console.services.gray_release_service.GrayReleaseService.update_route | console/tests/gray_release_service_light_test.py::GrayReleaseRouteUpdateLightTests.test_update_route_query_uses_original_service_port_when_ports_differ |
+| console.groupcopy.package-build-guard | 上传软件包组件禁止快速复制 | active | regression | console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata | console/tests/groupcopy_service_test.py::GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build |
 | console.helm-release.delete | 删除 Helm 发布并清理来源记录 | active | regression | console.views.team_resources.HelmReleaseDetailView.delete | console/tests/team_resources_test.py::HelmReleasesViewTestCase |
 | console.helm-release.detail | 查看 Helm 发布详情 | active | regression | console.views.team_resources.HelmReleaseDetailView.get | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_get_enriches_helm_release_detail_with_source_info |
 | console.helm-release.history | 查看 Helm 发布历史 | active | regression | console.views.team_resources.HelmReleaseHistoryView.get | console/tests/team_resources_test.py::HelmReleasesViewTestCase.test_get_uses_team_namespace_for_helm_release_history |
@@ -3402,6 +3403,16 @@
 - 业务入口: `console.services.gray_release_service.GrayReleaseService.update_route`
 - 代码路径: `console/services/gray_release_service.py`
 - 测试路径: `console/tests/gray_release_service_light_test.py::GrayReleaseRouteUpdateLightTests.test_update_route_query_uses_original_service_port_when_ports_differ`
+
+### 上传软件包组件禁止快速复制
+
+- Capability ID: `console.groupcopy.package-build-guard`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.groupcopy_service.GroupAppCopyService.get_modify_group_metadata`
+- 代码路径: `console/services/groupcopy_service.py`
+- 测试路径: `console/tests/groupcopy_service_test.py::GroupAppCopyServiceTests.test_get_modify_group_metadata_rejects_package_build`
 
 ### 删除 Helm 发布并清理来源记录
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -247,6 +247,7 @@
 | console.component.port-open-outer-only | 仅开放组件公网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports#enable_outer_only] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_enable_outer_only_maps_to_only_open_outer |
 | console.component.port-open-public | 打开组件公网端口 | active | regression | console.services.mcp_query_service.call_tool[rainbond_handle_component_ports] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_handle_component_ports_alias_action_maps_to_standard_action |
 | console.component.port-summary | 查看组件端口概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_ports] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_summary_delegates_to_port_handler |
+| console.component.port-toggle-events | 记录组件端口开关事件 | active | regression | console.services.app_config.port_service.AppPortService.manage_port | console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path |
 | console.component.probe-summary | 查看组件探针概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_probe] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_probe_summary_returns_probe_snapshot |
 | console.component.storage-create-mount | 创建组件共享存储挂载 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_mnt] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_mnt_batches_mounts |
 | console.component.storage-create-volume | 创建组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#create_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_returns_created_and_volume<br>console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_create_volume_rejects_collision_with_existing_config_file_path |
@@ -2932,6 +2933,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_manage_component_ports]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_manage_component_ports_summary_delegates_to_port_handler`
+
+### 记录组件端口开关事件
+
+- Capability ID: `console.component.port-toggle-events`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.port_service.AppPortService.manage_port`
+- 代码路径: `console/services/app_config/port_service.py`
+- 测试路径: `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_open_outer_port_synchronizes_region_component_event`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_outer_port_synchronizes_region_component_event`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_inner_port_toggle_keeps_region_component_event_path`
 
 ### 查看组件探针概览
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -310,6 +310,7 @@
 | console.helm.build | 构建 Helm 应用模板 | active | regression | console.services.mcp_query_service.call_tool[rainbond_build_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_build_helm_app_generates_template |
 | console.helm.check | 检查 Helm 应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_check_helm_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_check_helm_app_returns_check_result |
 | console.helm.daemonset-template | Helm DaemonSet 资源映射为组件模板 | active | regression | console.services.helm_app_yaml.HelmAppService.generate_template | console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type |
+| console.image-webhook.harbor-push-artifact | 解析 Harbor 镜像推送 Webhook | active | regression | console.views.webhook.parse_image_webhook_payload | console/tests/webhook_test.py::ImageWebhookPayloadTestCase |
 | console.image.python36-websocket-client | Console 镜像 Python 3.6 websocket-client 兼容性 | active | regression | requirements.txt | console/tests/dependency_compat_test.py::ConsoleImageDependencyCompatibilityTests |
 | console.image.runner-detect | 根据仓库前缀识别 runner 镜像 | active | regression | console.utils.runner_util.is_runner | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_runner |
 | console.image.slug-detect | 为非 docker 类语言识别基于 runner 的 slug 镜像 | active | regression | console.utils.slug_util.is_slug | console/tests/utils/image_classify_test.py::ImageClassifyTests.test_is_slug |
@@ -3561,6 +3562,16 @@
 - 业务入口: `console.services.helm_app_yaml.HelmAppService.generate_template`
 - 代码路径: `console/services/helm_app_yaml.py`
 - 测试路径: `console/tests/app_manage_test.py::ComponentDaemonSetSupportTests.test_helm_template_maps_daemonset_resource_type`
+
+### 解析 Harbor 镜像推送 Webhook
+
+- Capability ID: `console.image-webhook.harbor-push-artifact`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.webhook.parse_image_webhook_payload`
+- 代码路径: `console/views/webhook.py`
+- 测试路径: `console/tests/webhook_test.py::ImageWebhookPayloadTestCase`
 
 ### Console 镜像 Python 3.6 websocket-client 兼容性
 

--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+from urllib.parse import quote
 
 import httplib2
 import urllib3
@@ -1131,10 +1132,10 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
         res, body = self._put(url, self.default_headers, json.dumps(body), region=region)
         return body
 
-    def delete_gateway_http_route(self, region, tenant_name, namespace, name, region_app_id):
+    def delete_gateway_http_route(self, region, tenant_name, namespace, name, region_app_id, operator=""):
         url, token = self.__get_region_access_info(tenant_name, region)
-        url = url + "/v2/tenants/" + tenant_name + "/gateway-http-route?namespace={0}&name={1}&app_id={2}".format(
-            namespace, name, region_app_id)
+        url = url + "/v2/tenants/" + tenant_name + "/gateway-http-route?namespace={0}&name={1}&app_id={2}&operator={3}".format(
+            namespace, name, region_app_id, quote(operator or "", safe=""))
         res, body = self._delete(url, self.default_headers, region=region)
         return body
 

--- a/www/apiclient/regionapi.py
+++ b/www/apiclient/regionapi.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 import httplib2
 import urllib3
@@ -1212,10 +1213,10 @@ class RegionInvokeApi(RegionApiBaseHttpClient):
         return body
 
     def delete_gateway_http_route(self, region: str, tenant_name: str, namespace: str, name: str,
-                                  region_app_id: str) -> Optional[Dict[str, Any]]:
+                                  region_app_id: str, operator: str = "") -> Optional[Dict[str, Any]]:
         url, token = self.__get_region_access_info(tenant_name, region)
-        url = url + "/v2/tenants/" + tenant_name + "/gateway-http-route?namespace={0}&name={1}&app_id={2}".format(
-            namespace, name, region_app_id)
+        url = url + "/v2/tenants/" + tenant_name + "/gateway-http-route?namespace={0}&name={1}&app_id={2}&operator={3}".format(
+            namespace, name, region_app_id, quote(operator or "", safe=""))
         res, body = self._delete(url, self.default_headers, region=region)
         return body
 


### PR DESCRIPTION
## Summary

Merges `v6.9.2-dev` (16 commits of feature work developed on the old Python 3.6 / Django 2.2 stack) into the modernized `main` (Python 3.11 / Django 5.2 / DRF 3.16 / mypy strict typecheck gate), as a **merge commit** preserving the full history and original authors.

Both branches forked from `89d13dbf5`; `main` carried the +30-commit modernization and `v6.9.2-dev` carried +16 feature commits. Resolution principle: **`main`'s modernized stack wins on syntax/types** (`re_path` over `url`, type annotations, response TypedDicts); **`v6.9.2-dev`'s feature logic is preserved** and carried onto the new stack.

## Features brought in

- Realtime traffic proxy through console (websocket + http), docker console proxy with idle-timeout handling (`console/utils/realtime_proxy.py`)
- Global & enterprise image registries with scoped auth (user/enterprise), Harbor + cloud registry support, cloud registry API credentials (`access_key`/`access_secret`)
- Harbor image webhooks
- DaemonSet component metadata + change guard
- App creators granted full app permissions
- Reject package build quick copy
- Pass kubeblocks app id to plugin for resource statistics

## Conflict resolution notes

- 16 files conflicted; resolved keeping the modern stack and folding in feature logic.
- Annotated all merged-in code in the mypy strict-whitelisted modules (`console/services`, `console/views`, `console/repositories`) so the typecheck gate stays green.
- `test-manifest.json` merged as an additive union; added 8 missing capability entries for `realtime_proxy` and `kubeblocks` tests (the feature branch shipped these tests without manifest entries) and regenerated `test-manifest.md`.
- Adapted `registry_global_test` docker_run request mock for Django 5.2's strict `never_cache` (added `request.META`).

No `region` (Go) changes are involved — this is purely console-side; the API contract with the region is unchanged.

## Test plan

- [x] `scripts/typecheck_gate.sh` — green (no strict-whitelisted regressions)
- [x] `scripts/run_pytest.py console/tests` — **1013 passed, 0 failed**
- [x] `make test-manifest-check` — passes (523 capabilities)
- [ ] CI: Check Commit Message / DCO / rainbond-allinone

> Note: the 16 incoming commits were authored without `Signed-off-by`, so the DCO check may flag them; please remediate or accept per maintainer policy.
