### PR TITLE
fix(mcp): auto-generate unique k8s_app when not provided in rainbond_create_app

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -3002,7 +3002,7 @@ class MCPQueryService(object):
             "target_app": {
                 "app_id": target_app_id_int,
                 "app_name": self._value(created_app, "app_name") or target_app_name,
-                "k8s_app": k8s_app or None,
+                "k8s_app": self._value(created_app, "k8s_app") or k8s_app or None,
             },
             "installed": True,
             "install_result": install_result,
@@ -4980,25 +4980,55 @@ class MCPQueryService(object):
             }
         return None
 
+    K8S_APP_NAME_AUTO_BASE_MAX_LENGTH = 32
+
+    def _generate_k8s_app(self, team: Any, region_name: str, app_name: str, force_suffix: bool = False) -> str:
+        base = re.sub(r"[^a-z0-9-]+", "-", (app_name or "").lower())
+        base = re.sub(r"-+", "-", base).strip("-")
+        # k8s app 名称必须以小写字母开头
+        base = re.sub(r"^[^a-z]+", "", base).strip("-")
+        base = base[:self.K8S_APP_NAME_AUTO_BASE_MAX_LENGTH].rstrip("-")
+        if not re.match(self.K8S_APP_NAME_PATTERN, base):
+            base = "app"
+            force_suffix = True
+        candidate = "{}-{}".format(base, make_uuid()[:6]) if force_suffix else base
+        for _ in range(10):
+            if not group_repo.is_k8s_app_duplicate(team.tenant_id, region_name, candidate):
+                return candidate
+            candidate = "{}-{}".format(base, make_uuid()[:6])
+        return candidate
+
     def _create_app_with_mcp_error_details(self, team: Any, region_name: str, app_name: str, app_note: str,
                                            username: str, k8s_app: str = "") -> Any:
-        try:
-            return group_service.create_app(
-                team,
-                region_name,
-                app_name,
-                app_note,
-                username,
-                k8s_app=k8s_app if k8s_app else "",
-            )
-        except ServiceHandleException as exc:
-            raise ServiceHandleException(
-                msg=exc.msg,
-                msg_show=exc.msg_show,
-                status_code=exc.status_code,
-                error_code=exc.error_code,
-                details=self._build_create_app_error_details(exc, app_name, k8s_app),
-            )
+        auto_generated = not k8s_app
+        if auto_generated:
+            k8s_app = self._generate_k8s_app(team, region_name, app_name)
+        retried = False
+        while True:
+            try:
+                return group_service.create_app(
+                    team,
+                    region_name,
+                    app_name,
+                    app_note,
+                    username,
+                    k8s_app=k8s_app,
+                )
+            except ServiceHandleException as exc:
+                details = self._build_create_app_error_details(exc, app_name, k8s_app)
+                # 自动生成的名称与集群端残留记录冲突时，换一个带随机后缀的名称重试一次
+                if auto_generated and not retried and details and \
+                        details.get("field") == "k8s_app" and details.get("reason") == "duplicate":
+                    retried = True
+                    k8s_app = self._generate_k8s_app(team, region_name, app_name, force_suffix=True)
+                    continue
+                raise ServiceHandleException(
+                    msg=exc.msg,
+                    msg_show=exc.msg_show,
+                    status_code=exc.status_code,
+                    error_code=exc.error_code,
+                    details=details,
+                )
 
     @staticmethod
     def _parse_int_with_default(value: Any, default: Any) -> Any:

--- a/console/tests/mcp_query_service_test.py
+++ b/console/tests/mcp_query_service_test.py
@@ -1058,10 +1058,12 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
     @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
     @patch("console.services.mcp_query_service.group_service.create_app")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
     # capability_id: console.app.create
