### PR TITLE
chore: e2e product-gate smoke (bygpu CI sandbox)

### DIFF
--- a/docs/ci/e2e-gate-smoke.md
+++ b/docs/ci/e2e-gate-smoke.md
@@ -1,0 +1,5 @@
+# E2E product-gate smoke
+
+Throwaway marker to exercise the second-layer E2E gate end to end after
+migrating the gate to the dedicated bygpu CI sandbox (console_ci) and the
+runner to bygpu. Safe to delete; this PR is for pipeline validation only.


### PR DESCRIPTION
联调验证:第二层门禁迁到 bygpu 专用 CI 沙箱(console_ci)+ runner 迁 bygpu 后,真打一次。仅为流水线验证,跑完即关。打 `run-e2e` label 触发。