### PR TITLE
feat(mcp): add closed-loop signal tools for troubleshoot loop

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Any, List, Optional, Tuple
 
 from django.core import signing
@@ -260,15 +261,18 @@ class MCPQueryService(object):
 
     def list_tools(self, user: Any = None) -> List[dict]:
         tools = [
-            self._tool_get_current_user(), self._tool_get_app_detail(), self._tool_create_app(),
+            self._tool_get_current_user(), self._tool_get_app_detail(), self._tool_get_app_health_overview(),
+            self._tool_create_app(),
             self._tool_get_component_summary(), self._tool_get_component_detail(),
             self._tool_get_component_pods(), self._tool_get_pod_detail(),
             self._tool_get_component_logs(), self._tool_exec_component(), self._tool_get_config_file(),
+            self._tool_analyze_env_conflicts(),
             self._tool_get_component_events(), self._tool_get_component_build_logs(),
             self._tool_get_operation_failure_context(),
             self._tool_get_component_build_source(), self._tool_update_component_build_source(),
             self._tool_create_component(),
-            self._tool_delete_component(), self._tool_operate_app(), self._tool_manage_component_envs(),
+            self._tool_delete_component(), self._tool_operate_app(), self._tool_wait_for_build_completion(),
+            self._tool_manage_component_envs(),
             self._tool_manage_component_connection_envs(),
             self._tool_change_component_image(), self._tool_manage_component_ports(),
             self._tool_manage_component_storage(),
@@ -323,6 +327,8 @@ class MCPQueryService(object):
             return self.get_current_user(user)
         if name == "rainbond_get_app_detail":
             return self.get_app_detail(user, arguments)
+        if name == "rainbond_get_app_health_overview":
+            return self.get_app_health_overview(user, arguments)
         if name == "rainbond_create_app":
             return self.create_app(user, arguments)
         if name == "rainbond_get_component_summary":
@@ -337,6 +343,8 @@ class MCPQueryService(object):
             return self.exec_component(user, arguments)
         if name == "rainbond_get_config_file":
             return self.get_config_file(user, arguments)
+        if name == "rainbond_analyze_env_conflicts":
+            return self.analyze_env_conflicts(user, arguments)
         if name == "rainbond_get_component_build_logs":
             return self.get_component_build_logs(user, arguments)
         if name == "rainbond_get_component_build_source":
@@ -355,6 +363,8 @@ class MCPQueryService(object):
             return self.delete_component(user, arguments)
         if name == "rainbond_operate_app":
             return self.operate_app(user, arguments)
+        if name == "rainbond_wait_for_build_completion":
+            return self.wait_for_build_completion(user, arguments)
         if name == "rainbond_manage_component_envs":
             return self.manage_component_envs(user, arguments)
         if name == "rainbond_manage_component_connection_envs":
@@ -566,6 +576,73 @@ class MCPQueryService(object):
         app_info["used_memory"] = used_memory
         app_info["app_id"] = app.ID
         return app_info
+
+    def get_app_health_overview(self, user: Any, arguments: dict) -> dict:
+        """One call returns every component's status + a critical_blocker for the
+        abnormal ones. Replaces N get_component_summary calls in the troubleshoot
+        loop. Cost grows with the number of *unhealthy* components, not the total:
+        status comes from one batched status_multi_service call; only non-running
+        components are deep-dived (pod warnings -> classify_failure)."""
+        team, app = self._get_team_app_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+        )
+        services = group_service.get_group_services(app.ID)
+        service_ids = [s.service_id for s in services]
+        status_list = []
+        if service_ids:
+            status_list = base_service.status_multi_service(
+                region=app.region_name,
+                tenant_name=team.tenant_name,
+                service_ids=service_ids,
+                enterprise_id=team.enterprise_id,
+            )
+        status_map = {s["service_id"]: s["status"] for s in (status_list or [])}
+
+        components = []
+        running_count = 0
+        for service in services:
+            status = status_map.get(service.service_id, "")
+            if status == "running":
+                running_count += 1
+                blocker = None
+            else:
+                blocker = self._build_component_blocker(team, app.region_name, service)
+            data = service.to_dict()
+            components.append({
+                "service_id": service.service_id,
+                "name": data.get("k8s_component_name") or data.get("service_cname") or service.service_id,
+                "service_cname": data.get("service_cname"),
+                "status": status,
+                "critical_blocker": blocker,
+            })
+
+        return {
+            "team_name": team.tenant_name,
+            "region_name": app.region_name,
+            "app_id": app.ID,
+            "app_status": self._get_app_status(running_count, len(services)),
+            "components": components,
+            "total": len(components),
+        }
+
+    def _build_component_blocker(self, team: Any, region_name: str, service: Any) -> str:
+        """Classify a non-running component's blocker. Best-effort: any region
+        failure degrades to 'unknown' rather than aborting the whole overview.
+        The event-log tail is deliberately NOT fetched here (the empty second arg
+        to classify_failure): an overview deep-dives every abnormal component, so
+        adding a per-component event-log fetch would re-introduce the N+1 calls
+        this tool exists to avoid. Pod warnings carry the actionable signal
+        (image_pull/crash_loop/mount); use get_operation_failure_context for the
+        single-component event-log drilldown."""
+        try:
+            pod_warnings = self._collect_pod_warnings(team, region_name, service)
+            return classify_failure(pod_warnings, [])
+        except Exception as e:
+            logger.warning("health_overview: classify failed for %s: %s", service.service_id, e)
+            return "unknown"
 
     def create_app(self, user: Any, arguments: dict) -> dict:
         team = self._get_team_context(user, self._require_string(arguments, "team_name"))