-    def test_create_app_calls_group_service(self, mock_create_app, mock_get_region, mock_get_team):
+    def test_create_app_calls_group_service(self, mock_is_duplicate, mock_create_app, mock_get_region, mock_get_team):
         mock_get_team.return_value = self.team
         mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
         mock_create_app.return_value = {"app_id": 12, "app_name": "demo-app", "group_id": 12}
 
         result = mcp_query_service.call_tool(
@@ -1105,6 +1107,169 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
         self.assertEqual(context.exception.details["field"], "k8s_app")
         self.assertEqual(context.exception.details["reason"], "duplicate")
         self.assertFalse(context.exception.details["retryable"])
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_generates_k8s_app_when_empty(self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
+        mock_create_app.return_value = {"app_id": 12, "app_name": "vf-test-xk27", "group_id": 12}
+
+        mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_app",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_name": "vf-test-xk27",
+            },
+        )
+
+        mock_create_app.assert_called_once()
+        generated = mock_create_app.call_args.kwargs["k8s_app"]
+        self.assertEqual(generated, "vf-test-xk27")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_generates_k8s_app_for_non_ascii_app_name(
+            self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
+        mock_create_app.return_value = {"app_id": 12, "app_name": "演示应用", "group_id": 12}
+
+        mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_app",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_name": "演示应用",
+            },
+        )
+
+        generated = mock_create_app.call_args.kwargs["k8s_app"]
+        self.assertTrue(generated)
+        self.assertRegex(generated, mcp_query_service.K8S_APP_NAME_PATTERN)
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_normalizes_mixed_case_app_name(
+            self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
+        mock_create_app.return_value = {"app_id": 12, "app_name": "Demo_App.v1", "group_id": 12}
+
+        mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_app",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_name": "Demo_App.v1",
+            },
+        )
+
+        generated = mock_create_app.call_args.kwargs["k8s_app"]
+        self.assertEqual(generated, "demo-app-v1")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_appends_suffix_when_generated_name_taken_in_console(
+            self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.side_effect = [True, False]
+        mock_create_app.return_value = {"app_id": 12, "app_name": "demo-app", "group_id": 12}
+
+        mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_app",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_name": "demo-app",
+            },
+        )
+
+        generated = mock_create_app.call_args.kwargs["k8s_app"]
+        self.assertRegex(generated, r"^demo-app-[0-9a-f]{6}$")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_retries_with_suffix_on_region_side_duplicate(
+            self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
+        duplicate_exc = ServiceHandleException(
+            msg="k8s app name exists", msg_show="k8s app name exists", status_code=400, error_code=11011
+        )
+        mock_create_app.side_effect = [duplicate_exc, {"app_id": 12, "app_name": "demo-app", "group_id": 12}]
+
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_create_app",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_name": "demo-app",
+            },
+        )
+
+        self.assertEqual(result["app_name"], "demo-app")
+        self.assertEqual(mock_create_app.call_count, 2)
+        first_name = mock_create_app.call_args_list[0].kwargs["k8s_app"]
+        second_name = mock_create_app.call_args_list[1].kwargs["k8s_app"]
+        self.assertEqual(first_name, "demo-app")
+        self.assertRegex(second_name, r"^demo-app-[0-9a-f]{6}$")
+
+    @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
+    @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
+    @patch("console.services.mcp_query_service.group_service.create_app")
+    # capability_id: console.app.create-k8s-name-autogen
+    def test_create_app_does_not_retry_explicit_k8s_app_on_duplicate(
+            self, mock_create_app, mock_is_duplicate, mock_get_region, mock_get_team):
+        mock_get_team.return_value = self.team
+        mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
+        mock_create_app.side_effect = ServiceHandleException(
+            msg="k8s app name exists", msg_show="k8s app name exists", status_code=400, error_code=11011
+        )
+
+        with self.assertRaises(ServiceHandleException) as context:
+            mcp_query_service.call_tool(
+                self.user,
+                "rainbond_create_app",
+                {
+                    "team_name": "demo-team",
+                    "region_name": "rainbond",
+                    "app_name": "demo-app",
+                    "k8s_app": "demo-app",
+                },
+            )
+
+        self.assertEqual(mock_create_app.call_count, 1)
+        self.assertEqual(mock_create_app.call_args.kwargs["k8s_app"], "demo-app")
+        self.assertEqual(context.exception.details["provided_value"], "demo-app")
 
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
     @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
@@ -3971,12 +4136,15 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.app_version_service.get_overview")
     @patch("console.services.mcp_query_service.app_version_service.get_snapshot_detail")
     @patch("console.services.mcp_query_service.group_service.create_app")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
     # capability_id: console.app-version.create-app-from-snapshot
     def test_create_app_from_snapshot_version_installs_hidden_template_into_new_app(
-            self, mock_create_app, mock_get_snapshot_detail, mock_get_overview, mock_get_app, mock_get_region, mock_get_team, mock_install_app_model):
+            self, mock_is_duplicate, mock_create_app, mock_get_snapshot_detail, mock_get_overview, mock_get_app,
+            mock_get_region, mock_get_team, mock_install_app_model):
         region = Obj(region_name="rainbond", enterprise_id="eid-1")
         mock_get_team.return_value = self.team
         mock_get_region.return_value = region
