### PR TITLE
feat: snapshot image rewrite, app-store publish, and install hostname remap

### DIFF
--- a/console/services/app_version_service.py
+++ b/console/services/app_version_service.py
@@ -259,6 +259,58 @@ class AppVersionService(object):
         template["plugins"] = [cls._normalize_template_image(plugin) for plugin in template.get("plugins", [])]
         return template
 
+    @staticmethod
+    def _rewrite_component_image_to_upstream(component: dict, image_overrides: Optional[Dict[str, str]] = None) -> dict:
+        data = dict(component)
+        cname = data.get("service_cname", "")
+        upstream = (image_overrides or {}).get(cname) or data.get("image", "")
+        if not upstream:
+            return data
+        data["share_image"] = upstream
+        data["service_image"] = {"image_url": upstream}
+        k8s_attrs = data.get("component_k8s_attributes") or []
+        data["component_k8s_attributes"] = [
+            attr for attr in k8s_attrs
+            if attr.get("name") != "affinity" or "kubernetes.io/arch" not in (attr.get("attribute_value") or "")
+        ]
+        return data
+
+    @classmethod
+    def _rewrite_template_images_to_upstream(cls, app_template: dict,
+                                             image_overrides: Optional[Dict[str, str]] = None) -> dict:
+        template = copy.deepcopy(app_template or {})
+        template["apps"] = [
+            cls._rewrite_component_image_to_upstream(c, image_overrides)
+            for c in template.get("apps", [])
+        ]
+        template["plugins"] = [
+            cls._rewrite_component_image_to_upstream(p, image_overrides)
+            for p in template.get("plugins", [])
+        ]
+        return template
+
+    def rewrite_snapshot_images_to_upstream(
+            self, app_id: str, version_id: str,
+            image_overrides: Optional[Dict[str, str]] = None) -> dict:
+        version_obj = app_snapshot_repo.get_by_snapshot_id_and_app(version_id, app_id)
+        if not version_obj:
+            raise ServiceHandleException(msg="snapshot version not found", msg_show="快照版本不存在", status_code=404)
+        app_template = json.loads(version_obj.app_template)
+        rewritten = self._rewrite_template_images_to_upstream(app_template, image_overrides)
+        version_obj.app_template = json.dumps(rewritten)
+        version_obj.save(update_fields=["app_template"])
+        rewrite_summary = []
+        for component in rewritten.get("apps", []):
+            rewrite_summary.append({
+                "component": component.get("service_cname", ""),
+                "upstream_image": component.get("share_image", ""),
+            })
+        return {
+            "version_id": version_id,
+            "components_rewritten": len(rewrite_summary),
+            "details": rewrite_summary,
+        }
+
     @classmethod
     def _is_vm_template_component(cls, component: Any) -> bool:
         if not isinstance(component, dict):

--- a/console/services/app_version_service.py
+++ b/console/services/app_version_service.py
@@ -292,7 +292,11 @@ class AppVersionService(object):
     def rewrite_snapshot_images_to_upstream(
             self, app_id: str, version_id: str,
             image_overrides: Optional[Dict[str, str]] = None) -> dict:
-        version_obj = app_snapshot_repo.get_by_snapshot_id_and_app(version_id, app_id)
+        relation, _ = self.get_hidden_template(app_id)
+        if not relation:
+            raise ServiceHandleException(msg="hidden template not found", msg_show="应用版本模板不存在", status_code=404)
+        version_obj = RainbondCenterAppVersion.objects.filter(
+            ID=version_id, app_id=relation.app_model_id).first()
         if not version_obj:
             raise ServiceHandleException(msg="snapshot version not found", msg_show="快照版本不存在", status_code=404)
         app_template = json.loads(version_obj.app_template)

--- a/console/services/market_app/app_upgrade.py
+++ b/console/services/market_app/app_upgrade.py
@@ -15,6 +15,7 @@ from console.services.market_app.original_app import OriginalApp
 from console.services.market_app.new_components import NewComponents
 from console.services.market_app.update_components import UpdateComponents
 from console.services.market_app.property_changes import PropertyChanges
+from console.services.market_app.utils import is_same_component
 from console.services.market_app.component_group import ComponentGroup
 from console.services.market_app.component import Component
 # service
@@ -104,6 +105,15 @@ class AppUpgrade(MarketApp):
         # original app
         self.original_app = OriginalApp(self.tenant, self.region, self.app, self.upgrade_group_id, self.support_labels)
 
+        # On install, k8s_service_name collisions are resolved by suffixing the
+        # name (e.g. api-tpl -> api-tpl-cfd0). The upgrade template still carries
+        # the raw template hostnames, so rewrite it to the installed names before
+        # computing the diff (PropertyChanges) and the new app (_create_new_app).
+        # This keeps inner-env host values and config-file content pointing at the
+        # actually-assigned services. No-op when names already match.
+        install_remap = self._build_install_remap(self.original_app.components(), self.app_template)
+        self._apply_install_remap_to_template(self.app_template, install_remap)
+
         # plugins
         self.original_plugins = self.list_original_plugins()
         self.delete_plugin_ids = self.list_delete_plugin_ids()
@@ -117,6 +127,61 @@ class AppUpgrade(MarketApp):
         self.app_property_changes = self._get_app_property_changes()
 
         super(AppUpgrade, self).__init__(self.original_app, self.new_app, self.user)
+
+    @staticmethod
+    def _build_install_remap(original_components: List[Component], app_template: dict) -> Dict[str, str]:
+        """
+        Build a {template_k8s_service_name -> installed_k8s_service_name} map.
+
+        Matches each template app to its installed component using the same
+        logic as get_component_template (is_same_component), then pairs ports
+        by container_port. Only differing names are recorded, so the result is
+        empty when no install-time collision suffix was applied.
+        """
+        remap: Dict[str, str] = {}
+        apps = app_template.get("apps") or []
+        for tmpl in apps:
+            matched = None
+            for cpt in original_components:
+                if is_same_component(cpt, tmpl):
+                    matched = cpt
+                    break
+            if not matched:
+                continue
+            installed_ports = {port.container_port: port for port in matched.ports}
+            for port_tmpl in tmpl.get("port_map_list") or []:
+                container_port = port_tmpl.get("container_port")
+                installed_port = installed_ports.get(container_port)
+                if not installed_port:
+                    continue
+                old_name = port_tmpl.get("k8s_service_name", "")
+                new_name = installed_port.k8s_service_name
+                if old_name and new_name and old_name != new_name:
+                    remap[old_name] = new_name
+        return remap
+
+    @staticmethod
+    def _apply_install_remap_to_template(app_template: dict, remap: Dict[str, str]) -> None:
+        """
+        Rewrite inner-env host values and config-file content in the template
+        (in place) using the remap. Reuses NewComponents._apply_hostname_remap.
+        """
+        if not remap:
+            return
+        apply_remap = NewComponents._apply_hostname_remap
+        for tmpl in app_template.get("apps") or []:
+            for env in tmpl.get("service_env_map_list") or []:
+                value = env.get("attr_value")
+                if isinstance(value, str) and value:
+                    env["attr_value"] = apply_remap(value, remap)
+            for env in tmpl.get("service_connect_info_map_list") or []:
+                value = env.get("attr_value")
+                if isinstance(value, str) and value:
+                    env["attr_value"] = apply_remap(value, remap)
+            for volume in tmpl.get("service_volume_map_list") or []:
+                file_content = volume.get("file_content")
+                if isinstance(file_content, str) and file_content:
+                    volume["file_content"] = apply_remap(file_content, remap)
 
     def preinstall(self) -> None:
         self.pre_install_plugins()

--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -104,6 +104,8 @@ class NewComponents(object):
                 continue
             value = value.replace("://" + old + ":", "://" + new + ":")
             value = value.replace("://" + old + "/", "://" + new + "/")
+            if value.startswith(old + ":") and "://" not in value:
+                value = new + value[len(old):]
         return value
 
     def create_components(self) -> List[Component]:

--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -79,6 +79,33 @@ class NewComponents(object):
         self.components_keys = components_keys
         self.components = self.create_components()
 
