### PR TITLE
fix: gate hostname remap exact-match on host-valued envs

### DIFF
--- a/console/services/market_app/app_upgrade.py
+++ b/console/services/market_app/app_upgrade.py
@@ -169,15 +169,16 @@ class AppUpgrade(MarketApp):
         if not remap:
             return
         apply_remap = NewComponents._apply_hostname_remap
+        is_host = NewComponents._is_host_env_name
         for tmpl in app_template.get("apps") or []:
             for env in tmpl.get("service_env_map_list") or []:
                 value = env.get("attr_value")
                 if isinstance(value, str) and value:
-                    env["attr_value"] = apply_remap(value, remap)
+                    env["attr_value"] = apply_remap(value, remap, is_host(env.get("attr_name")))
             for env in tmpl.get("service_connect_info_map_list") or []:
                 value = env.get("attr_value")
                 if isinstance(value, str) and value:
-                    env["attr_value"] = apply_remap(value, remap)
+                    env["attr_value"] = apply_remap(value, remap, is_host(env.get("attr_name")))
             for volume in tmpl.get("service_volume_map_list") or []:
                 file_content = volume.get("file_content")
                 if isinstance(file_content, str) and file_content:

--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -96,11 +96,27 @@ class NewComponents(object):
         return remap
 
     @staticmethod
-    def _apply_hostname_remap(value: str, remap: dict) -> str:
+    def _is_host_env_name(attr_name: str) -> bool:
+        """Whether an env holds a bare hostname (``*_HOST`` / ``*_HOSTNAME`` / ``HOST``).
+
+        Only these may have their whole value exact-matched against a colliding
+        service name during hostname remap. Other envs whose value happens to
+        equal a service name (e.g. Harbor's ``POSTGRESQL_DATABASE=registry``,
+        which collides with the ``registry`` component) must NOT be rewritten.
+        """
+        if not attr_name:
+            return False
+        return attr_name == "HOST" or attr_name.endswith("_HOST") or attr_name.endswith("_HOSTNAME")
+
+    @staticmethod
+    def _apply_hostname_remap(value: str, remap: dict, is_host_env: bool = False) -> str:
         if not value or not remap:
             return value
         for old, new in remap.items():
-            if value == old:
+            # Exact whole-value match is only safe for hostname-valued envs; a
+            # database name / username that merely equals a service name must be
+            # left alone. URL and host:port rewrites below are unambiguous.
+            if is_host_env and value == old:
                 value = new
                 continue
             value = value.replace("://" + old + ":", "://" + new + ":")
@@ -321,7 +337,8 @@ class NewComponents(object):
             resolved = self._resolve_none_placeholder(attr_value)
             if resolved is not None:
                 attr_value = resolved