+        mock_is_duplicate.return_value = False
         mock_get_app.return_value = self.app
         mock_get_overview.return_value = {"template_id": "hidden-template-id"}
         mock_get_snapshot_detail.return_value = {"version_id": 5, "version": "1.2.3"}
@@ -4015,7 +4183,7 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
             "snapshot-copy",
             "from snapshot",
             self.user.nick_name,
-            k8s_app="",
+            k8s_app="snapshot-copy",
         )
         mock_install_app_model.assert_called_once_with(
             self.user,
@@ -4033,11 +4201,13 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name")
     @patch("console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name")
     @patch("console.services.mcp_query_service.group_service.create_app")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
     # capability_id: console.gateway.create-app-invalid-display-name
     def test_create_app_returns_structured_details_for_illegal_app_name(
-            self, mock_create_app, mock_get_region, mock_get_team):
+            self, mock_is_duplicate, mock_create_app, mock_get_region, mock_get_team):
         mock_get_team.return_value = self.team
         mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
         mock_create_app.side_effect = ServiceHandleException(
             msg="app_name illegal",
             msg_show="应用名称只支持中英文, 数字, 下划线, 中划线和点",
@@ -4066,11 +4236,14 @@ class MCPQueryServiceApplicationToolTests(SimpleTestCase):
     @patch("console.services.mcp_query_service.app_version_service.get_overview")
     @patch("console.services.mcp_query_service.app_version_service.get_snapshot_detail")
     @patch("console.services.mcp_query_service.group_service.create_app")
+    @patch("console.services.mcp_query_service.group_repo.is_k8s_app_duplicate")
     # capability_id: console.app-version.create-app-from-snapshot-invalid-name
     def test_create_app_from_snapshot_version_returns_structured_details_for_illegal_target_app_name(
-            self, mock_create_app, mock_get_snapshot_detail, mock_get_overview, mock_get_app, mock_get_region, mock_get_team):
+            self, mock_is_duplicate, mock_create_app, mock_get_snapshot_detail, mock_get_overview, mock_get_app,
+            mock_get_region, mock_get_team):
         mock_get_team.return_value = self.team
         mock_get_region.return_value = Obj(region_name="rainbond", enterprise_id="eid-1")
+        mock_is_duplicate.return_value = False
         mock_get_app.return_value = self.app
         mock_get_overview.return_value = {"template_id": "hidden-template-id"}
         mock_get_snapshot_detail.return_value = {"version_id": 5, "version": "1.2.3"}

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1379,6 +1379,32 @@
       "status": "active"
     },
     {
+      "id": "console.app-scale.vertical-gpu-default",
+      "title": "Vertical scale keeps GPU value when omitted",
+      "title_zh": "垂直伸缩未传 GPU 时保留组件当前值",
+      "interface_type": "service_method",
+      "interface": "console.services.app_actions.app_manage.AppManageService.vertical_upgrade",
+      "code_paths": [
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_keeps_current_value_instead_of_null"
+        },
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_defaults_to_zero_when_current_is_none"
+        },
+        {
+          "path": "console/tests/vertical_upgrade_gpu_test.py",
+          "selector": "VerticalUpgradeGPUTests.test_explicit_gpu_is_applied_and_sent_to_region"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-share.complete",
       "title": "App Share Complete",
       "title_zh": "App Share Complete",
@@ -2753,6 +2779,44 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_create_app_from_yaml_creates_compose_record"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app.create-k8s-name-autogen",
+      "title": "App Create K8s Name Auto Generation",
+      "title_zh": "创建应用时自动生成 k8s_app 名称",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[console.app.create-k8s-name-autogen]",
+      "code_paths": [
+        "console/services/mcp_query_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_when_empty"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_for_non_ascii_app_name"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_normalizes_mixed_case_app_name"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_appends_suffix_when_generated_name_taken_in_console"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_retries_with_suffix_on_region_side_duplicate"
+        },
+        {
+          "path": "console/tests/mcp_query_service_test.py",
+          "selector": "MCPQueryServiceApplicationToolTests.test_create_app_does_not_retry_explicit_k8s_app_on_duplicate"
         }
       ],
       "test_type": "regression",