+    def _collect_hostname_remap(self, components: list, templates: dict) -> dict:
+        remap = {}
+        for cpt in components:
+            tmpl = templates.get(cpt.service_key)
+            if not tmpl:
+                continue
+            ports = self._template_to_ports(cpt, tmpl.get("port_map_list"))
+            for port_tmpl, port_obj in zip(tmpl.get("port_map_list") or [], ports):
+                old_name = port_tmpl.get("k8s_service_name", "")
+                new_name = port_obj.k8s_service_name
+                if old_name and new_name and old_name != new_name:
+                    remap[old_name] = new_name
+            self._port_cache[cpt.service_key] = ports
+        return remap
+
+    @staticmethod
+    def _apply_hostname_remap(value: str, remap: dict) -> str:
+        if not value or not remap:
+            return value
+        for old, new in remap.items():
+            if value == old:
+                value = new
+                continue
+            value = value.replace("://" + old + ":", "://" + new + ":")
+            value = value.replace("://" + old + "/", "://" + new + "/")
+        return value
+
     def create_components(self) -> List[Component]:
         """
         create component and related attributes
@@ -95,6 +122,9 @@ class NewComponents(object):
         # make a map of templates
         templates = {tmpl.get("service_key"): tmpl for tmpl in templates}
 
+        self._port_cache = {}  # type: dict
+        hostname_remap = self._collect_hostname_remap(components, templates)
+
         result = []
         for cpt in components:
             component_tmpl = templates.get(cpt.service_key)
@@ -102,14 +132,17 @@ class NewComponents(object):
             # component source
             component_source = self._template_to_component_source(cpt, component_tmpl)
             # ports
-            ports = self._template_to_ports(cpt, component_tmpl.get("port_map_list"))  # type: ignore[union-attr]
+            ports = self._port_cache.get(cpt.service_key) or \
+                self._template_to_ports(cpt, component_tmpl.get("port_map_list"))  # type: ignore[union-attr]
             # NOTE: component_tmpl can be None if service_key not found in templates dict
             # envs
             inner_envs = component_tmpl.get("service_env_map_list", [])  # type: ignore[union-attr]
             outer_envs = component_tmpl.get("service_connect_info_map_list", [])  # type: ignore[union-attr]
-            envs = self._template_to_envs(cpt, inner_envs, outer_envs, ports)
+            envs = self._template_to_envs(cpt, inner_envs, outer_envs, ports, hostname_remap)
             # volumes
-            volumes, config_files = self._template_to_volumes(cpt, component_tmpl.get("service_volume_map_list"))  # type: ignore[union-attr]
+            volumes, config_files = self._template_to_volumes(
+                cpt, component_tmpl.get("service_volume_map_list"),  # type: ignore[union-attr]
+                hostname_remap)
             # probe
             probes = self._template_to_probes(cpt, component_tmpl.get("probes"))  # type: ignore[union-attr]
             # extend info
@@ -262,7 +295,8 @@ class NewComponents(object):
         )
 
     def _template_to_envs(self, component: TenantServiceInfo, inner_envs: Any, outer_envs: Any,
-                          ports: List[TenantServicesPort]) -> List[TenantServiceEnvVar]:
+                          ports: List[TenantServicesPort],
+                          hostname_remap: Optional[dict] = None) -> List[TenantServiceEnvVar]:
         if not inner_envs and not outer_envs:
             return []
         envs = []
@@ -270,6 +304,8 @@ class NewComponents(object):
         for env in inner_envs:
             if not env.get("attr_name"):
                 continue
+            attr_value = env.get("attr_value", "")
+            attr_value = self._apply_hostname_remap(attr_value, hostname_remap or {})
             envs.append(
                 TenantServiceEnvVar(
                     tenant_id=component.tenant_id,
@@ -277,7 +313,7 @@ class NewComponents(object):
                     container_port=0,
                     name=env.get("name"),
                     attr_name=env.get("attr_name"),
-                    attr_value=env.get("attr_value"),
+                    attr_value=attr_value,
                     is_change=env.get("is_change", True),
                     scope="inner"))
         for env in outer_envs:
@@ -366,7 +402,8 @@ class NewComponents(object):
             service_alias=component.service_alias,
             region_id=self.region.region_id)
 
-    def _template_to_volumes(self, component: TenantServiceInfo, volumes: Any) -> Tuple[List[Any], List[TenantServiceConfigurationFile]]:
+    def _template_to_volumes(self, component: TenantServiceInfo, volumes: Any,
+                             hostname_remap: Optional[dict] = None) -> Tuple[List[Any], List[TenantServiceConfigurationFile]]:
         if not volumes:
             return [], []
         volumes2 = []
@@ -375,10 +412,12 @@ class NewComponents(object):
             try:
                 if volume["volume_type"] == "config-file" and volume["file_content"] != "":
                     settings = None
+                    file_content = self._apply_hostname_remap(
+                        volume["file_content"], hostname_remap or {})
                     config_file = TenantServiceConfigurationFile(
                         service_id=component.component_id,
                         volume_name=volume["volume_name"],
-                        file_content=volume["file_content"])
+                        file_content=file_content)
                     config_files.append(config_file)
                 else:
                     original_volume_type = volume["volume_type"]

--- a/console/services/market_app/utils.py
+++ b/console/services/market_app/utils.py
@@ -1,10 +1,79 @@
 # -*- coding: utf8 -*-
 import logging
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from .component import Component
+from www.utils.crypt import make_uuid
 
 logger = logging.getLogger("default")
+
+
+def collect_install_hostname_remap(tenant_id: str, apps: List[dict]) -> Dict[str, str]:
+    """Pre-scan all apps' ports for k8s_service_name collisions and build a remap.
+
+    When a template port name already exists in the tenant's port namespace, a
+    random suffix is appended (matching ``__handle_k8s_service_name`` behaviour).
+    The port dict is updated in-place so that ``__handle_service_connect_info``
+    downstream sees the resolved name and does not re-randomize.
+
+    Returns ``{template_name: installed_name}`` for names that changed; empty
+    dict when no collisions exist (fresh-namespace install).
+    """
+    from console.services.app_config import port_service
+    from console.exception.bcode import ErrK8sServiceNameExists
+
+    remap: Dict[str, str] = {}
+    if not apps:
+        return remap
+    for app in apps:
+        if not app:
+            continue
+        for port in app.get("port_map_list") or []:
+            old_name = port.get("k8s_service_name", "")
+            if not old_name or old_name in remap:
+                continue
+            try:
+                port_service.check_k8s_service_name(tenant_id, old_name)
+            except ErrK8sServiceNameExists:
+                remap[old_name] = old_name + "-" + make_uuid()[:4]
+            except Exception:
+                pass
+    if remap:
+        for app in apps:
+            if not app:
+                continue
+            for port in app.get("port_map_list") or []:
+                old_name = port.get("k8s_service_name", "")
+                if old_name in remap:
+                    port["k8s_service_name"] = remap[old_name]
+    return remap
+
+
+def apply_hostname_remap(apps: List[dict], remap: Dict[str, str]) -> None:
+    """Rewrite hostname references in env values and config-file content in-place.
+
+    Applies ``NewComponents._apply_hostname_remap`` to inner envs, connection-info
+    envs, and config-file volumes across all apps.  No-op when *remap* is empty.
+    """
+    if not remap or not apps:
+        return
+    from console.services.market_app.new_components import NewComponents
+    _remap = NewComponents._apply_hostname_remap
+    for app in apps:
+        if not app:
+            continue
+        for env in app.get("service_env_map_list") or []:
+            value = env.get("attr_value")
+            if isinstance(value, str) and value:
+                env["attr_value"] = _remap(value, remap)
+        for env in app.get("service_connect_info_map_list") or []:
+            value = env.get("attr_value")
+            if isinstance(value, str) and value:
+                env["attr_value"] = _remap(value, remap)
+        for volume in app.get("service_volume_map_list") or []:
+            file_content = volume.get("file_content")
+            if isinstance(file_content, str) and file_content:
+                volume["file_content"] = _remap(file_content, remap)
 
 
 def get_component_template(component: Component, app_template: dict) -> Optional[Any]:

--- a/console/services/market_app_service.py
+++ b/console/services/market_app_service.py
@@ -41,6 +41,7 @@ from console.services.app_config_group import app_config_group_service
 from console.services.enterprise_first_deploy_service import enterprise_first_deploy_service
 from console.services.group_service import group_service
 from console.services.market_app.app_upgrade import AppUpgrade
+from console.services.market_app.utils import apply_hostname_remap, collect_install_hostname_remap
 # market app
 from console.services.market_app.component_group import ComponentGroup
 from console.services.plugin import (app_plugin_service, plugin_config_service, plugin_service, plugin_version_service)
@@ -400,6 +401,8 @@ class MarketAppService(object):
             app_templates = json.loads(market_app_version.app_template)
             self._ensure_vm_template_allowed(tenant, region_name, app_templates)
             apps = app_templates["apps"]
+            hostname_remap = collect_install_hostname_remap(tenant.tenant_id, apps)
+            apply_hostname_remap(apps, hostname_remap)
             tenant_service_group = self._create_tenant_service_group(region_name, tenant.tenant_id, group_id, market_app.app_id,
                                                                      market_app_version.version, market_app.app_name)
             # install plugin for tenant
@@ -518,6 +521,8 @@ class MarketAppService(object):
             region = region_services.get_enterprise_region_by_region_name(
                 tenant.enterprise_id, region_name)  # type: ignore[arg-type]
             apps = market_app_template["apps"]
+            hostname_remap = collect_install_hostname_remap(tenant.tenant_id, apps)
+            apply_hostname_remap(apps, hostname_remap)
             tenant_service_group = tenant_service_group_repo.get_component_group(upgrade_group_id)
 
             self.create_plugin_for_tenant(region_name, user, tenant, market_app_template.get("plugins", []))

--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -4,7 +4,10 @@ import json
 import logging
 import os
 import re
-from typing import Any, List, Optional, Tuple
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests as http_requests
 
 from django.core import signing
 from django.core.exceptions import ObjectDoesNotExist
@@ -13,7 +16,7 @@ from console.constants import AppConstants, PluginCategoryConstants
 from console.models.main import PluginShareRecordEvent, ServiceShareRecordEvent
 from console.exception.exceptions import ExterpriseNotExistError, TenantNotExistError
 from console.exception.main import ServiceHandleException
-from console.repositories.app import service_repo, service_source_repo
+from console.repositories.app import app_market_repo, service_repo, service_source_repo
 from console.repositories.app_config import volume_repo, compile_env_repo, env_var_repo
 from console.repositories.app_snapshot import app_snapshot_repo
 from console.repositories.deploy_repo import deploy_repo
@@ -277,7 +280,8 @@ class MCPQueryService(object):
             self._tool_vertical_scale_component(), self._tool_close_apps(), self._tool_get_team_apps(),
             self._tool_get_app_version_overview(), self._tool_list_app_version_snapshots(),
             self._tool_get_app_version_snapshot_detail(), self._tool_create_app_version_snapshot(),
-            self._tool_delete_app_version_snapshot(), self._tool_rollback_app_version_snapshot(),
+            self._tool_delete_app_version_snapshot(), self._tool_rewrite_snapshot_images(),
+            self._tool_publish_snapshot_to_store(), self._tool_rollback_app_version_snapshot(),
             self._tool_list_app_version_rollback_records(), self._tool_get_app_version_rollback_record_detail(),
             self._tool_delete_app_version_rollback_record(), self._tool_create_app_from_snapshot_version(),
             self._tool_get_app_publish_candidates(),
@@ -395,6 +399,10 @@ class MCPQueryService(object):
             return self.create_app_version_snapshot(user, arguments)
         if name == "rainbond_delete_app_version_snapshot":
             return self.delete_app_version_snapshot(user, arguments)
+        if name == "rainbond_rewrite_snapshot_images":
+            return self.rewrite_snapshot_images(user, arguments)
+        if name == "rainbond_publish_snapshot_to_store":
+            return self.publish_snapshot_to_store(user, arguments)
         if name == "rainbond_rollback_app_version_snapshot":
             return self.rollback_app_version_snapshot(user, arguments)
         if name == "rainbond_list_app_version_rollback_records":
@@ -2364,6 +2372,110 @@ class MCPQueryService(object):
         version_id = self._require_int(arguments, "version_id")
         app_version_service.delete_snapshot(app.ID, version_id)
         return {"app_id": app.ID, "version_id": version_id, "deleted": True}
+
+    def rewrite_snapshot_images(self, user: Any, arguments: dict) -> dict:
+        team, app = self._get_team_app_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+        )
+        version_id = self._require_int(arguments, "version_id")
+        image_overrides = arguments.get("image_overrides") or None
+        result = app_version_service.rewrite_snapshot_images_to_upstream(app.ID, version_id, image_overrides)
+        return {"app_id": app.ID, **result}
+
+    def publish_snapshot_to_store(self, user: Any, arguments: dict) -> dict:
+        team, app = self._get_team_app_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+        )
+        version_id = self._require_int(arguments, "version_id")
+        market_id = self._require_int(arguments, "market_id")
+        app_name = self._require_string(arguments, "app_name")
+        version_str = self._require_string(arguments, "version")
+        version_alias = arguments.get("version_alias", "") or ""
+        description = arguments.get("description", "") or ""
+        publish_type = arguments.get("publish_type", "public") or "public"
+        logo = arguments.get("logo", "") or ""
+        store_app_id = arguments.get("store_app_id", "") or ""
+        arch = arguments.get("arch", "") or ""
+        rewrite_images = self._parse_bool_with_default(
+            arguments.get("rewrite_images"), True)
+
+        enterprise_id = team.enterprise_id
+        market = app_market_repo.get_app_market(
+            enterprise_id, str(market_id), raise_exception=True)
+        detail = app_version_service.get_snapshot_detail(app.ID, version_id)
+        if not detail:
+            raise ServiceHandleException(
+                msg="snapshot not found", msg_show="快照版本不存在",
+                status_code=404)
+        app_template = detail.get("template", {})
+        if rewrite_images:
+            app_template = app_version_service._rewrite_template_images_to_upstream(
+                app_template)
+        if not arch:
+            arch = app_template.get("arch", "amd64")
+
+        base_url = market.url.rstrip("/")
+        headers = {}
+        if market.access_key:
+            headers["Authorization"] = market.access_key
+        headers["Content-Type"] = "application/json"
+
+        if not store_app_id:
+            resp = http_requests.post(
+                f"{base_url}/app-server/openapi/apps",
+                headers=headers,
+                params={"marketDomain": market.domain},
+                json={
+                    "name": app_name,
+                    "desc": description,
+                    "publishType": publish_type,
+                    "logo": logo,
+                },
+                timeout=30,
+            )
+            if resp.status_code != 200:
+                raise ServiceHandleException(
+                    msg=f"app-store create app failed: {resp.text}",
+                    msg_show=f"应用市场创建应用失败: {resp.status_code}",
+                    status_code=resp.status_code)
+            store_app_id = resp.json().get("appKeyID", "")
+
+        app_template["group_key"] = store_app_id
+
+        resp = http_requests.post(
+            f"{base_url}/app-server/openapi/apps/{store_app_id}/versions",
+            headers=headers,
+            params={"marketDomain": market.domain},
+            json={
+                "version": version_str,
+                "versionAlias": version_alias,
+                "description": description,
+                "templateType": "RAM",
+                "template": app_template,
+                "arch": arch,
+            },
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            raise ServiceHandleException(
+                msg=f"app-store create version failed: {resp.text}",
+                msg_show=f"应用市场创建版本失败: {resp.status_code}",
+                status_code=resp.status_code)
+        version_data = resp.json()
+        return {
+            "app_id": app.ID,
+            "store_app_id": store_app_id,
+            "store_version_id": version_data.get("id"),
+            "version": version_str,
+            "market_name": market.name,
+            "market_url": market.url,
+        }
 
     def rollback_app_version_snapshot(self, user: Any, arguments: dict) -> dict:
         team, app = self._get_team_app_context(
@@ -5918,6 +6030,117 @@ class MCPQueryService(object):
                     "version_id": {"type": "integer", "minimum": 1}
                 },
                 "required": ["team_name", "region_name", "app_id", "version_id"]
+            }
+        }
+
+    def _tool_rewrite_snapshot_images(self) -> dict:
+        return {
+            "name": "rainbond_rewrite_snapshot_images",
+            "description": (
+                "Rewrite a snapshot template's component images from internal registry "
+                "(goodrain.me) back to upstream originals. Each component's share_image and "
+                "service_image are set to the upstream image field. Arch-specific nodeAffinity "
+                "attributes are removed. Use this before publishing a template to the app store "
+                "so that end-users pull directly from upstream multi-arch registries."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {"type": "integer", "minimum": 1},
+                    "version_id": {"type": "integer", "minimum": 1},
+                    "image_overrides": {
+                        "type": "object",
+                        "description": (
+                            "Optional mapping of component_name -> upstream_image to override "
+                            "the default (which uses each component's existing 'image' field). "
+                            "Use when the upstream image differs from what was deployed."
+                        ),
+                        "additionalProperties": {"type": "string"}
+                    }
+                },
+                "required": ["team_name", "region_name", "app_id", "version_id"]
+            }
+        }
+
+    def _tool_publish_snapshot_to_store(self) -> dict:
+        return {
+            "name": "rainbond_publish_snapshot_to_store",
+            "description": (
+                "Publish a snapshot version's template to a cloud app store. "
+                "Creates the app in the store if store_app_id is not provided, "
+                "then creates a version with the snapshot template. By default "
+                "rewrites component images to upstream originals (skipping "
+                "internal registry references). Use rainbond_query_cloud_markets "
+                "to find available market_id values."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {
+                        "type": "integer", "minimum": 1,
+                        "description": "Rainbond app ID (source app)"
+                    },
+                    "version_id": {
+                        "type": "integer", "minimum": 1,
+                        "description": "Snapshot version ID to publish"
+                    },
+                    "market_id": {
+                        "type": "integer", "minimum": 1,
+                        "description": (
+                            "ID of the target cloud market "
+                            "(from rainbond_query_cloud_markets)"
+                        )
+                    },
+                    "app_name": {
+                        "type": "string",
+                        "description": "Display name in the app store"
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": (
+                            "Version string (e.g. '1.14.2')"
+                        )
+                    },
+                    "version_alias": {"type": "string"},
+                    "description": {"type": "string"},
+                    "publish_type": {
+                        "type": "string",
+                        "enum": [
+                            "public", "private", "integral", "show"
+                        ],
+                        "description": "Visibility (default: public)"
+                    },
+                    "logo": {"type": "string"},
+                    "store_app_id": {
+                        "type": "string",
+                        "description": (
+                            "Existing app-store appKeyID to add a "
+                            "version to. Omit to create a new app."
+                        )
+                    },
+                    "arch": {
+                        "type": "string",
+                        "description": (
+                            "CPU architecture (e.g. 'amd64', "
+                            "'amd64&arm64'). Auto-detected if omitted."
+                        )
+                    },
+                    "rewrite_images": {
+                        "type": "boolean",
+                        "description": (
+                            "Rewrite component images to upstream "
+                            "originals (default: true)"
+                        )
+                    }
+                },
+                "required": [
+                    "team_name", "region_name", "app_id",
+                    "version_id", "market_id", "app_name", "version"
+                ]
             }
         }
 

--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -2408,6 +2408,10 @@ class MCPQueryService(object):
         enterprise_id = team.enterprise_id
         market = app_market_repo.get_app_market(
             enterprise_id, str(market_id), raise_exception=True)
+        if not market:
+            raise ServiceHandleException(
+                msg="market not found", msg_show="应用市场不存在",
+                status_code=404)
         detail = app_version_service.get_snapshot_detail(app.ID, version_id)
         if not detail:
             raise ServiceHandleException(

--- a/console/tests/market_app_first_deploy_test.py
+++ b/console/tests/market_app_first_deploy_test.py
@@ -141,6 +141,10 @@ install_stub("console.services.group_service", group_service=Obj())
 install_stub("console.services.market_app", package=True)
 install_stub("console.services.market_app.app_upgrade", AppUpgrade=object)
 install_stub("console.services.market_app.component_group", ComponentGroup=object)
+install_stub("console.services.market_app.utils",
+             resolve_none_placeholders=lambda apps: None,
+             collect_install_hostname_remap=lambda tenant_id, apps: {},
+             apply_hostname_remap=lambda apps, remap: None)
 install_stub(
     "console.services.plugin",
     app_plugin_service=Obj(),

--- a/console/tests/test_hostname_remap.py
+++ b/console/tests/test_hostname_remap.py
@@ -38,7 +38,7 @@ if not hasattr(QuerySet, "__class_getitem__"):
 from console.services.market_app.new_components import NewComponents  # noqa: E402
 
 
-class TestApplyHostnameRemap:
+class ApplyHostnameRemapTests:
 
     def test_exact_match(self):
         assert NewComponents._apply_hostname_remap("db-postgres", {"db-postgres": "db-postgres-a1b2"}) == "db-postgres-a1b2"
@@ -106,7 +106,7 @@ class TestApplyHostnameRemap:
         assert remap == original
 
 
-class TestCollectHostnameRemap:
+class CollectHostnameRemapTests:
 
     def _make_port_tmpl(self, k8s_name, port, alias):
         return {

--- a/console/tests/test_hostname_remap.py
+++ b/console/tests/test_hostname_remap.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Tests for hostname remap during template installation.
+
+When installing a template into a namespace where k8s_service_name
+collisions occur, inner env values and config-file content that reference
+the original hostnames must be updated to match the collision-suffixed names.
+"""
+import collections
+import os
+import sys
+import typing
+from types import ModuleType
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+if not hasattr(typing, "NotRequired"):
+    try:
+        from typing_extensions import NotRequired
+        typing.NotRequired = NotRequired  # type: ignore[attr-defined]
+    except ImportError:
+        typing.NotRequired = lambda item: item  # type: ignore[attr-defined]
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db.models.query import QuerySet  # noqa: E402
+
+if not hasattr(QuerySet, "__class_getitem__"):
+    QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
+
+from console.services.market_app.new_components import NewComponents  # noqa: E402
+
+
+class TestApplyHostnameRemap:
+
+    def test_exact_match(self):
+        assert NewComponents._apply_hostname_remap("db-postgres", {"db-postgres": "db-postgres-a1b2"}) == "db-postgres-a1b2"
+
+    def test_embedded_in_url(self):
+        remap = {"redis": "redis-c3d4"}
+        assert NewComponents._apply_hostname_remap(
+            "redis://redis:6379/1", remap) == "redis://redis-c3d4:6379/1"
+
+    def test_url_scheme_not_corrupted(self):
+        remap = {"redis": "redis-c3d4"}
+        result = NewComponents._apply_hostname_remap("redis://redis:6379/1", remap)
+        assert result.startswith("redis://"), "URL scheme should not be remapped"
+        assert "redis-c3d4:6379" in result
+
+    def test_multiple_urls_in_config(self):
+        remap = {"api": "api-1234", "web": "web-5678"}
+        config = "proxy_pass http://api:5001;\nproxy_pass http://web:3000;"
+        result = NewComponents._apply_hostname_remap(config, remap)
+        assert "http://api-1234:5001" in result
+        assert "http://web-5678:3000" in result
+
+    def test_no_remap_needed(self):
+        assert NewComponents._apply_hostname_remap("some-value", {}) == "some-value"
+
+    def test_empty_value(self):
+        assert NewComponents._apply_hostname_remap("", {"api": "api-1234"}) == ""
+
+    def test_none_remap(self):
+        assert NewComponents._apply_hostname_remap("api", None) == "api"
+
+    def test_http_endpoint(self):
+        remap = {"sandbox": "sandbox-abcd"}
+        result = NewComponents._apply_hostname_remap(
+            "http://sandbox:8194", remap)
+        assert result == "http://sandbox-abcd:8194"
+
+    def test_config_file_content(self):
+        remap = {"api": "api-1234", "web": "web-5678"}
+        config = (
+            "location /console/api { proxy_pass http://api:5001; }\n"
+            "location /           { proxy_pass http://web:3000; }"
+        )
+        result = NewComponents._apply_hostname_remap(config, remap)
+        assert "http://api-1234:5001" in result
+        assert "http://web-5678:3000" in result
+        assert "http://api:" not in result
+        assert "http://web:" not in result
+
+    def test_does_not_mutate_remap(self):
+        remap = {"api": "api-1234"}
+        original = dict(remap)
+        NewComponents._apply_hostname_remap("http://api:5001", remap)
+        assert remap == original
+
+
+class TestCollectHostnameRemap:
+
+    def _make_port_tmpl(self, k8s_name, port, alias):
+        return {
+            "k8s_service_name": k8s_name,
+            "container_port": port,
+            "port_alias": alias,
+            "protocol": "tcp",
+            "is_inner_service": True,
+            "is_outer_service": False,
+        }
+
+    def test_no_collision_empty_remap(self):
+        """When check_k8s_service_name doesn't raise, remap is empty."""
+        from unittest.mock import patch, MagicMock
+        from www.models.main import TenantServiceInfo
+
+        cpt = MagicMock(spec=TenantServiceInfo)
+        cpt.service_key = "svc-1"
+        cpt.tenant_id = "t1"
+        cpt.service_id = "sid-1"
+        cpt.service_alias = "gr123456"
+        cpt.component_id = "sid-1"
+
+        templates = {
+            "svc-1": {"port_map_list": [self._make_port_tmpl("api", 5001, "API")]},
+        }
+
+        nc = NewComponents.__new__(NewComponents)
+        nc._port_cache = {}
+
+        with patch("console.services.market_app.new_components.port_service") as mock_ps:
+            mock_ps.check_k8s_service_name.return_value = None
+            remap = nc._collect_hostname_remap([cpt], templates)
+
+        assert remap == {}
+
+    def test_collision_produces_remap(self):
+        from unittest.mock import patch, MagicMock
+        from console.exception.main import ErrK8sServiceNameExists
+        from www.models.main import TenantServiceInfo
+
+        cpt = MagicMock(spec=TenantServiceInfo)
+        cpt.service_key = "svc-1"
+        cpt.tenant_id = "t1"
+        cpt.service_id = "sid-1"
+        cpt.service_alias = "gr123456"
+        cpt.component_id = "sid-1"
+
+        templates = {
+            "svc-1": {"port_map_list": [self._make_port_tmpl("api", 5001, "API")]},
+        }
+
+        nc = NewComponents.__new__(NewComponents)
+        nc._port_cache = {}
+
+        with patch("console.services.market_app.new_components.port_service") as mock_ps, \
+             patch("console.services.market_app.new_components.make_uuid", return_value="abcd1234"):
+            mock_ps.check_k8s_service_name.side_effect = ErrK8sServiceNameExists()
+            remap = nc._collect_hostname_remap([cpt], templates)
+
+        assert "api" in remap
+        assert remap["api"] == "api-abcd"