-            attr_value = self._apply_hostname_remap(attr_value, hostname_remap or {})
+            attr_value = self._apply_hostname_remap(
+                attr_value, hostname_remap or {}, self._is_host_env_name(env.get("attr_name")))
             envs.append(
                 TenantServiceEnvVar(
                     tenant_id=component.tenant_id,

--- a/console/services/market_app/utils.py
+++ b/console/services/market_app/utils.py
@@ -106,17 +106,18 @@ def apply_hostname_remap(apps: List[dict], remap: Dict[str, str]) -> None:
         return
     from console.services.market_app.new_components import NewComponents
     _remap = NewComponents._apply_hostname_remap
+    _is_host = NewComponents._is_host_env_name
     for app in apps:
         if not app:
             continue
         for env in app.get("service_env_map_list") or []:
             value = env.get("attr_value")
             if isinstance(value, str) and value:
-                env["attr_value"] = _remap(value, remap)
+                env["attr_value"] = _remap(value, remap, _is_host(env.get("attr_name")))
         for env in app.get("service_connect_info_map_list") or []:
             value = env.get("attr_value")
             if isinstance(value, str) and value:
-                env["attr_value"] = _remap(value, remap)
+                env["attr_value"] = _remap(value, remap, _is_host(env.get("attr_name")))
         for volume in app.get("service_volume_map_list") or []:
             file_content = volume.get("file_content")
             if isinstance(file_content, str) and file_content:

--- a/console/tests/test_hostname_remap.py
+++ b/console/tests/test_hostname_remap.py
@@ -40,8 +40,16 @@ from console.services.market_app.new_components import NewComponents  # noqa: E4
 
 class ApplyHostnameRemapTests:
 
-    def test_exact_match(self):
-        assert NewComponents._apply_hostname_remap("db-postgres", {"db-postgres": "db-postgres-a1b2"}) == "db-postgres-a1b2"
+    def test_exact_match_host_env(self):
+        # A bare hostname value is remapped only when the env is host-valued.
+        assert NewComponents._apply_hostname_remap(
+            "db-postgres", {"db-postgres": "db-postgres-a1b2"}, is_host_env=True) == "db-postgres-a1b2"
+
+    def test_exact_match_non_host_env_left_alone(self):
+        # A non-host value that merely equals a service name must not be rewritten
+        # (e.g. Harbor POSTGRESQL_DATABASE=registry vs the registry component).
+        assert NewComponents._apply_hostname_remap(
+            "db-postgres", {"db-postgres": "db-postgres-a1b2"}) == "db-postgres"
 
     def test_embedded_in_url(self):
         remap = {"redis": "redis-c3d4"}

--- a/console/tests/test_install_hostname_remap.py
+++ b/console/tests/test_install_hostname_remap.py
@@ -194,3 +194,17 @@ class ApplyHostnameRemapTests:
         content = apps[0]["service_volume_map_list"][0]["file_content"]
         assert "http://api-tpl-aaaa:5001" in content
         assert "http://db-tpl-bbbb:5432" in content
+
+    def test_does_not_remap_non_host_env_matching_service_name(self):
+        # Regression (Harbor): the Harbor DB name "registry" collides with the
+        # registry component's k8s service name. A non-host env value that merely
+        # equals a service name must NOT be rewritten — only host references are.
+        apps = [_app(inner=[_env("POSTGRESQL_DATABASE", "registry")])]
+        apply_hostname_remap(apps, {"registry": "registry-e51e"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "registry"
+
+    def test_remaps_bare_host_env_matching_service_name(self):
+        # A *_HOST env whose bare value equals a colliding service name IS remapped.
+        apps = [_app(inner=[_env("POSTGRESQL_HOST", "harbor-postgresql")])]
+        apply_hostname_remap(apps, {"harbor-postgresql": "harbor-postgresql-673b"})
+        assert apps[0]["service_env_map_list"][0]["attr_value"] == "harbor-postgresql-673b"


### PR DESCRIPTION
## Problem

The install-time hostname remap (`_apply_hostname_remap`, added in #2017) rewrites any env or connection value that **exactly equals** a colliding service name — including values that are not hostnames at all.

Harbor's core component sets `POSTGRESQL_DATABASE=registry`, and Harbor also has a component whose k8s service name is `registry`. On a same-tenant (collision) market install, the remap builds `{registry: registry-e51e, ...}` and rewrites `POSTGRESQL_DATABASE` from `registry` to `registry-e51e`. harbor-core then crashes in a loop:

```
FATAL: database "registry-e51e" does not exist (SQLSTATE 3D000)
```

The hostname reference `POSTGRESQL_HOST=harbor-postgresql` **is** correctly remapped — only the non-host value that happens to collide is the problem.

## Fix

Restrict the whole-value exact-match branch to **host-valued envs** — those whose name is `HOST` or ends in `_HOST` / `_HOSTNAME`. URL (`://host:port`, `://host/`) and bare `host:port` rewrites are unambiguous and remain unchanged, so hostname references are still remapped everywhere they appear.

Applied consistently across all three remap callers:
- local install — `NewComponents._template_to_envs`
- cloud/market install — `utils.apply_hostname_remap`
- upgrade — `AppUpgrade._apply_install_remap_to_template`

Only same-tenant installs (where a template service name collides with an existing one) are affected; a fresh-namespace install has an empty remap and was never impacted.

## Test plan

- Added to `console/tests/test_install_hostname_remap.py`:
  - `test_does_not_remap_non_host_env_matching_service_name` — `POSTGRESQL_DATABASE=registry` with remap `{registry: registry-e51e}` stays `registry`
  - `test_remaps_bare_host_env_matching_service_name` — `POSTGRESQL_HOST=harbor-postgresql` is still remapped
- `test_install_hostname_remap.py` (18 passed) + `test_upgrade_hostname_remap.py` (9 passed) — no regressions.
- Verified live: a same-tenant Harbor market install keeps `POSTGRESQL_DATABASE=registry` while all host references (`POSTGRESQL_HOST`, `_REDIS_URL_*`, `REGISTRY_URL`, `CORE_URL`) are correctly remapped to the suffixed service names.