@@ -5199,6 +5263,24 @@
         {
           "path": "console/tests/utils/validation_test.py",
           "selector": "EndpointValidationTests.test_validate_endpoints_info_rejects_duplicate_addresses"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.enterprise-config.concurrent-initialization",
+      "title": "Handle concurrent enterprise config initialization",
+      "title_zh": "处理企业配置并发初始化",
+      "interface_type": "service_method",
+      "interface": "console.services.config_service.ConfigService.add_config",
+      "code_paths": [
+        "console/services/config_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/config_service_test.py",
+          "selector": "EnterpriseConfigServiceTests.test_add_config_returns_existing_record_when_concurrent_create_wins"
         }
       ],
       "test_type": "regression",
@@ -8460,18 +8542,18 @@
       "status": "active"
     },
     {
-      "id": "console.timeutil.current-time-str",
-      "title": "Return the current datetime formatted as a default timestamp string",
-      "title_zh": "返回格式化的当前时间字符串",
-      "interface_type": "workflow",
-      "interface": "console.utils.timeutil.current_time_str",
+      "id": "console.region-api.vm-snapshot-feature-gate-msg",
+      "title": "_check_status translates VM snapshot feature gate error to actionable msg_show",
+      "title_zh": "_check_status 将虚拟机快照功能门禁错误翻译为可操作提示",
+      "interface_type": "service_method",
+      "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
       "code_paths": [
-        "console/utils/timeutil.py"
+        "www/apiclient/regionapibaseclient.py"
       ],
       "tests": [
         {
-          "path": "console/tests/utils/timeutil_test.py",
-          "selector": "TimeUtilTests.test_current_time_str"
+          "path": "console/tests/regionapibaseclient_test.py",
+          "selector": "RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show"
         }
       ],
       "test_type": "regression",
@@ -9665,36 +9747,18 @@
       "status": "active"
     },
     {
-      "id": "console.enterprise-config.concurrent-initialization",
-      "title": "Handle concurrent enterprise config initialization",
-      "title_zh": "处理企业配置并发初始化",
-      "interface_type": "service_method",
-      "interface": "console.services.config_service.ConfigService.add_config",
+      "id": "console.timeutil.current-time-str",
+      "title": "Return the current datetime formatted as a default timestamp string",
+      "title_zh": "返回格式化的当前时间字符串",
+      "interface_type": "workflow",
+      "interface": "console.utils.timeutil.current_time_str",
       "code_paths": [
-        "console/services/config_service.py"
+        "console/utils/timeutil.py"
       ],
       "tests": [
         {
-          "path": "console/tests/config_service_test.py",
-          "selector": "EnterpriseConfigServiceTests.test_add_config_returns_existing_record_when_concurrent_create_wins"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.region-api.vm-snapshot-feature-gate-msg",
-      "title": "_check_status translates VM snapshot feature gate error to actionable msg_show",
-      "title_zh": "_check_status 将虚拟机快照功能门禁错误翻译为可操作提示",
-      "interface_type": "service_method",
-      "interface": "www.apiclient.regionapibaseclient.RegionApiBaseHttpClient._check_status",
-      "code_paths": [
-        "www/apiclient/regionapibaseclient.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/regionapibaseclient_test.py",
-          "selector": "RegionApiBaseHttpClientTestCase.test_check_status_translates_snapshot_feature_gate_error_to_actionable_msg_show"
+          "path": "console/tests/utils/timeutil_test.py",
+          "selector": "TimeUtilTests.test_current_time_str"
         }
       ],
       "test_type": "regression",
@@ -10625,32 +10689,6 @@
       "tests": [
         {
           "path": "console/tests/vm_asset_instantiation_test.py"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
-      "id": "console.app-scale.vertical-gpu-default",
-      "title": "Vertical scale keeps GPU value when omitted",
-      "title_zh": "垂直伸缩未传 GPU 时保留组件当前值",
-      "interface_type": "service_method",
-      "interface": "console.services.app_actions.app_manage.AppManageService.vertical_upgrade",
-      "code_paths": [
-        "console/services/app_actions/app_manage.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/vertical_upgrade_gpu_test.py",
-          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_keeps_current_value_instead_of_null"
-        },
-        {
-          "path": "console/tests/vertical_upgrade_gpu_test.py",
-          "selector": "VerticalUpgradeGPUTests.test_omitted_gpu_defaults_to_zero_when_current_is_none"
-        },
-        {
-          "path": "console/tests/vertical_upgrade_gpu_test.py",
-          "selector": "VerticalUpgradeGPUTests.test_explicit_gpu_is_applied_and_sent_to_region"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -153,6 +153,7 @@
 | console.app.copy-services-guard | 应用复制时拦截无效的 services 参数 | active | regression | console.services.mcp_query_service.copy_app | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_copy_app_rejects_non_list_services |
 | console.app.create | 创建应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_calls_group_service |
 | console.app.create-from-yaml | 从 YAML 创建应用 | active | regression | console.services.mcp_query_service.call_tool[rainbond_create_app_from_yaml] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_yaml_creates_compose_record |
+| console.app.create-k8s-name-autogen | 创建应用时自动生成 k8s_app 名称 | active | regression | console.services.mcp_query_service.call_tool[console.app.create-k8s-name-autogen] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_when_empty<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_for_non_ascii_app_name<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_normalizes_mixed_case_app_name<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_appends_suffix_when_generated_name_taken_in_console<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_retries_with_suffix_on_region_side_duplicate<br>console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_does_not_retry_explicit_k8s_app_on_duplicate |
 | console.app.create-k8s-name-duplicate | App Create K8s Name Duplicate | active | regression | console.services.mcp_query_service.call_tool[console.app.create-k8s-name-duplicate] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_exposes_structured_k8s_app_duplicate_error |
 | console.app.delete | 删除应用及隐藏快照模板 | active | regression | console.services.group_service._delete_app | console/tests/group_service_test.py::GroupServiceDeleteAppTestCase |
 | console.app.delete-confirmation-guard | 阻止无效的应用删除确认 | active | regression | console.services.mcp_query_service.call_tool[rainbond_delete_app] | console/tests/mcp_query_service_test.py::MCPQueryServiceDeleteAppTests.test_delete_app_rejects_invalid_confirmation_token |
@@ -2061,6 +2062,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_create_app_from_yaml]`
 - 代码路径: `console/services/mcp_query_service.py`, `console/services/compose_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_from_yaml_creates_compose_record`
+
+### 创建应用时自动生成 k8s_app 名称
+
+- Capability ID: `console.app.create-k8s-name-autogen`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `console.services.mcp_query_service.call_tool[console.app.create-k8s-name-autogen]`
+- 代码路径: `console/services/mcp_query_service.py`
+- 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_when_empty`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_generates_k8s_app_for_non_ascii_app_name`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_normalizes_mixed_case_app_name`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_appends_suffix_when_generated_name_taken_in_console`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_retries_with_suffix_on_region_side_duplicate`, `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_does_not_retry_explicit_k8s_app_on_duplicate`
 
 ### App Create K8s Name Duplicate
 


### PR DESCRIPTION
## What changed

- `console/services/mcp_query_service.py`: when the MCP tool `rainbond_create_app` (and `rainbond_create_app_from_snapshot_version`) is called without `k8s_app`, the console now auto-generates a valid, unique name from `app_name` instead of forwarding an empty string to the region API:
  - normalize `app_name` to a qualified k8s name (lowercase, fold invalid chars to `-`, strip leading non-letters, truncate to 32 chars); fall back to `app-<random>` when nothing usable remains (e.g. pure-Chinese names)
  - dedupe against the same team/region via `group_repo.is_k8s_app_duplicate`, appending a 6-char random suffix on conflict
  - if the region still reports a duplicate (bcode 11011) for an auto-generated name, retry once with a suffixed name
  - explicitly provided `k8s_app` values behave exactly as before (no retry, structured 400 on duplicate)
- `create_app_from_snapshot_version` now returns the effective `k8s_app` (region-backfilled value) instead of `null`.

## Why

With an empty `k8s_app`, the console-side duplicate check short-circuits on the empty string and the region API receives `k8s_app: ""`, which it rejects with 400 bcode 11011 ("k8s app name exists") for **any** new app name. Reproduced on run.rainbond.com (team `tynwrm27`, 2026-07-24): even a guaranteed-unique `app_name=vf-test-xk27` failed, while passing `k8s_app` explicitly worked.

## Tests

- 6 new unit tests in `console/tests/mcp_query_service_test.py`: unique English name passthrough, non-ASCII fallback, mixed-case normalization (`Demo_App.v1` → `demo-app-v1`), console-side conflict suffixing, region-side 11011 retry, and no-retry for explicit `k8s_app`.
- 4 existing tests updated to mock `is_k8s_app_duplicate` (the new logic queries the DB, which `SimpleTestCase` forbids).
- `mcp_query_service_test.py` + `mcp_query_error_contract_test.py`: 176/176 pass; full `console/tests` failures are identical to the pre-change baseline (environment-only), flake8 clean on changed lines.