### PR TITLE
fix: make never_cache decorator support DRF Request objects

### DIFF
--- a/console/utils/cache_decorators.py
+++ b/console/utils/cache_decorators.py
@@ -1,24 +1,40 @@
 # -*- coding: utf-8 -*-
 """Cache-related view decorators compatible with class-based DRF views.
 
-Django 4.0 added a strict ``hasattr(request, "META")`` guard to
-``django.views.decorators.cache.never_cache``. Applying the raw decorator
-directly to a class/instance method (``@never_cache`` above ``def get(self, ...)``)
-makes the wrapper receive the bound ``self`` as its first argument instead of the
-request, so it raises::
+Django 4.0+ hardened ``django.views.decorators.cache.never_cache`` with a strict
+``isinstance(request, HttpRequest)`` guard. DRF dispatches view methods with a
+``rest_framework.request.Request`` (which is **not** an ``HttpRequest`` subclass),
+so applying the stock decorator to a view method — even via ``method_decorator`` —
+raises at call time::
 
     TypeError: never_cache didn't receive an HttpRequest. If you are decorating a
     classmethod, be sure to use @method_decorator.
 
-The project applies ``@never_cache`` to view methods in dozens of places. To keep
-those call sites unchanged we expose a ``never_cache`` that is already wrapped with
-``method_decorator``, which is the Django-recommended way to apply a function-view
-decorator to a method.
+The project applies ``@never_cache`` to DRF view methods in dozens of places. To
+keep those call sites unchanged while supporting any request type, this variant
+does not inspect the request at all: it simply invokes the wrapped method and
+stamps the standard never-cache headers onto the returned response (which is
+exactly what Django's decorator does, minus the request-type guard).
 """
 
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache as _never_cache
+from functools import wraps
 
-# Method-friendly variant. Use exactly like the original ``never_cache`` but on
-# class/instance methods of DRF views.
-never_cache = method_decorator(_never_cache)
+from django.utils.cache import add_never_cache_headers
+
+
+def never_cache(view_method):
+    """Mark a class-based view method's response as never-cacheable.
+
+    Use exactly like Django's ``never_cache`` but on a bound view method
+    (``def get(self, request, ...)``). The request is passed straight through to
+    the wrapped method, so DRF ``Request`` instances (and plain test doubles) are
+    supported.
+    """
+
+    @wraps(view_method)
+    def _wrapped(self, request, *args, **kwargs):
+        response = view_method(self, request, *args, **kwargs)
+        add_never_cache_headers(response)
+        return response
+
+    return _wrapped

--- a/console/utils/cache_decorators_test.py
+++ b/console/utils/cache_decorators_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import os
+from unittest import TestCase
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.test_settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.http import HttpResponse  # noqa: E402
+
+from console.utils.cache_decorators import never_cache  # noqa: E402
+
+
+class _DRFLikeRequest(object):
+    """A stand-in for ``rest_framework.request.Request``.
+
+    DRF passes this to view methods; it is intentionally NOT a subclass of
+    ``django.http.HttpRequest``, which is what tripped the stock ``never_cache``.
+    """
+
+    def __init__(self):
+        self.GET = {}
+
+
+class NeverCacheDecoratorTests(TestCase):
+    def test_passes_through_non_httprequest_and_sets_headers(self):
+        class View(object):
+            @never_cache
+            def get(self, request):
+                return HttpResponse("ok")
+
+        # Must not raise "never_cache didn't receive an HttpRequest".
+        response = View().get(_DRFLikeRequest())
+
+        self.assertEqual(response.status_code, 200)
+        cache_control = response["Cache-Control"]
+        self.assertIn("no-cache", cache_control)
+        self.assertIn("max-age=0", cache_control)
+
+    def test_forwards_arguments_and_returns_view_response(self):
+        class View(object):
+            @never_cache
+            def get(self, request, *args, **kwargs):
+                return HttpResponse("{}-{}".format(args[0], kwargs["flag"]))
+
+        response = View().get(_DRFLikeRequest(), "x", flag="y")
+
+        self.assertEqual(response.content, b"x-y")
+        self.assertIn("no-cache", response["Cache-Control"])


### PR DESCRIPTION
## Problem

`main` is currently red: the unit-test job fails on
`console/tests/app_check_view_test.py::AppCheckViewDiagnosticsTests::test_get_reports_source_check_failure_without_changing_response`
(introduced by #1999) with:

```
TypeError: never_cache didn't receive an HttpRequest. If you are decorating a
classmethod, be sure to use @method_decorator.
```

This blocks every PR branched off main (e.g. #2000, #2001), since the full suite runs on each.

## Root cause

Django 4.0+ hardened `django.views.decorators.cache.never_cache` with a strict
`isinstance(request, HttpRequest)` guard. DRF dispatches view methods with a
`rest_framework.request.Request`, which is **not** an `HttpRequest` subclass. The
previous `console/utils/cache_decorators.never_cache` only wrapped the stock
decorator in `method_decorator` — that fixes the bound-`self` issue but still hands
a DRF `Request` to the guard, so `@never_cache` on any DRF view method raises at
call time under the Django 5.2 upgrade. The new `app_check` test is simply the
first to call such a method directly and expose it.

## Fix

Rewrite the decorator so it does not inspect the request at all: call the wrapped
method and stamp the standard never-cache headers onto the returned response via
`django.utils.cache.add_never_cache_headers` — exactly what Django's decorator does,
minus the request-type guard. Works for DRF `Request`, plain `HttpRequest`, and test
doubles. All existing `@never_cache` call sites are unchanged.

Adds `console/utils/cache_decorators_test.py` covering the DRF-Request path and
argument forwarding.

## Verification (local, Python 3.11 / Django 5.2 container matching CI)

- New decorator test reproduces the exact `TypeError` against the old decorator (RED) and passes on the fix (GREEN).
- `console/tests/app_check_view_test.py` (main's failing test) now passes.
- Full `console www openapi` suite: **1084 passed, 0 failed**.
- `make test-manifest-check` passes.

## Test plan

- [ ] CI unit-test job goes green on this PR.
- [ ] After merge, #2000 / #2001 rebased on main pass unit-test.