### PR TITLE
ci: parameterize python base images to allow a mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ARG IMAGE_NAMESPACE=rainbond
 ARG VERSION=v6.0.0-release
 ARG IMAGE_VERSION=v6.0.0-release
+# Python base images, overridable to a mirror (e.g. GHCR) to avoid Docker Hub
+# pull-rate limits in CI. Defaults keep pulling from Docker Hub (release builds
+# unchanged); dev-build overrides these to a mirror via --build-arg.
+ARG PYTHON_BASE=python:3.11-bookworm
+ARG PYTHON_SLIM_BASE=python:3.11-slim-bookworm
 
 # build ui
 FROM ${IMAGE_NAMESPACE}/rainbond-ui:${IMAGE_VERSION} AS ui
@@ -14,7 +19,7 @@ RUN mv /dist/index.html /app/ui/www/templates/index.html && \
     cp -a /dist/* /app/ui/www/static/dists/
 
 # build console
-FROM python:3.11-bookworm AS build-console
+FROM ${PYTHON_BASE} AS build-console
 ARG PYTHONPROXY
 ARG TARGETARCH
 ARG VERSION
@@ -44,7 +49,7 @@ RUN git clone --depth=1 -b main https://github.com/goodrain/rainbond-chart /app/
     chmod +x /tmp/helm
 
 # build console image
-FROM python:3.11-slim-bookworm
+FROM ${PYTHON_SLIM_BASE}
 
 ARG RELEASE_DESC=
 ARG VERSION


### PR DESCRIPTION
## Why

CI `dev-build` (allinone image) repeatedly hits Docker Hub's pull-rate limit (429 Too Many Requests) on `FROM python:3.11-slim-bookworm` / `python:3.11-bookworm`. The build already authenticates to Docker Hub, but the authenticated account's free quota (200 pulls / 6h) gets exhausted by repeated builds on GitHub-hosted runners.

## What

Parameterize the two python base images via build args, **defaulting to Docker Hub** so release builds are unchanged:

```dockerfile
ARG PYTHON_BASE=python:3.11-bookworm
ARG PYTHON_SLIM_BASE=python:3.11-slim-bookworm
...
FROM ${PYTHON_BASE} AS build-console
FROM ${PYTHON_SLIM_BASE}
```

`dev-build.yml` (goodrain/rainbond) will override these to a GHCR mirror (`ghcr.io/goodrain/python:...`, unmetered + fast from GitHub Actions) — see the companion PR. No behavior change unless the build args are passed.

Companion: goodrain/rainbond dev-build.yml PR + a one-time mirror of the two python images into `ghcr.io/goodrain` (public).