### PR TITLE
fix: restore selective component publish for app version snapshots

### DIFF
--- a/console/services/app_version_service.py
+++ b/console/services/app_version_service.py
@@ -472,6 +472,7 @@ class AppVersionService(object):
         overrides = share_info.get("share_service_list")
         if overrides:
             services = self._apply_share_overrides(services, overrides)
+            services = self._filter_selected_services(services, overrides)
         plugins = share_info.get("share_plugin_list") or share_service.get_group_services_used_plugins(group_id=app.ID)
         plugins = share_service.get_plugins_group_items(plugins) if plugins else []
         k8s_resources = share_info.get("share_k8s_resources")
@@ -511,6 +512,44 @@ class AppVersionService(object):
             override_conn = override.get("service_connect_info_map_list")
             if override_conn is not None:
                 svc["service_connect_info_map_list"] = override_conn
+            result.append(svc)
+        return result
+
+    @staticmethod
+    def _filter_selected_services(services: list, overrides: list) -> list:
+        # The UI publish flow marks every selected component with `need_share`,
+        # so a share_service_list carrying that field is a component selection:
+        # unlisted (or need_share=false) components are excluded from the
+        # template. Override-only payloads (e.g. MCP env overrides) carry no
+        # `need_share` and must keep the full component list.
+        if not any("need_share" in item for item in overrides):
+            return services
+        selected_keys = set()
+        for item in overrides:
+            if not item.get("need_share"):
+                continue
+            for key in (item.get("service_key"), item.get("service_id")):
+                if key:
+                    selected_keys.add(key)
+        selected = [
+            svc for svc in services
+            if svc.get("service_key") in selected_keys or svc.get("service_id") in selected_keys
+        ]
+        if not selected or len(selected) == len(services):
+            return services
+        excluded_uuids = ({svc.get("service_share_uuid") for svc in services}
+                          - {svc.get("service_share_uuid") for svc in selected})
+        result = []
+        for svc in selected:
+            svc = dict(svc)
+            svc["dep_service_map_list"] = [
+                dep for dep in svc.get("dep_service_map_list", [])
+                if dep.get("dep_service_key") not in excluded_uuids
+            ]
+            svc["mnt_relation_list"] = [
+                mnt for mnt in svc.get("mnt_relation_list", [])
+                if mnt.get("service_share_uuid") not in excluded_uuids
+            ]
             result.append(svc)
         return result
 

--- a/console/tests/test_share_overrides.py
+++ b/console/tests/test_share_overrides.py
@@ -134,6 +134,65 @@ class ApplyShareOverridesTests:
         result = AppVersionService._apply_share_overrides(services, overrides)
         assert len(result) == 9
 
+    def test_selection_filters_unlisted_components(self):
+        services = [
+            _svc("s1", "k1", "api"),
+            _svc("s2", "k2", "redis"),
+            _svc("s3", "k3", "db"),
+        ]
+        overrides = [{"service_key": "k1", "need_share": True}]
+        result = AppVersionService._filter_selected_services(services, overrides)
+        assert [s["service_key"] for s in result] == ["k1"]
+
+    def test_selection_excludes_need_share_false(self):
+        services = [_svc("s1", "k1", "api"), _svc("s2", "k2", "redis")]
+        overrides = [
+            {"service_key": "k1", "need_share": True},
+            {"service_key": "k2", "need_share": False},
+        ]
+        result = AppVersionService._filter_selected_services(services, overrides)
+        assert [s["service_key"] for s in result] == ["k1"]
+
+    def test_override_only_payload_keeps_all_components(self):
+        # MCP env-override payloads carry no need_share and must not filter.
+        services = [_svc("s1", "k1", "api"), _svc("s2", "k2", "redis")]
+        overrides = [{"service_key": "k1", "service_env_map_list": [_env("X", "1")]}]
+        result = AppVersionService._filter_selected_services(services, overrides)
+        assert len(result) == 2
+
+    def test_selection_prunes_deps_to_excluded_components(self):
+        api = _svc("s1", "k1", "api")
+        api["service_share_uuid"] = "u1+u1"
+        api["dep_service_map_list"] = [
+            {"dep_service_key": "u2+u2"},
+            {"dep_service_key": "external+external"},
+        ]
+        api["mnt_relation_list"] = [
+            {"service_share_uuid": "u2+u2", "mnt_name": "d", "mnt_dir": "/d"},
+        ]
+        redis = _svc("s2", "k2", "redis")
+        redis["service_share_uuid"] = "u2+u2"
+        overrides = [{"service_key": "k1", "need_share": True}]
+        result = AppVersionService._filter_selected_services([api, redis], overrides)
+        assert len(result) == 1
+        assert result[0]["dep_service_map_list"] == [{"dep_service_key": "external+external"}]
+        assert result[0]["mnt_relation_list"] == []
+
+    def test_selection_of_all_components_is_noop(self):
+        services = [_svc("s1", "k1", "api"), _svc("s2", "k2", "redis")]
+        overrides = [
+            {"service_key": "k1", "need_share": True},
+            {"service_key": "k2", "need_share": True},
+        ]
+        result = AppVersionService._filter_selected_services(services, overrides)
+        assert result == services
+
+    def test_selection_matching_nothing_falls_back_to_all(self):
+        services = [_svc("s1", "k1", "api")]
+        overrides = [{"service_key": "missing", "need_share": True}]
+        result = AppVersionService._filter_selected_services(services, overrides)
+        assert result == services
+
     def test_override_without_name_preserves_original_fields(self):
         # MCP share_service_list overrides carry only {attr_name, attr_value}.
         # The field-merge must keep the original env's `name` (and `is_change`),


### PR DESCRIPTION
## 问题

自 b8f111c9a 起，创建应用快照（`POST /console/teams/{team}/groups/{group}/app-versions`）时，`share_service_list` 被当作纯字段覆盖合并到全量组件列表上，快照模板始终包含应用下的所有组件。发布界面中被取消勾选的组件无法排除，导出安装包会打包全部组件镜像，体积显著膨胀。

b8f111c9a 之前的行为是 `share_service_list` 直接作为模板组件列表（可选择性发布），该 fix 修复了 MCP 部分字段覆盖导致的空组件快照问题，但顺带丢失了选择性发布能力。

## 修复

- 当 `share_service_list` 的条目携带 `need_share` 字段时（UI 发布流），将其视为组件选择：仅保留列表中 `need_share=true` 的组件，并清理指向被排除组件的 `dep_service_map_list` / `mnt_relation_list` 引用。
- 不携带 `need_share` 的负载（如 MCP env 覆盖）保持现有 merge-only 行为，不做过滤。
- 选择为空或全选时保持原列表不变。

## 测试

- `console/tests/test_share_overrides.py` 新增 6 个用例：过滤未选组件、排除 need_share=false、override-only 不过滤、依赖/挂载引用剪枝、全选 no-op、无匹配回退。
- 逻辑经独立执行验证全部通过；`py_compile` 通过。