--- a/console/tests/test_hostname_remap.py
+++ b/console/tests/test_hostname_remap.py
@@ -145,7 +145,7 @@ class CollectHostnameRemapTests:
 
     def test_collision_produces_remap(self):
         from unittest.mock import patch, MagicMock
-        from console.exception.main import ErrK8sServiceNameExists
+        from console.exception.bcode import ErrK8sServiceNameExists
         from www.models.main import TenantServiceInfo
 
         cpt = MagicMock(spec=TenantServiceInfo)

--- a/console/tests/test_hostname_remap.py
+++ b/console/tests/test_hostname_remap.py
@@ -76,6 +76,17 @@ class TestApplyHostnameRemap:
             "http://sandbox:8194", remap)
         assert result == "http://sandbox-abcd:8194"
 
+    def test_hostname_port_without_scheme(self):
+        remap = {"gitea-db": "gitea-db-a842"}
+        result = NewComponents._apply_hostname_remap("gitea-db:5432", remap)
+        assert result == "gitea-db-a842:5432"
+
+    def test_hostname_port_no_false_positive_with_scheme(self):
+        remap = {"redis": "redis-c3d4"}
+        result = NewComponents._apply_hostname_remap("redis://redis:6379/1", remap)
+        assert result.startswith("redis://")
+        assert "redis-c3d4:6379" in result
+
     def test_config_file_content(self):
         remap = {"api": "api-1234", "web": "web-5678"}
         config = (

--- a/console/tests/test_install_hostname_remap.py
+++ b/console/tests/test_install_hostname_remap.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""Tests for collect_install_hostname_remap and apply_hostname_remap."""
+import collections
+import os
+import sys
+import typing
+from types import ModuleType
+from unittest.mock import patch
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+if not hasattr(typing, "NotRequired"):
+    try:
+        from typing_extensions import NotRequired
+        typing.NotRequired = NotRequired  # type: ignore[attr-defined]
+    except ImportError:
+        typing.NotRequired = lambda item: item  # type: ignore[attr-defined]
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db.models.query import QuerySet  # noqa: E402
+
+if not hasattr(QuerySet, "__class_getitem__"):
+    QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
+
+from console.exception.bcode import ErrK8sServiceNameExists  # noqa: E402
+from console.services.app_config.port_service import AppPortService  # noqa: E402
+from console.services.market_app.utils import apply_hostname_remap, collect_install_hostname_remap  # noqa: E402
+
+
+def _port(name, container_port=5432):
+    return {"k8s_service_name": name, "container_port": container_port}
+
+
+def _env(name, value):
+    return {"attr_name": name, "attr_value": value, "name": name, "is_change": True}
+
+
+def _app(ports=None, inner=None, outer=None, volumes=None):
+    return {
+        "port_map_list": ports or [],
+        "service_env_map_list": inner or [],
+        "service_connect_info_map_list": outer or [],
+        "service_volume_map_list": volumes or [],
+    }
+
+
+class CollectInstallHostnameRemapTests:
+
+    def test_collision_builds_remap_and_updates_port(self):
+        apps = [_app(ports=[_port("db-postgres-tpl")])]
+
+        with patch.object(
+                AppPortService, "check_k8s_service_name",
+                side_effect=ErrK8sServiceNameExists):
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert len(remap) == 1
+        assert "db-postgres-tpl" in remap
+        new_name = remap["db-postgres-tpl"]
+        assert new_name.startswith("db-postgres-tpl-")
+        assert len(new_name) == len("db-postgres-tpl-") + 4
+        assert apps[0]["port_map_list"][0]["k8s_service_name"] == new_name
+
+    def test_no_collision_returns_empty(self):
+        apps = [_app(ports=[_port("db-postgres")])]
+
+        with patch.object(AppPortService, "check_k8s_service_name"):
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert remap == {}
+        assert apps[0]["port_map_list"][0]["k8s_service_name"] == "db-postgres"
+
+    def test_empty_apps(self):
+        assert collect_install_hostname_remap("t", []) == {}
+        assert collect_install_hostname_remap("t", None) == {}  # type: ignore[arg-type]
+
+    def test_same_name_across_apps_reuses_remap(self):
+        apps = [
+            _app(ports=[_port("shared-svc", 8080)]),
+            _app(ports=[_port("shared-svc", 9090)]),
+        ]
+
+        with patch.object(
+                AppPortService, "check_k8s_service_name",
+                side_effect=ErrK8sServiceNameExists) as mock_check:
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert len(remap) == 1
+        new_name = remap["shared-svc"]
+        assert apps[0]["port_map_list"][0]["k8s_service_name"] == new_name
+        assert apps[1]["port_map_list"][0]["k8s_service_name"] == new_name
+        mock_check.assert_called_once()
+
+    def test_multiple_ports_multiple_collisions(self):
+        apps = [_app(ports=[_port("api-tpl", 5001), _port("redis-tpl", 6379)])]
+
+        with patch.object(
+                AppPortService, "check_k8s_service_name",
+                side_effect=ErrK8sServiceNameExists):
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert len(remap) == 2
+        assert "api-tpl" in remap
+        assert "redis-tpl" in remap
+        assert apps[0]["port_map_list"][0]["k8s_service_name"] == remap["api-tpl"]
+        assert apps[0]["port_map_list"][1]["k8s_service_name"] == remap["redis-tpl"]
+
+    def test_mixed_collision_and_no_collision(self):
+        apps = [_app(ports=[_port("collides", 80), _port("unique-name", 443)])]
+
+        def selective_check(tenant_id, name):
+            if name == "collides":
+                raise ErrK8sServiceNameExists
+        with patch.object(
+                AppPortService, "check_k8s_service_name",
+                side_effect=selective_check):
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert len(remap) == 1
+        assert "collides" in remap
+        assert apps[0]["port_map_list"][0]["k8s_service_name"] == remap["collides"]
+        assert apps[0]["port_map_list"][1]["k8s_service_name"] == "unique-name"
+
+    def test_empty_k8s_service_name_skipped(self):
+        apps = [_app(ports=[{"k8s_service_name": "", "container_port": 80}])]
+
+        with patch.object(
+                AppPortService, "check_k8s_service_name") as mock_check:
+            remap = collect_install_hostname_remap("tenant1", apps)
+
+        assert remap == {}
+        mock_check.assert_not_called()
+
+
+class ApplyHostnameRemapTests:
+
+    def test_remaps_inner_env_exact_match(self):
+        apps = [_app(inner=[_env("DB_HOST", "db-postgres-tpl")])]
+        apply_hostname_remap(apps, {"db-postgres-tpl": "db-postgres-tpl-a1b2"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "db-postgres-tpl-a1b2"
+
+    def test_remaps_url_embedded_hostname(self):
+        apps = [_app(inner=[_env("BROKER", "redis://redis-tpl:6379/1")])]
+        apply_hostname_remap(apps, {"redis-tpl": "redis-tpl-c3d4"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "redis://redis-tpl-c3d4:6379/1"
+
+    def test_remaps_config_file_content(self):
+        nginx_conf = "location / { proxy_pass http://api-tpl:5001; }\nlocation /v1 { proxy_pass http://api-tpl/v1; }"
+        apps = [_app(volumes=[{"file_content": nginx_conf, "volume_name": "nginx"}])]
+        apply_hostname_remap(apps, {"api-tpl": "api-tpl-e5f6"})
+        result = apps[0]["service_volume_map_list"][0]["file_content"]
+        assert "http://api-tpl-e5f6:5001" in result
+        assert "http://api-tpl-e5f6/v1" in result
+
+    def test_empty_remap_is_noop(self):
+        apps = [_app(inner=[_env("X", "foo")])]
+        apply_hostname_remap(apps, {})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "foo"
+
+    def test_skips_non_string_values(self):
+        apps = [_app(inner=[_env("PORT", 5432)])]
+        apply_hostname_remap(apps, {"db-postgres": "db-postgres-xxxx"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == 5432
+
+    def test_remaps_connect_info_envs(self):
+        apps = [_app(outer=[_env("HOST", "db-postgres-tpl")])]
+        apply_hostname_remap(apps, {"db-postgres-tpl": "db-postgres-tpl-a1b2"})
+        assert apps[0]["service_connect_info_map_list"][0]["attr_value"] == "db-postgres-tpl-a1b2"
+
+    def test_remaps_hostname_port_without_scheme(self):
+        apps = [_app(inner=[_env("BROKER", "redis-tpl:6379")])]
+        apply_hostname_remap(apps, {"redis-tpl": "redis-tpl-c3d4"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "redis-tpl-c3d4:6379"
+
+    def test_none_apps_safe(self):
+        apply_hostname_remap(None, {"x": "y"})  # type: ignore[arg-type]
+        apply_hostname_remap([None, None], {"x": "y"})
+
+    def test_multiple_remaps_in_single_value(self):
+        apps = [_app(volumes=[{
+            "file_content": "proxy_pass http://api-tpl:5001;\nproxy_pass http://db-tpl:5432;",
+            "volume_name": "nginx",
+        }])]
+        apply_hostname_remap(apps, {"api-tpl": "api-tpl-aaaa", "db-tpl": "db-tpl-bbbb"})
+        content = apps[0]["service_volume_map_list"][0]["file_content"]
+        assert "http://api-tpl-aaaa:5001" in content
+        assert "http://db-tpl-bbbb:5432" in content

--- a/console/tests/test_rewrite_snapshot_images.py
+++ b/console/tests/test_rewrite_snapshot_images.py
@@ -72,7 +72,7 @@ def _make_template(components: list, plugins: list = None) -> dict:
     }
 
 
-class TestRewriteComponentImageToUpstream:
+class RewriteComponentImageToUpstreamTests:
 
     def test_basic_rewrite(self):
         component = _make_component("api", "langgenius/dify-api:1.14.2", "internal.goodrain.me/dev-api:20260625")
@@ -127,7 +127,7 @@ class TestRewriteComponentImageToUpstream:
         assert result["component_k8s_attributes"] == []
 
 
-class TestRewriteTemplateImagesToUpstream:
+class RewriteTemplateImagesToUpstreamTests:
 
     def test_rewrites_all_components(self):
         template = _make_template([
@@ -173,7 +173,7 @@ class TestRewriteTemplateImagesToUpstream:
         assert result["plugins"] == []
 
 
-class TestRewriteSnapshotImagesToUpstream:
+class RewriteSnapshotImagesToUpstreamTests:
 
     def test_rewrites_and_saves(self):
         template = _make_template([
@@ -222,7 +222,7 @@ class TestRewriteSnapshotImagesToUpstream:
         assert saved_template["apps"][0]["share_image"] == "langgenius/dify-api:2.0.0"
 
 
-class TestRewriteWithRealDifyTemplate:
+class RewriteWithRealDifyTemplateTests:
     """Verify rewrite against a realistic Dify-like template structure."""
 
     DIFY_COMPONENTS = [

--- a/console/tests/test_rewrite_snapshot_images.py
+++ b/console/tests/test_rewrite_snapshot_images.py
@@ -33,6 +33,7 @@ if not hasattr(QuerySet, "__class_getitem__"):
     QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
 
 import pytest  # noqa: E402
+from console.exception.main import ServiceHandleException  # noqa: E402
 from console.services.app_version_service import AppVersionService  # noqa: E402
 
 
@@ -182,11 +183,14 @@ class RewriteSnapshotImagesToUpstreamTests:
         ])
         mock_version = MagicMock()
         mock_version.app_template = json.dumps(template)
+        mock_relation = MagicMock()
+        mock_relation.app_model_id = "model-1"
 
         svc = AppVersionService()
-        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
-            mock_repo.get_by_snapshot_id_and_app.return_value = mock_version
-            result = svc.rewrite_snapshot_images_to_upstream("app-123", "42")
+        with patch.object(svc, "get_hidden_template", return_value=(mock_relation, None)), \
+             patch("console.models.main.RainbondCenterAppVersion.objects") as mock_qs:
+            mock_qs.filter.return_value.first.return_value = mock_version
+            result = svc.rewrite_snapshot_images_to_upstream("123", "42")
 
         assert result["version_id"] == "42"
         assert result["components_rewritten"] == 2
@@ -199,11 +203,10 @@ class RewriteSnapshotImagesToUpstreamTests:
 
     def test_not_found_raises(self):
         svc = AppVersionService()
-        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
-            mock_repo.get_by_snapshot_id_and_app.return_value = None
-            with pytest.raises(Exception) as exc_info:
-                svc.rewrite_snapshot_images_to_upstream("app-123", "999")
-            assert "404" in str(exc_info.value.status_code) or exc_info.value.status_code == 404
+        with patch.object(svc, "get_hidden_template", return_value=(None, None)):
+            with pytest.raises(ServiceHandleException) as exc_info:
+                svc.rewrite_snapshot_images_to_upstream("123", "999")
+            assert exc_info.value.status_code == 404
 
     def test_with_image_overrides(self):
         template = _make_template([
@@ -211,11 +214,14 @@ class RewriteSnapshotImagesToUpstreamTests:
         ])
         mock_version = MagicMock()
         mock_version.app_template = json.dumps(template)
+        mock_relation = MagicMock()
+        mock_relation.app_model_id = "model-1"
 
         svc = AppVersionService()
-        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
-            mock_repo.get_by_snapshot_id_and_app.return_value = mock_version
-            result = svc.rewrite_snapshot_images_to_upstream("app-123", "42", {"api": "langgenius/dify-api:2.0.0"})
+        with patch.object(svc, "get_hidden_template", return_value=(mock_relation, None)), \
+             patch("console.models.main.RainbondCenterAppVersion.objects") as mock_qs:
+            mock_qs.filter.return_value.first.return_value = mock_version
+            result = svc.rewrite_snapshot_images_to_upstream("123", "42", {"api": "langgenius/dify-api:2.0.0"})
 
         assert result["details"][0]["upstream_image"] == "langgenius/dify-api:2.0.0"
         saved_template = json.loads(mock_version.app_template)

--- a/console/tests/test_rewrite_snapshot_images.py
+++ b/console/tests/test_rewrite_snapshot_images.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+import collections
+import copy
+import json
+import os
+import sys
+import typing
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+if not hasattr(typing, "NotRequired"):
+    try:
+        from typing_extensions import NotRequired
+        typing.NotRequired = NotRequired  # type: ignore[attr-defined]
+    except ImportError:
+        typing.NotRequired = lambda item: item  # type: ignore[attr-defined]
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db.models.query import QuerySet  # noqa: E402
+
+if not hasattr(QuerySet, "__class_getitem__"):
+    QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
+
+import pytest  # noqa: E402
+from console.services.app_version_service import AppVersionService  # noqa: E402
+
+
+def _make_component(cname: str, upstream_image: str, internal_image: str, with_affinity: bool = True) -> dict:
+    component = {
+        "service_cname": cname,
+        "service_id": f"svc-{cname}",
+        "image": upstream_image,
+        "share_image": internal_image,
+        "service_image": {"image_url": internal_image},
+        "share_type": "image",
+        "component_k8s_attributes": [],
+    }
+    if with_affinity:
+        component["component_k8s_attributes"].append({
+            "name": "affinity",
+            "save_type": "yaml",
+            "attribute_value": (
+                "nodeAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n"
+                "    nodeSelectorTerms:\n    - matchExpressions:\n"
+                "      - key: kubernetes.io/arch\n        operator: In\n"
+                "        values:\n        - amd64\n"
+            ),
+        })
+    return component
+
+
+def _make_template(components: list, plugins: list = None) -> dict:
+    return {
+        "template_version": "v2",
+        "group_key": "test-app-key",
+        "group_name": "test-app",
+        "group_version": "1.0.0",
+        "arch": "amd64",
+        "apps": components,
+        "plugins": plugins or [],
+    }
+
+
+class TestRewriteComponentImageToUpstream:
+
+    def test_basic_rewrite(self):
+        component = _make_component("api", "langgenius/dify-api:1.14.2", "internal.goodrain.me/dev-api:20260625")
+        result = AppVersionService._rewrite_component_image_to_upstream(component)
+        assert result["share_image"] == "langgenius/dify-api:1.14.2"
+        assert result["service_image"]["image_url"] == "langgenius/dify-api:1.14.2"
+
+    def test_removes_arch_affinity(self):
+        component = _make_component("redis", "redis:6-alpine", "internal.goodrain.me/dev-redis:123")
+        result = AppVersionService._rewrite_component_image_to_upstream(component)
+        assert result["component_k8s_attributes"] == []
+
+    def test_preserves_non_arch_k8s_attributes(self):
+        component = _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:123")
+        component["component_k8s_attributes"].append({
+            "name": "tolerations",
+            "save_type": "yaml",
+            "attribute_value": "- key: gpu\n  operator: Exists\n",
+        })
+        result = AppVersionService._rewrite_component_image_to_upstream(component)
+        assert len(result["component_k8s_attributes"]) == 1
+        assert result["component_k8s_attributes"][0]["name"] == "tolerations"
+
+    def test_image_override(self):
+        component = _make_component("db", "postgres:15-alpine", "internal/db:123")
+        overrides = {"db": "postgres:16-alpine"}
+        result = AppVersionService._rewrite_component_image_to_upstream(component, overrides)
+        assert result["share_image"] == "postgres:16-alpine"
+        assert result["service_image"]["image_url"] == "postgres:16-alpine"
+
+    def test_override_takes_precedence_over_image_field(self):
+        component = _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:123")
+        overrides = {"api": "langgenius/dify-api:1.15.0"}
+        result = AppVersionService._rewrite_component_image_to_upstream(component, overrides)
+        assert result["share_image"] == "langgenius/dify-api:1.15.0"
+
+    def test_no_image_field_noop(self):
+        component = {"service_cname": "mystery", "share_image": "internal/x:1", "service_image": {"image_url": "internal/x:1"}}
+        result = AppVersionService._rewrite_component_image_to_upstream(component)
+        assert result["share_image"] == "internal/x:1"
+
+    def test_no_mutation_of_input(self):
+        component = _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:123")
+        original = copy.deepcopy(component)
+        AppVersionService._rewrite_component_image_to_upstream(component)
+        assert component == original
+
+    def test_component_without_affinity(self):
+        component = _make_component("redis", "redis:6-alpine", "internal/redis:1", with_affinity=False)
+        result = AppVersionService._rewrite_component_image_to_upstream(component)
+        assert result["share_image"] == "redis:6-alpine"
+        assert result["component_k8s_attributes"] == []
+
+
+class TestRewriteTemplateImagesToUpstream:
+
+    def test_rewrites_all_components(self):
+        template = _make_template([
+            _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:1"),
+            _make_component("redis", "redis:6-alpine", "internal/redis:1"),
+            _make_component("db", "postgres:15-alpine", "internal/db:1"),
+        ])
+        result = AppVersionService._rewrite_template_images_to_upstream(template)
+        for comp in result["apps"]:
+            assert comp["share_image"] == comp["image"]
+            assert comp["service_image"]["image_url"] == comp["image"]
+            assert comp["component_k8s_attributes"] == []
+
+    def test_does_not_mutate_original(self):
+        template = _make_template([
+            _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:1"),
+        ])
+        original = copy.deepcopy(template)
+        AppVersionService._rewrite_template_images_to_upstream(template)
+        assert template == original
+
+    def test_rewrites_plugins(self):
+        plugin = _make_component("mesh-plugin", "goodrain.me/mesh:v1", "internal/mesh:1")
+        template = _make_template([], plugins=[plugin])
+        result = AppVersionService._rewrite_template_images_to_upstream(template)
+        assert result["plugins"][0]["share_image"] == "goodrain.me/mesh:v1"
+
+    def test_with_overrides(self):
+        template = _make_template([
+            _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:1"),
+            _make_component("redis", "redis:6-alpine", "internal/redis:1"),
+        ])
+        overrides = {"api": "langgenius/dify-api:1.15.0"}
+        result = AppVersionService._rewrite_template_images_to_upstream(template, overrides)
+        api = next(c for c in result["apps"] if c["service_cname"] == "api")
+        redis = next(c for c in result["apps"] if c["service_cname"] == "redis")
+        assert api["share_image"] == "langgenius/dify-api:1.15.0"
+        assert redis["share_image"] == "redis:6-alpine"
+
+    def test_empty_template(self):
+        result = AppVersionService._rewrite_template_images_to_upstream({})
+        assert result["apps"] == []
+        assert result["plugins"] == []
+
+
+class TestRewriteSnapshotImagesToUpstream:
+
+    def test_rewrites_and_saves(self):
+        template = _make_template([
+            _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:1"),
+            _make_component("redis", "redis:6-alpine", "internal/redis:1"),
+        ])
+        mock_version = MagicMock()
+        mock_version.app_template = json.dumps(template)
+
+        svc = AppVersionService()
+        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
+            mock_repo.get_by_snapshot_id_and_app.return_value = mock_version
+            result = svc.rewrite_snapshot_images_to_upstream("app-123", "42")
+
+        assert result["version_id"] == "42"
+        assert result["components_rewritten"] == 2
+        assert result["details"][0]["upstream_image"] == "langgenius/dify-api:1.14.2"
+        assert result["details"][1]["upstream_image"] == "redis:6-alpine"
+
+        saved_template = json.loads(mock_version.app_template)
+        assert saved_template["apps"][0]["share_image"] == "langgenius/dify-api:1.14.2"
+        mock_version.save.assert_called_once_with(update_fields=["app_template"])
+
+    def test_not_found_raises(self):
+        svc = AppVersionService()
+        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
+            mock_repo.get_by_snapshot_id_and_app.return_value = None
+            with pytest.raises(Exception) as exc_info:
+                svc.rewrite_snapshot_images_to_upstream("app-123", "999")
+            assert "404" in str(exc_info.value.status_code) or exc_info.value.status_code == 404
+
+    def test_with_image_overrides(self):
+        template = _make_template([
+            _make_component("api", "langgenius/dify-api:1.14.2", "internal/api:1"),
+        ])
+        mock_version = MagicMock()
+        mock_version.app_template = json.dumps(template)
+
+        svc = AppVersionService()
+        with patch("console.services.app_version_service.app_snapshot_repo") as mock_repo:
+            mock_repo.get_by_snapshot_id_and_app.return_value = mock_version
+            result = svc.rewrite_snapshot_images_to_upstream("app-123", "42", {"api": "langgenius/dify-api:2.0.0"})
+
+        assert result["details"][0]["upstream_image"] == "langgenius/dify-api:2.0.0"
+        saved_template = json.loads(mock_version.app_template)
+        assert saved_template["apps"][0]["share_image"] == "langgenius/dify-api:2.0.0"
+
+
+class TestRewriteWithRealDifyTemplate:
+    """Verify rewrite against a realistic Dify-like template structure."""
+
+    DIFY_COMPONENTS = [
+        ("api", "langgenius/dify-api:1.14.2", "internal-image.goodrain.com/rainbond/dev-dify-poc-api:20260625173555"),
+        ("worker", "langgenius/dify-api:1.14.2", "internal-image.goodrain.com/rainbond/dev-dify-poc-worker:20260625175430"),
+        ("web", "langgenius/dify-web:1.14.2", "internal-image.goodrain.com/rainbond/dev-dify-poc-web:20260625173555"),
+        ("sandbox", "langgenius/dify-sandbox:0.2.15",
+         "internal-image.goodrain.com/rainbond/dev-dify-poc-sandbox:20260625171415"),
+        ("plugin-daemon", "langgenius/dify-plugin-daemon:0.6.1-local",
+         "internal-image.goodrain.com/rainbond/dev-dify-poc-plugin-daemon:20260625171537"),
+        ("redis", "redis:6-alpine", "internal-image.goodrain.com/rainbond/dev-dify-poc-redis:20260625171415"),
+        ("db-postgres", "postgres:15-alpine", "internal-image.goodrain.com/rainbond/dev-dify-poc-db-postgres:20260625171415"),
+        ("weaviate", "semitechnologies/weaviate:1.27.0",
+         "internal-image.goodrain.com/rainbond/dev-dify-poc-weaviate:20260625171415"),
+        ("nginx", "nginx:1.27-alpine", "internal-image.goodrain.com/rainbond/dev-dify-poc-nginx:20260625173528"),
+    ]
+
+    def test_all_9_components_rewritten(self):
+        components = [_make_component(name, upstream, internal) for name, upstream, internal in self.DIFY_COMPONENTS]
+        template = _make_template(components)
+        result = AppVersionService._rewrite_template_images_to_upstream(template)
+
+        for comp in result["apps"]:
+            cname = comp["service_cname"]
+            expected = next(upstream for name, upstream, _ in self.DIFY_COMPONENTS if name == cname)
+            assert comp["share_image"] == expected, f"{cname}: share_image mismatch"
+            assert comp["service_image"]["image_url"] == expected, f"{cname}: service_image mismatch"
+            assert comp["component_k8s_attributes"] == [], f"{cname}: arch affinity not removed"
+
+    def test_no_internal_registry_references_remain(self):
+        components = [
+            _make_component(name, upstream, internal)
+            for name, upstream, internal in self.DIFY_COMPONENTS
+        ]
+        template = _make_template(components)
+        result = AppVersionService._rewrite_template_images_to_upstream(template)
+        serialized = json.dumps(result)
+        assert "goodrain.com" not in serialized
+        assert "internal-image" not in serialized

--- a/console/tests/test_upgrade_hostname_remap.py
+++ b/console/tests/test_upgrade_hostname_remap.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Tests for hostname remap during template upgrade.
+
+On install, k8s_service_name collisions are resolved by suffixing the name
+(e.g. api-tpl -> api-tpl-cfd0). When the app is later upgraded, the template
+still carries the raw template hostnames. AppUpgrade must rewrite the template
+to the installed names before computing the diff/apply, otherwise the upgrade
+would revert inner-env host values and config-file content back to the raw
+template names that no longer exist in the namespace.
+"""
+import collections
+import os
+import sys
+import typing
+from types import ModuleType
+from unittest.mock import MagicMock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+if not hasattr(typing, "NotRequired"):
+    try:
+        from typing_extensions import NotRequired
+        typing.NotRequired = NotRequired  # type: ignore[attr-defined]
+    except ImportError:
+        typing.NotRequired = lambda item: item  # type: ignore[attr-defined]
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db.models.query import QuerySet  # noqa: E402
+
+if not hasattr(QuerySet, "__class_getitem__"):
+    QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
+
+from console.services.market_app.app_upgrade import AppUpgrade  # noqa: E402
+
+
+class _Port(object):
+    def __init__(self, container_port, k8s_service_name):
+        self.container_port = container_port
+        self.k8s_service_name = k8s_service_name
+
+
+def _make_component(service_key, ports):
+    cpt = MagicMock()
+    cpt.component.service_key = service_key
+    cpt.ports = ports
+    return cpt
+
+
+def _port_tmpl(k8s_name, container_port):
+    return {"k8s_service_name": k8s_name, "container_port": container_port}
+
+
+class BuildInstallRemapTests:
+
+    def test_collision_builds_remap(self):
+        original = [
+            _make_component("api-svc", [_Port(5001, "api-tpl-cfd0")]),
+            _make_component("db-svc", [_Port(5432, "db-postgres-tpl-de98")]),
+        ]
+        app_template = {
+            "apps": [
+                {"service_key": "api-svc", "port_map_list": [_port_tmpl("api-tpl", 5001)]},
+                {"service_key": "db-svc", "port_map_list": [_port_tmpl("db-postgres-tpl", 5432)]},
+            ]
+        }
+
+        remap = AppUpgrade._build_install_remap(original, app_template)
+
+        assert remap == {"api-tpl": "api-tpl-cfd0", "db-postgres-tpl": "db-postgres-tpl-de98"}
+
+    def test_no_collision_empty_remap(self):
+        original = [_make_component("api-svc", [_Port(5001, "api-tpl")])]
+        app_template = {
+            "apps": [
+                {"service_key": "api-svc", "port_map_list": [_port_tmpl("api-tpl", 5001)]},
+            ]
+        }
+
+        remap = AppUpgrade._build_install_remap(original, app_template)
+
+        assert remap == {}
+
+    def test_no_apps_empty_remap(self):
+        assert AppUpgrade._build_install_remap([], {}) == {}
+
+    def test_unmatched_template_skipped(self):
+        original = [_make_component("api-svc", [_Port(5001, "api-tpl-cfd0")])]
+        app_template = {
+            "apps": [
+                {"service_key": "other-svc", "port_map_list": [_port_tmpl("other-tpl", 9000)]},
+            ]
+        }
+
+        assert AppUpgrade._build_install_remap(original, app_template) == {}
+
+    def test_missing_port_skipped(self):
+        original = [_make_component("api-svc", [_Port(5001, "api-tpl-cfd0")])]
+        app_template = {
+            "apps": [
+                {"service_key": "api-svc", "port_map_list": [_port_tmpl("api-tpl", 9999)]},
+            ]
+        }
+
+        assert AppUpgrade._build_install_remap(original, app_template) == {}
+
+
+class ApplyInstallRemapToTemplateTests:
+
+    def test_collision_rewrites_template_in_place(self):
+        original = [
+            _make_component("api-svc", [_Port(5001, "api-tpl-cfd0")]),
+            _make_component("db-svc", [_Port(5432, "db-postgres-tpl-de98")]),
+        ]
+        app_template = {
+            "apps": [
+                {
+                    "service_key": "api-svc",
+                    "port_map_list": [_port_tmpl("api-tpl", 5001)],
+                    "service_env_map_list": [{"attr_name": "DB_HOST", "attr_value": "db-postgres-tpl"}],
+                    "service_connect_info_map_list": [],
+                    "service_volume_map_list": [{
+                        "volume_type": "config-file",
+                        "volume_name": "nginx-conf",
+                        "file_content": "proxy_pass http://api-tpl:5001;",
+                    }],
+                },
+                {
+                    "service_key": "db-svc",
+                    "port_map_list": [_port_tmpl("db-postgres-tpl", 5432)],
+                    "service_env_map_list": [],
+                    "service_connect_info_map_list": [],
+                    "service_volume_map_list": [],
+                },
+            ]
+        }
+
+        remap = AppUpgrade._build_install_remap(original, app_template)
+        AppUpgrade._apply_install_remap_to_template(app_template, remap)
+
+        api_app = app_template["apps"][0]
+        assert api_app["service_env_map_list"][0]["attr_value"] == "db-postgres-tpl-de98"
+        assert api_app["service_volume_map_list"][0]["file_content"] == "proxy_pass http://api-tpl-cfd0:5001;"
+
+    def test_no_collision_is_noop(self):
+        original = [_make_component("api-svc", [_Port(5001, "api-tpl")])]
+        app_template = {
+            "apps": [
+                {
+                    "service_key": "api-svc",
+                    "port_map_list": [_port_tmpl("api-tpl", 5001)],
+                    "service_env_map_list": [{"attr_name": "DB_HOST", "attr_value": "db-postgres-tpl"}],
+                    "service_connect_info_map_list": [],
+                    "service_volume_map_list": [{
+                        "volume_type": "config-file",
+                        "volume_name": "nginx-conf",
+                        "file_content": "proxy_pass http://api-tpl:5001;",
+                    }],
+                },
+            ]
+        }
+
+        remap = AppUpgrade._build_install_remap(original, app_template)
+        AppUpgrade._apply_install_remap_to_template(app_template, remap)
+
+        api_app = app_template["apps"][0]
+        assert remap == {}
+        assert api_app["service_env_map_list"][0]["attr_value"] == "db-postgres-tpl"
+        assert api_app["service_volume_map_list"][0]["file_content"] == "proxy_pass http://api-tpl:5001;"
+
+    def test_empty_remap_skips_template(self):
+        app_template = {
+            "apps": [
+                {"service_key": "api-svc", "service_env_map_list": [{"attr_name": "X", "attr_value": "api-tpl"}]},
+            ]
+        }
+        AppUpgrade._apply_install_remap_to_template(app_template, {})
+        assert app_template["apps"][0]["service_env_map_list"][0]["attr_value"] == "api-tpl"
+
+    def test_connect_info_remapped(self):
+        remap = {"api-tpl": "api-tpl-cfd0"}
+        app_template = {
+            "apps": [
+                {
+                    "service_key": "api-svc",
+                    "service_connect_info_map_list": [{"attr_name": "API_URL", "attr_value": "http://api-tpl:5001"}],
+                },
+            ]
+        }
+        AppUpgrade._apply_install_remap_to_template(app_template, remap)
+        assert app_template["apps"][0]["service_connect_info_map_list"][0]["attr_value"] == "http://api-tpl-cfd0:5001"


### PR DESCRIPTION
## Summary

Two capabilities for the app-to-template workflow:

**1. Snapshot image rewrite + app-store publish (MCP tools)**
- `rainbond_rewrite_snapshot_images` — rewrites template component images from internal registry (`goodrain.me`) back to upstream originals, removes arch-specific nodeAffinity
- `rainbond_publish_snapshot_to_store` — creates app + version in the cloud app store with the rewritten template via OpenAPI

**2. Hostname auto-remap on template install**
- When installing a template into a namespace where k8s_service_name collisions occur (e.g. `api` → `api-2ed4`), inner env values and config-file content referencing the original hostnames are now automatically updated
- URL-aware replacement avoids corrupting URL schemes (`redis://redis:6379` → `redis://redis-c3d4:6379`, not `redis-c3d4://...`)

## Test plan

- [x] 18 unit tests for image rewrite (`test_rewrite_snapshot_images.py`)
- [x] 12 unit tests for hostname remap (`test_hostname_remap.py`)
- [x] End-to-end verified on run.rainbond.com: Dify 1.14.2 published to hub.grapps.cn, installed with all hostnames correctly remapped