### PR TITLE
fix: keep current GPU value when vertical scale omits new_gpu

### DIFF
--- a/console/services/app_actions/app_manage.py
+++ b/console/services/app_actions/app_manage.py
@@ -958,6 +958,9 @@ class AppManageService(AppManageBase):
             body["container_cpu"] = new_cpu
             if new_gpu is not None and type(new_gpu) == int:
                 body["container_gpu"] = new_gpu
+            else:
+                # container_gpu 为非空列，未传 GPU 时保持组件当前值，避免写入 NULL
+                new_gpu = service.container_gpu if service.container_gpu is not None else 0
             body["operator"] = str(user.nick_name)
             body["enterprise_id"] = tenant.enterprise_id
             try:

--- a/console/tests/vertical_upgrade_gpu_test.py
+++ b/console/tests/vertical_upgrade_gpu_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase, mock
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from console.services.app_actions import app_manage_service  # noqa: E402
+
+MODULE = "console.services.app_actions.app_manage"
+
+
+class VerticalUpgradeGPUTests(TestCase):
+    def setUp(self):
+        self.tenant = SimpleNamespace(tenant_name="demo-team", enterprise_id="ent-id", creater=1)
+        self.user = SimpleNamespace(nick_name="demo-user")
+        self.service = SimpleNamespace(
+            service_alias="demo-web",
+            service_region="demo-region",
+            create_status="complete",
+            min_node=1,
+            min_memory=2048,
+            min_cpu=1000,
+            container_gpu=0,
+            save=mock.Mock(),
+        )
+
+    def _vertical_upgrade(self, **kwargs):
+        with mock.patch(MODULE + ".check_account_quota", return_value=True), \
+                mock.patch(MODULE + ".baseService.calculate_service_cpu", return_value=2000), \
+                mock.patch(MODULE + ".region_api.vertical_upgrade") as region_mock:
+            code, msg = app_manage_service.vertical_upgrade(self.tenant, self.service, self.user, oauth_instance=None, **kwargs)
+        return code, msg, region_mock
+
+    def test_omitted_gpu_keeps_current_value_instead_of_null(self):
+        self.service.container_gpu = 512
+
+        code, _, region_mock = self._vertical_upgrade(new_memory=4096, new_gpu=None, new_cpu=0)
+
+        self.assertEqual(200, code)
+        self.assertEqual(512, self.service.container_gpu)
+        self.service.save.assert_called_once()
+        body = region_mock.call_args[0][3]
+        self.assertNotIn("container_gpu", body)
+
+    def test_omitted_gpu_defaults_to_zero_when_current_is_none(self):
+        self.service.container_gpu = None
+
+        code, _, _ = self._vertical_upgrade(new_memory=4096, new_gpu=None, new_cpu=0)
+
+        self.assertEqual(200, code)
+        self.assertEqual(0, self.service.container_gpu)
+        self.service.save.assert_called_once()
+
+    def test_explicit_gpu_is_applied_and_sent_to_region(self):
+        code, _, region_mock = self._vertical_upgrade(new_memory=4096, new_gpu=1024, new_cpu=0)
+
+        self.assertEqual(200, code)
+        self.assertEqual(1024, self.service.container_gpu)
+        body = region_mock.call_args[0][3]
+        self.assertEqual(1024, body["container_gpu"])

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -10555,6 +10555,32 @@
       ],
       "test_type": "regression",
       "status": "active"
+    },
+    {
+      "id": "console.app-scale.vertical-gpu-default",
+      "title": "Vertical scale keeps GPU value when omitted",
+      "title_zh": "垂直伸缩未传 GPU 时保留组件当前值",
+      "interface_type": "service_method",
+      "interface": "console.services.app_actions.app_manage.AppManageService.vertical_upgrade",
+      "code_paths": [
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_keeps_current_value_instead_of_null"
+        },
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_defaults_to_zero_when_current_is_none"
+        },
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_explicit_gpu_is_applied_and_sent_to_region"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Calling the vertical scale API (`VerticalExtendAppView` → `AppManageService.vertical_upgrade`) without `new_gpu` returns HTTP 500:

```
MySQL error (1048, "Column 'container_gpu' cannot be null")
```

Reproduced 2026-07-21 on run.rainbond.com via the Rainbond MCP tool `rainbond_vertical_scale_component` with only `new_memory=4096` and `new_cpu=0`.

## Cause

In `vertical_upgrade`, `body["container_gpu"]` is only set when `new_gpu` is a valid int, but `service.container_gpu = new_gpu` runs unconditionally — writing `NULL` into the NOT NULL `container_gpu` column when the parameter is omitted.

## Fix

When `new_gpu` is omitted or invalid, fall back to the component's current `container_gpu` (or 0 when unset) so the GPU allocation stays unchanged. The region API request body is unchanged (still omits `container_gpu` when not explicitly provided).

## Tests

- `console/tests/vertical_upgrade_gpu_test.py`: 3 regression tests (omitted GPU keeps current value; omitted GPU defaults to 0 when current is None; explicit GPU still applied and sent to region). The two omitted-GPU tests fail without the fix and pass with it.
- Registered in `test-manifest.json`; manifest validation, flake8, and yapf pass on changed files.