@@ -869,6 +946,65 @@ class MCPQueryService(object):
             "total": len(items),
         }
 
+    def analyze_env_conflicts(self, user: Any, arguments: dict) -> dict:
+        """Detect env vars whose same attr_name is supplied by more than one
+        source (component self-define vs dependency-injected) with diverging
+        values. Surfaces the M0 collision class where an upserted env clashes with
+        an auto-generated port-alias env (<ALIAS>_PORT) or a dependency-injected
+        connection env. Identical value from two sources is harmless and not
+        flagged."""
+        team, app, service = self._get_team_app_service_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+            self._require_string(arguments, "service_id"),
+        )
+        grouped = {}  # type: dict
+        order = []  # type: List[str]  # preserve first-seen order for stable output
+        for env in env_var_service.get_all_envs_incloud_depend_env(team, service):
+            attr_name = getattr(env, "attr_name", None)
+            if not attr_name:
+                continue
+            origin = "self" if getattr(env, "service_id", None) == service.service_id else "dependency"
+            source = {
+                "origin": origin,
+                "value": getattr(env, "attr_value", ""),
+                "scope": getattr(env, "scope", ""),
+                "service_id": getattr(env, "service_id", ""),
+            }
+            if attr_name not in grouped:
+                grouped[attr_name] = []
+                order.append(attr_name)
+            grouped[attr_name].append(source)
+
+        conflicts = []
+        for attr_name in order:
+            sources = grouped[attr_name]
+            if len(sources) < 2:
+                continue
+            # Distinctness is computed on the REAL values; the output values are
+            # masked for secret-looking names so a SECRET_KEY/DB_PASSWORD conflict
+            # is still surfaced without leaking the secret to the AI client.
+            distinct_values = {s["value"] for s in sources}
+            if len(distinct_values) < 2:
+                # same name, same value from multiple sources: harmless
+                continue
+            masked_sources = [
+                {**s, "value": self._mask_env_value(attr_name, s["value"])}
+                for s in sources
+            ]
+            conflicts.append({"attr_name": attr_name, "sources": masked_sources})
+
+        return {
+            "team_name": team.tenant_name,
+            "region_name": app.region_name,
+            "app_id": app.ID,
+            "service_id": service.service_id,
+            "conflicts": conflicts,
+            "total": len(conflicts),
+        }
+
     def get_component_events(self, user: Any, arguments: dict) -> dict:
         page = self._parse_int_with_default(arguments.get("page"), 1)
         page_size = self._parse_int_with_default(arguments.get("page_size"), 10)
@@ -1086,6 +1222,114 @@ class MCPQueryService(object):
 
     def _redact_failure_line(self, message: Any) -> str:
         return self._FAILURE_CONTEXT_SECRET_RE.sub(r"\1\2***", str(message or ""))
