### PR TITLE
fix: pass upgrade_group_id when creating openapi upgrade record

### DIFF
--- a/console/services/upgrade_services.py
+++ b/console/services/upgrade_services.py
@@ -845,10 +845,12 @@ class UpgradeService(object):
                 continue
             exist_component = services.first()
             pc = PropertiesChanges(exist_component, team, all_component_one_model=services)
+            upgrade_group_id = update_version.get("upgrade_group_id") or exist_component.tenant_service_group_id
             recode_kwargs = {
                 "tenant_id": team.tenant_id,
                 "group_id": int(app_id),
                 "group_key": app_model_id,
+                "upgrade_group_id": upgrade_group_id,
                 "is_from_cloud": bool(market_name),
                 "market_name": market_name,
             }

--- a/console/tests/upgrade_services_test.py
+++ b/console/tests/upgrade_services_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 from types import ModuleType
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
     if not hasattr(collections, attr):
@@ -42,6 +43,7 @@ import django  # noqa: E402
 django.setup()
 
 from console.models.main import AppUpgradeRecordType, UpgradeStatus  # noqa: E402
+from console.services import upgrade_services as upgrade_services_module  # noqa: E402
 from console.services.upgrade_services import UpgradeService  # noqa: E402
 
 
@@ -89,3 +91,73 @@ class UpgradeServiceRecordStatusTests(TestCase):
         self.service._update_app_record_status(app_record, [])
 
         self.assertEqual(UpgradeStatus.PARTIAL_UPGRADED.value, app_record.status)
+
+
+class FakeTeam(object):
+    def __init__(self):
+        self.tenant_id = "tenant-1"
+        self.enterprise_id = "ent-1"
+
+
+# capability_id: console.app-upgrade.openapi-upgrade-group-id
+class OpenapiUpgradeGroupIdTests(TestCase):
+    """openapi_upgrade_app_models must always pass upgrade_group_id to
+    get_or_create_upgrade_record (which requires it as a positional arg).
+
+    Regression for the missing-argument crash: the OpenAPI upgrade endpoint
+    and the MCP upgrade tool both reached get_or_create_upgrade_record without
+    upgrade_group_id, raising TypeError. The value comes from the request when
+    supplied, otherwise falls back to the component's tenant_service_group_id.
+    """
+
+    def setUp(self):
+        self.service = upgrade_services_module.upgrade_service
+        self.team = FakeTeam()
+
+    def _run(self, update_version):
+        exist_component = MagicMock()
+        exist_component.tenant_service_group_id = 2878
+        services = MagicMock()
+        services.first.return_value = exist_component
+
+        created_record = MagicMock()
+        created_record.ID = 99
+
+        data = {"update_versions": [update_version]}
+
+        with patch.object(upgrade_services_module.group_service, "get_rainbond_services", return_value=services), \
+                patch.object(upgrade_services_module, "PropertiesChanges"), \
+                patch.object(self.service, "get_upgrade_info", return_value=({}, {})), \
+                patch.object(self.service, "get_or_create_upgrade_record",
+                             return_value=created_record) as mock_get_or_create, \
+                patch.object(self.service, "synchronous_upgrade_status"), \
+                patch.object(upgrade_services_module.AppUpgradeRecord.objects, "get", return_value=created_record), \
+                patch.object(upgrade_services_module.service_repo,
+                             "get_services_by_service_ids_and_group_key", return_value=[]), \
+                patch.object(self.service, "upgrade_database"), \
+                patch.object(self.service, "send_upgrade_request"), \
+                patch.object(upgrade_services_module.upgrade_repo, "change_app_record_status"):
+            self.service.openapi_upgrade_app_models(
+                user=MagicMock(), team=self.team, region_name="rainbond",
+                oauth_instance=None, app_id="3199", data=data)
+
+        return mock_get_or_create
+
+    def test_uses_upgrade_group_id_from_request_when_provided(self):
+        mock_get_or_create = self._run({
+            "app_model_id": "model-1",
+            "app_model_version": "1.14.4",
+            "market_name": "market-1",
+            "upgrade_group_id": 2867,
+        })
+
+        self.assertEqual(2867, mock_get_or_create.call_args.kwargs["upgrade_group_id"])
+
+    def test_falls_back_to_component_group_id_when_request_omits_it(self):
+        mock_get_or_create = self._run({
+            "app_model_id": "model-1",
+            "app_model_version": "1.14.4",
+            "market_name": "market-1",
+        })
+
+        self.assertEqual(2878, mock_get_or_create.call_args.kwargs["upgrade_group_id"])

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1797,6 +1797,24 @@
       "status": "active"
     },
     {
+      "id": "console.app-upgrade.openapi-upgrade-group-id",
+      "title": "OpenAPI upgrade passes upgrade_group_id to record creation",
+      "title_zh": "OpenAPI 升级向记录创建传递 upgrade_group_id",
+      "interface_type": "service_method",
+      "interface": "console.services.upgrade_services.UpgradeService.openapi_upgrade_app_models",
+      "code_paths": [
+        "console/services/upgrade_services.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/upgrade_services_test.py",
+          "selector": "OpenapiUpgradeGroupIdTests"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-upgrade.records",
       "title": "App Upgrade Records",
       "title_zh": "App Upgrade Records",


### PR DESCRIPTION
## Problem

\`UpgradeService.openapi_upgrade_app_models\` builds \`recode_kwargs\` without \`upgrade_group_id\`, but \`get_or_create_upgrade_record\` requires it as a positional argument:

\`\`\`python
def get_or_create_upgrade_record(self, tenant_id, group_id, group_key,
                                 upgrade_group_id, is_from_cloud, market_name):
\`\`\`

As a result the call always raises \`TypeError: get_or_create_upgrade_record() missing 1 required positional argument: 'upgrade_group_id'\` before reaching the region deploy. This affects both entry points:

- The OpenAPI upgrade endpoint \`POST /openapi/v1/.../apps/{app_id}/upgrade\` (\`openapi/views/apps/market.py\`) — its \`UpgradeBaseSerializer\` does not carry \`upgrade_group_id\`.
- The MCP \`upgrade_app\` tool (\`console/services/mcp_query_service.py\`).

## Fix

Resolve \`upgrade_group_id\` from the request payload when supplied, otherwise fall back to the component's \`tenant_service_group_id\` (the group the components already belong to), and pass it into \`recode_kwargs\`.

## Test plan

- Added \`OpenapiUpgradeGroupIdTests\` in \`console/tests/upgrade_services_test.py\`:
  - uses \`upgrade_group_id\` from the request when provided
  - falls back to the component's \`tenant_service_group_id\` when omitted
- \`upgrade_services_test.py\` (5 passed), \`upgrade_view_test.py\` (3 passed), \`mcp_query_operation_event_ids_test.py\` (5 passed) — no regressions.
- Verified live: market-app upgrade (Dify v1.14.2 → v1.14.4) now creates the upgrade record and deploys the changed components.