+
+    # Env var names whose value must be masked in analyze_env_conflicts output:
+    # the AI only needs to know the values differ, never the secret itself.
+    _SENSITIVE_ENV_NAME_RE = re.compile(
+        r"(?i)(password|passwd|pwd|token|secret|access[_-]?key|api[_-]?key|"
+        r"authorization|private[_-]?key|credential)")
+
+    @classmethod
+    def _mask_env_value(cls, attr_name: str, value: Any) -> Any:
+        if cls._SENSITIVE_ENV_NAME_RE.search(str(attr_name or "")):
+            return "***"
+        return value
+
+    # --- wait_for_build_completion ---------------------------------------
+    WAIT_BUILD_POLL_INTERVAL_SECONDS = 5
+    WAIT_BUILD_DEFAULT_TIMEOUT = 60
+    # Bounds the blocking wait the caller asked for. Note the worker is held for
+    # at most WAIT_BUILD_MAX_TIMEOUT plus the duration of one in-flight region
+    # call (region_api default read timeout x retries) before the deadline check
+    # fires; under a healthy region that tail is sub-second.
+    WAIT_BUILD_MAX_TIMEOUT = 120
+    # Page-1 window when locating the awaited event by id. The event was just
+    # triggered (operate_app/build_component returned it) so it is the newest
+    # event; a wide window guards against it scrolling off page 1 on a chatty
+    # component. Kept separate from FAILURE_CONTEXT_EVENT_QUERY_SIZE.
+    WAIT_BUILD_EVENT_QUERY_SIZE = 100
+    # Event terminal statuses: success -> "success"; failure/timeout -> "failure".
+    _WAIT_BUILD_SUCCESS_STATUSES = ("success",)
+    _WAIT_BUILD_FAILURE_STATUSES = ("failure", "timeout")
+
+    def wait_for_build_completion(self, user: Any, arguments: dict) -> dict:
+        """Bounded blocking poll of a build/deploy operation event until it
+        reaches a terminal state. Returns success/failure immediately on terminal;
+        on failure attaches a redacted error_summary + classified_reason (NOT raw
+        logs). When the clamped timeout elapses without a terminal state, returns
+        status='running' plus event_id so the caller can resume waiting with
+        another call. Replaces the M0 for+sleep+curl self-spin while bounding
+        worker occupancy to <= WAIT_BUILD_MAX_TIMEOUT seconds."""
+        team, app, service = self._get_team_app_service_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+            self._require_string(arguments, "service_id"),
+        )
+        event_id = self._require_string(arguments, "event_id")
+        timeout = self._parse_int_with_default(arguments.get("timeout"), self.WAIT_BUILD_DEFAULT_TIMEOUT)
+        if timeout <= 0:
+            timeout = self.WAIT_BUILD_DEFAULT_TIMEOUT
+        timeout = min(timeout, self.WAIT_BUILD_MAX_TIMEOUT)
+
+        deadline = time.monotonic() + timeout
+        while True:
+            event = self._query_operation_event(team, app, service, event_id)
+            event_status = (event.get("status") or "").lower() if event else ""
+            if event_status in self._WAIT_BUILD_SUCCESS_STATUSES:
+                return self._wait_build_result(team, app, service, event_id, "success", timeout, event_status)
+            if event_status in self._WAIT_BUILD_FAILURE_STATUSES:
+                return self._wait_build_result(team, app, service, event_id, "failure", timeout, event_status)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return self._wait_build_result(team, app, service, event_id, "running", timeout, event_status)
+            # Cap the sleep to the remaining budget so a small timeout (e.g. 1s)
+            # is honored rather than over-blocking by a full poll interval.
+            time.sleep(min(self.WAIT_BUILD_POLL_INTERVAL_SECONDS, remaining))
+
+    def _query_operation_event(self, team: Any, app: Any, service: Any, event_id: str) -> Optional[dict]:
+        """Locate the operation event by id from the service event list.
+        Best-effort: any sub-query failure returns None (treated as still running)
+        rather than aborting the poll."""
+        try:
+            res, body = region_api.get_target_events_list(
+                app.region_name, team.tenant_name, "service", service.service_id,
+                1, self.WAIT_BUILD_EVENT_QUERY_SIZE)
+            items = body.get("list") or [] if (int(res.status) == 200 and isinstance(body, dict)) else []
+        except Exception as e:
+            logger.warning("wait_build: list events failed for %s: %s", service.service_id, e)
+            return None
+        for item in items:
+            if isinstance(item, dict) and (item.get("event_id") or "") == event_id:
+                return item
+        return None
+
+    def _wait_build_result(self, team: Any, app: Any, service: Any, event_id: str,
+                           status: str, timeout: int, event_status: str) -> dict:
+        error_summary = []  # type: List[str]
+        classified_reason = None
+        if status == "failure":
+            error_summary = self._read_failure_event_log_tail(
+                team, app.region_name, event_id, self.FAILURE_CONTEXT_DEFAULT_LOG_TAIL)
+            # Image-pull / crash-loop signals live in pod warnings, not the event
+            # log; the log tail only carries the k8s_api_rejected fallback. Gather
+            # both so the build failure classifies the same way as
+            # get_operation_failure_context. _collect_pod_warnings is best-effort.
+            pod_warnings = self._collect_pod_warnings(team, app.region_name, service)
+            classified_reason = classify_failure(pod_warnings, error_summary)
+        return {
+            "team_name": team.tenant_name,
+            "region_name": app.region_name,
+            "app_id": app.ID,
+            "service_id": service.service_id,
+            "event_id": event_id,
+            "status": status,
+            "event_status": event_status,
+            "timeout": timeout,
+            "error_summary": error_summary,
+            "classified_reason": classified_reason,
+        }
 
     def _collect_pod_warnings(self, team: Any, region_name: str, service: Any) -> List[dict]:
         """Pull Warning events from up to N abnormal pods. Best-effort: any
@@ -5319,6 +5563,26 @@ class MCPQueryService(object):
             }
         }
 
+    def _tool_get_app_health_overview(self) -> dict:
+        return {
+            "name": "rainbond_get_app_health_overview",
+            "description": (
+                "一次性返回应用下全部组件的运行状态与每个异常组件的 critical_blocker，"
+                "用于排障 loop 的健康总览，免去逐个组件调用 get_component_summary。"
+                "全绿组件 critical_blocker 为 null；非 running 组件会自动深挖 pod 告警并归类阻滞原因"
+                "（如 image_pull_failed / crash_loop / config_file_configmap_missing / unknown）。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {"type": "integer", "minimum": 1},
+                },
+                "required": ["team_name", "region_name", "app_id"],
+            },
+        }
+
     def _tool_create_app(self) -> dict:
         return {
             "name": "rainbond_create_app",
@@ -5436,6 +5700,26 @@ class MCPQueryService(object):
                 },
                 "required": ["team_name", "region_name", "app_id", "service_id"]
             }
+        }
+
+    def _tool_analyze_env_conflicts(self) -> dict:
+        return {
+            "name": "rainbond_analyze_env_conflicts",
+            "description": (
+                "检测组件环境变量的多源冲突：同一 attr_name 由多个来源（组件自身定义 vs 依赖注入的连接变量/"
+                "端口别名自动生成变量）提供且取值不一致时判定为冲突。用于排障 loop 在改 env 前规避 M0 实测的"
+                "<ALIAS>_PORT 同名 412 类问题。同名同值不算冲突。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {"type": "integer", "minimum": 1},
+                    "service_id": {"type": "string"},
+                },
+                "required": ["team_name", "region_name", "app_id", "service_id"],
+            },
         }
 
     def _tool_manage_component_envs(self) -> dict:
@@ -5774,6 +6058,31 @@ class MCPQueryService(object):
                 },
                 "required": ["team_name", "region_name", "app_id", "action"]
             }
+        }
+
+    def _tool_wait_for_build_completion(self) -> dict:
+        return {
+            "name": "rainbond_wait_for_build_completion",
+            "description": (
+                "有界阻塞轮询某次构建/部署操作事件直到终态，用于排障 loop 在部署后获取统一就绪信号，"
+                "免去客户端 for+sleep+curl 自旋。返回 status=success/failure/running："
+                "success/failure 在事件终态时立即返回，failure 附带脱敏后的关键错误摘要(error_summary)"
+                "与归类原因(classified_reason)；若在超时(默认 60s，最大 120s)内仍未终态，返回 status=running 与 event_id，"
+                "调用方可携带同一 event_id 再次调用以续等。event_id 来自 operate_app/build_component 的返回。"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {"type": "integer", "minimum": 1},
+                    "service_id": {"type": "string"},
+                    "event_id": {"type": "string", "description": "构建/部署操作事件 ID，来自 operate_app/build_component 返回"},
+                    "timeout": {"type": "integer", "minimum": 1,
+                                "description": "阻塞等待上限秒数，默认 60，超过 120 按 120 截断"},
+                },
+                "required": ["team_name", "region_name", "app_id", "service_id", "event_id"],
+            },
         }
 
     def _tool_update_component_envs(self) -> dict:

--- a/console/tests/mcp_query_env_conflicts_test.py
+++ b/console/tests/mcp_query_env_conflicts_test.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""Service-level tests for the analyze_env_conflicts MCP tool.
+
+Detects the same env attr_name supplied by more than one source (component
+self-define vs dependency-injected) and/or with diverging values — the M0
+<ALIAS>_PORT 412 collision class. Backed by
+env_var_service.get_all_envs_incloud_depend_env, mocked here.
+"""
+import os
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import django
+from django.test import SimpleTestCase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+django.setup()
+
+from console.services.mcp_query_service import mcp_query_service
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _team():
+    return Obj(tenant_name="team1", tenant_id="tid-1", enterprise_id="eid-1")
+
+
+def _app():
+    return Obj(ID=7, region_name="rg")
+
+
+def _service():
+    return Obj(service_id="svc-self", service_alias="gr1234", service_region="rg", tenant_id="tid-1")
+
+
+def _env(attr_name, attr_value, service_id, scope="inner"):
+    return Obj(attr_name=attr_name, attr_value=attr_value, service_id=service_id,
+               scope=scope, name=attr_name, container_port=0)
+
+
+class EnvConflictTests(SimpleTestCase):
+
+    # capability_id: console.mcp.env-conflicts
+    def test_same_name_diff_value_is_conflict(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7", "service_id": "svc-self"}
+        envs = [_env("SANDBOX_PORT", "8194", "svc-self"),
+                _env("SANDBOX_PORT", "9999", "svc-self")]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.env_var_service.get_all_envs_incloud_depend_env",
+                       return_value=iter(envs)):
+                result = mcp_query_service.analyze_env_conflicts(Obj(nick_name="t"), args)
+        self.assertEqual(result["total"], 1)
+        c = result["conflicts"][0]
+        self.assertEqual(c["attr_name"], "SANDBOX_PORT")
+        self.assertEqual(len(c["sources"]), 2)
+
+    # capability_id: console.mcp.env-conflicts
+    def test_self_vs_dependency_cross_source_conflict(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7", "service_id": "svc-self"}
+        envs = [_env("DB_HOST", "db-postgres", "svc-self"),
+                _env("DB_HOST", "old-host", "svc-dep")]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.env_var_service.get_all_envs_incloud_depend_env",
+                       return_value=iter(envs)):
+                result = mcp_query_service.analyze_env_conflicts(Obj(nick_name="t"), args)
+        self.assertEqual(result["total"], 1)
+        origins = {s["origin"] for s in result["conflicts"][0]["sources"]}
+        self.assertEqual(origins, {"self", "dependency"})
+
+    # capability_id: console.mcp.env-conflicts
+    def test_same_name_same_value_not_conflict(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7", "service_id": "svc-self"}
+        envs = [_env("REDIS_HOST", "redis", "svc-self"),
+                _env("REDIS_HOST", "redis", "svc-dep")]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.env_var_service.get_all_envs_incloud_depend_env",
+                       return_value=iter(envs)):
+                result = mcp_query_service.analyze_env_conflicts(Obj(nick_name="t"), args)
+        # identical value from two sources is harmless: not flagged
+        self.assertEqual(result["total"], 0)
+
+    # capability_id: console.mcp.env-conflicts
+    def test_sensitive_value_is_masked_but_conflict_still_flagged(self):
+        # A SECRET_KEY/DB_PASSWORD conflict must still be reported, but the raw
+        # secret values must NOT leak into the AI-facing response.
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7", "service_id": "svc-self"}
+        envs = [_env("DB_PASSWORD", "supersecret-A", "svc-self"),
+                _env("DB_PASSWORD", "supersecret-B", "svc-dep")]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.env_var_service.get_all_envs_incloud_depend_env",
+                       return_value=iter(envs)):
+                result = mcp_query_service.analyze_env_conflicts(Obj(nick_name="t"), args)
+        self.assertEqual(result["total"], 1)
+        values = [s["value"] for s in result["conflicts"][0]["sources"]]
+        self.assertEqual(values, ["***", "***"])
+        joined = str(result)
+        self.assertNotIn("supersecret-A", joined)
+        self.assertNotIn("supersecret-B", joined)
+
+    # capability_id: console.mcp.env-conflicts
+    def test_no_conflict_unique_names(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7", "service_id": "svc-self"}
+        envs = [_env("A", "1", "svc-self"), _env("B", "2", "svc-self")]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.env_var_service.get_all_envs_incloud_depend_env",
+                       return_value=iter(envs)):
+                result = mcp_query_service.analyze_env_conflicts(Obj(nick_name="t"), args)
+        self.assertEqual(result["conflicts"], [])
+        self.assertEqual(result["total"], 0)
+
+
+class EnvConflictRegistrationTests(SimpleTestCase):
+    # capability_id: console.mcp.env-conflicts
+    def test_tool_is_listed_and_dispatchable(self):
+        user = Obj(user_id=1, enterprise_id="eid-1", nick_name="u", is_enterprise_admin=False)
+        names = [t["name"] for t in mcp_query_service.list_tools(user)]
+        self.assertIn("rainbond_analyze_env_conflicts", names)

--- a/console/tests/mcp_query_health_overview_test.py
+++ b/console/tests/mcp_query_health_overview_test.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Service-level tests for the get_app_health_overview MCP tool.
+
+One batched status_multi_service call gives every component's status;
+only non-running components are deep-dived (pod warnings + classify).
+region_api / repos are mocked so no live region is needed.
+"""
+import os
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import django
+from django.test import SimpleTestCase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+django.setup()
+
+from console.services.mcp_query_service import mcp_query_service
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _team():
+    return Obj(tenant_name="team1", tenant_id="tid-1", enterprise_id="eid-1")
+
+
+def _app():
+    return Obj(ID=7, region_name="rg")
+
+
+class _Svc(object):
+    def __init__(self, sid, cname, k8s):
+        self.service_id = sid
+        self.service_cname = cname
+        self.k8s_component_name = k8s
+        self.service_alias = "gr" + sid
+        self.service_region = "rg"
+
+    def to_dict(self):
+        return {"service_id": self.service_id, "service_cname": self.service_cname,
+                "k8s_component_name": self.k8s_component_name}
+
+
+class HealthOverviewTests(SimpleTestCase):
+
+    # capability_id: console.mcp.app-health-overview
+    def test_all_running_no_blocker_no_deepdive(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7"}
+        services = [_Svc("a", "api", "api"), _Svc("b", "db", "db-postgres")]
+        status_list = [{"service_id": "a", "status": "running"},
+                       {"service_id": "b", "status": "running"}]
+        with patch.object(mcp_query_service, "_get_team_app_context",
+                          return_value=(_team(), _app())):
+            with patch("console.services.mcp_query_service.group_service.get_group_services",
+                       return_value=services):
+                with patch("console.services.mcp_query_service.base_service.status_multi_service",
+                           return_value=status_list):
+                    with patch.object(mcp_query_service, "_collect_pod_warnings") as deep:
+                        result = mcp_query_service.get_app_health_overview(Obj(nick_name="t"), args)
+        # all running => app_status running, no per-component deep-dive at all
+        self.assertEqual(result["app_status"], "running")
+        deep.assert_not_called()
+        blockers = {c["service_id"]: c["critical_blocker"] for c in result["components"]}
+        self.assertEqual(blockers, {"a": None, "b": None})
+        self.assertEqual(result["total"], 2)
+
+    # capability_id: console.mcp.app-health-overview
+    def test_abnormal_component_deepdived_for_blocker(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7"}
+        services = [_Svc("a", "api", "api"), _Svc("b", "db", "db-postgres")]
+        status_list = [{"service_id": "a", "status": "running"},
+                       {"service_id": "b", "status": "abnormal"}]
+        warnings = [{"reason": "ImagePullBackOff", "message": "Back-off pulling image"}]
+        with patch.object(mcp_query_service, "_get_team_app_context",
+                          return_value=(_team(), _app())):
+            with patch("console.services.mcp_query_service.group_service.get_group_services",
+                       return_value=services):
+                with patch("console.services.mcp_query_service.base_service.status_multi_service",
+                           return_value=status_list):
+                    with patch.object(mcp_query_service, "_collect_pod_warnings",
+                                      return_value=warnings) as deep:
+                        result = mcp_query_service.get_app_health_overview(Obj(nick_name="t"), args)
+        # only the abnormal component is deep-dived
+        self.assertEqual(deep.call_count, 1)
+        self.assertEqual(result["app_status"], "part_running")
+        blockers = {c["service_id"]: c["critical_blocker"] for c in result["components"]}
+        self.assertIsNone(blockers["a"])
+        self.assertEqual(blockers["b"], "image_pull_failed")
+
+    # capability_id: console.mcp.app-health-overview
+    def test_deepdive_failure_degrades_to_unknown(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7"}
+        services = [_Svc("b", "db", "db-postgres")]
+        status_list = [{"service_id": "b", "status": "abnormal"}]
+        with patch.object(mcp_query_service, "_get_team_app_context",
+                          return_value=(_team(), _app())):
+            with patch("console.services.mcp_query_service.group_service.get_group_services",
+                       return_value=services):
+                with patch("console.services.mcp_query_service.base_service.status_multi_service",
+                           return_value=status_list):
+                    with patch.object(mcp_query_service, "_collect_pod_warnings",
+                                      side_effect=Exception("region down")):
+                        result = mcp_query_service.get_app_health_overview(Obj(nick_name="t"), args)
+        # deep-dive failure must not break aggregation
+        self.assertEqual(result["components"][0]["critical_blocker"], "unknown")
+
+    # capability_id: console.mcp.app-health-overview
+    def test_empty_app(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7"}
+        with patch.object(mcp_query_service, "_get_team_app_context",
+                          return_value=(_team(), _app())):
+            with patch("console.services.mcp_query_service.group_service.get_group_services",
+                       return_value=[]):
+                result = mcp_query_service.get_app_health_overview(Obj(nick_name="t"), args)
+        self.assertEqual(result["components"], [])
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["app_status"], "closed")
+
+
+class HealthOverviewRegistrationTests(SimpleTestCase):
+
+    # capability_id: console.mcp.app-health-overview
+    def test_tool_is_listed_and_dispatchable(self):
+        user = Obj(user_id=1, enterprise_id="eid-1", nick_name="u", is_enterprise_admin=False)
+        names = [t["name"] for t in mcp_query_service.list_tools(user)]
+        self.assertIn("rainbond_get_app_health_overview", names)

--- a/console/tests/mcp_query_wait_build_test.py
+++ b/console/tests/mcp_query_wait_build_test.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Service-level tests for the wait_for_build_completion MCP tool.
+
+Bounded blocking poll: returns immediately on terminal state; on failure
+attaches a redacted error_summary + classified_reason; when the (clamped)
+timeout elapses without a terminal state, returns status=running so the caller
+can resume. time.sleep is patched to a no-op so tests never actually wait.
+"""
+import os
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import django
+from django.test import SimpleTestCase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+django.setup()
+
+from console.services.mcp_query_service import mcp_query_service
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _team():
+    return Obj(tenant_name="team1", tenant_id="tid-1", enterprise_id="eid-1")
+
+
+def _app():
+    return Obj(ID=7, region_name="rg")
+
+
+def _service():
+    return Obj(service_id="svc-1", service_alias="gr1234", service_region="rg", tenant_id="tid-1")
+
+
+def _resp(status):
+    return Obj(status=status)
+
+
+def _events_body(items):
+    return (_resp(200), {"list": items})
+
+
+def _pods_payload(pod_names):
+    return {"bean": {"new_pods": [{"pod_name": n, "pod_status": "ABNORMAL"} for n in pod_names], "old_pods": []}}
+
+
+def _pod_detail_payload(events):
+    return {"bean": {"status": {"type_str": "ABNORMAL"}, "events": events}}
+
+
+class WaitBuildTerminalTests(SimpleTestCase):
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_success_first_poll_no_sleep(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-1"}
+        items = [{"event_id": "ev-1", "status": "success", "final_status": "complete",
+                  "opt_type": "build"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       return_value=_events_body(items)):
+                with patch("console.services.mcp_query_service.time.sleep") as slept:
+                    result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["event_id"], "ev-1")
+        slept.assert_not_called()
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_failure_attaches_error_summary_and_reason(self):
+        # error_summary comes from the event log tail (build output); the
+        # classified_reason comes from pod warnings (ImagePullBackOff is a K8s
+        # pod event, not build-log text), matching get_operation_failure_context.
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-1"}
+        items = [{"event_id": "ev-1", "status": "failure", "final_status": "complete",
+                  "opt_type": "build", "message": "build failed"}]
+        log = [{"message": "deploy step failed, see pod events"}]
+        pod_events = [{"reason": "ImagePullBackOff", "message": "Back-off pulling image foo; ImagePullBackOff"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       return_value=_events_body(items)):
+                with patch("console.services.mcp_query_service.region_api.get_events_log",
+                           return_value=(_resp(200), {"list": log})):
+                    with patch("console.services.mcp_query_service.region_api.get_service_pods",
+                               return_value=_pods_payload(["pod-a"])):
+                        with patch("console.services.mcp_query_service.region_api.pod_detail",
+                                   return_value=_pod_detail_payload(pod_events)):
+                            with patch("console.services.mcp_query_service.time.sleep"):
+                                result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        self.assertEqual(result["status"], "failure")
+        self.assertEqual(result["classified_reason"], "image_pull_failed")
+        self.assertTrue(result["error_summary"])
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_running_then_success_polls_again(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-1"}
+        running = [{"event_id": "ev-1", "status": "", "final_status": "", "opt_type": "build"}]
+        done = [{"event_id": "ev-1", "status": "success", "final_status": "complete", "opt_type": "build"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       side_effect=[_events_body(running), _events_body(done)]):
+                with patch("console.services.mcp_query_service.time.sleep") as slept:
+                    result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        self.assertEqual(result["status"], "success")
+        slept.assert_called_once()
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_timeout_returns_running_with_event_id(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-1", "timeout": 5}
+        running = [{"event_id": "ev-1", "status": "", "final_status": "", "opt_type": "build"}]
+        # monotonic: start=0, then >=deadline so the loop exits after first check
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       return_value=_events_body(running)):
+                with patch("console.services.mcp_query_service.time.sleep"):
+                    with patch("console.services.mcp_query_service.time.monotonic",
+                               side_effect=[0.0, 100.0, 100.0]):
+                        result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        self.assertEqual(result["status"], "running")
+        self.assertEqual(result["event_id"], "ev-1")
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_event_not_found_treated_as_running(self):
+        # If the awaited event is absent from the list (scrolled off / not yet
+        # recorded), _query_operation_event returns None -> treated as running,
+        # and the bounded wait eventually returns status='running' (not a crash).
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-missing", "timeout": 5}
+        others = [{"event_id": "ev-other", "status": "success", "final_status": "complete"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       return_value=_events_body(others)):
+                with patch("console.services.mcp_query_service.time.sleep"):
+                    with patch("console.services.mcp_query_service.time.monotonic",
+                               side_effect=[0.0, 100.0, 100.0]):
+                        result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        self.assertEqual(result["status"], "running")
+        self.assertEqual(result["event_id"], "ev-missing")
+        self.assertEqual(result["event_status"], "")
+
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_timeout_clamped_to_max(self):
+        args = {"team_name": "team1", "region_name": "rg", "app_id": "7",
+                "service_id": "svc-1", "event_id": "ev-1", "timeout": 99999}
+        done = [{"event_id": "ev-1", "status": "success", "final_status": "complete", "opt_type": "build"}]
+        with patch.object(mcp_query_service, "_get_team_app_service_context",
+                          return_value=(_team(), _app(), _service())):
+            with patch("console.services.mcp_query_service.region_api.get_target_events_list",
+                       return_value=_events_body(done)):
+                with patch("console.services.mcp_query_service.time.sleep"):
+                    result = mcp_query_service.wait_for_build_completion(Obj(nick_name="t"), args)
+        # success regardless; the assertion here is that an absurd timeout does
+        # not blow up (clamp applied internally).
+        self.assertEqual(result["status"], "success")
+        self.assertLessEqual(result["timeout"], mcp_query_service.WAIT_BUILD_MAX_TIMEOUT)
+
+
+class WaitBuildRegistrationTests(SimpleTestCase):
+    # capability_id: console.mcp.wait-for-build-completion
+    def test_tool_is_listed_and_dispatchable(self):
+        user = Obj(user_id=1, enterprise_id="eid-1", nick_name="u", is_enterprise_admin=False)
+        names = [t["name"] for t in mcp_query_service.list_tools(user)]
+        self.assertIn("rainbond_wait_for_build_completion", names)

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -9283,6 +9283,57 @@
       "status": "active"
     },
     {
+      "id": "console.mcp.env-conflicts",
+      "title": "MCP analyze_env_conflicts tool",
+      "title_zh": "MCP 环境变量多源冲突检测工具",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.mcp.env-conflicts]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_env_conflicts_test.py"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.app-health-overview",
+      "title": "MCP get_app_health_overview tool",
+      "title_zh": "MCP 应用健康总览工具",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.mcp.app-health-overview]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_health_overview_test.py"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
+      "id": "console.mcp.wait-for-build-completion",
+      "title": "MCP wait_for_build_completion tool",
+      "title_zh": "MCP 构建/部署就绪等待工具",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.mcp.wait-for-build-completion]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_wait_build_test.py"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
       "id": "console.mcp.operation-failure-context",
       "title": "MCP get_operation_failure_context tool",
       "title_zh": "MCP 操作失败上下文工具",


### PR DESCRIPTION
## Summary

Add three MCP tools that provide the signal infrastructure for the automated troubleshooting loop:

- **`get_app_health_overview`** — one-call batch health snapshot of all components; only deep-dives into non-running ones for `critical_blocker` classification
- **`wait_for_build_completion`** — bounded blocking poll (default 60s / max 120s) that returns terminal build status with classified failure reason
- **`analyze_env_conflicts`** — detects multi-source env var conflicts (component-defined vs dependency-injected) with secret value masking

Each tool is registered in `mcp_query_service.py` with schema, dispatch, and `test-manifest.json` capability entry. 18 unit tests across 3 test files, all passing.

## Test plan

- [x] 18 unit tests (`mcp_query_health_overview_test.py`, `mcp_query_wait_build_test.py`, `mcp_query_env_conflicts_test.py`)
- [x] Live-verified against dify-poc (app_id 3141) via MCP hot-sync