### PR TITLE
fix: preserve port k8s_service_name and remap hostnames on app copy/migrate

### DIFF
--- a/console/services/groupapp_recovery/groupapps_migrate.py
+++ b/console/services/groupapp_recovery/groupapps_migrate.py
@@ -29,8 +29,11 @@ from console.services.app_config.component_graph import component_graph_service
 from console.services.app_config.port_service import port_repo
 from console.services.app_config.service_monitor import service_monitor_repo
 from console.services.app_config_group import app_config_group_service
+from console.exception.bcode import ErrK8sServiceNameExists
+from console.exception.main import AbortRequest
 from console.services.config_service import EnterpriseConfigService
 from console.services.exception import (ErrBackupRecordNotFound, ErrNeedAllServiceCloesed, ErrObjectStorageInfoNotFound)
+from console.services.market_app.hostname_remap import (apply_hostname_remap, is_host_env_name)
 from console.services.group_service import group_service
 from django.db import transaction
 from www.apiclient.regionapi import RegionInvokeApi
@@ -241,6 +244,11 @@ class GroupappsMigrateService(object):
         tar_group_k8s_component_names = [service.k8s_component_name for service in services]
         apps = metadata["apps"]
 
+        # Decide every copied port's k8s_service_name up front so that env values
+        # and config files referencing a renamed (collision-suffixed) hostname
+        # can be rewritten, no matter which component they belong to.
+        port_name_map, hostname_remap = self.__collect_port_k8s_service_names(migrate_tenant, apps, changed_service_map)
+
         old_new_service_id_map = dict()
         service_relations_list: List[Dict[str, Any]] = []
         service_mnt_list: List[Dict[str, Any]] = []
@@ -260,13 +268,15 @@ class GroupappsMigrateService(object):
             old_new_service_id_map[app["service_base"]["service_id"]] = ts.service_id
             group_service.add_service_to_group(migrate_tenant, migrate_region, group.ID, ts.service_id)  # type: ignore[union-attr]  # NOTE: group may be None if group not found
             governance_mode = group.governance_mode  # type: ignore[union-attr]  # NOTE: group may be None
+            port_k8s_service_names = port_name_map.get(app["service_base"]["service_id"], {})
             port_failures = self.__save_port(migrate_region, migrate_tenant, ts, app["service_ports"],
-                                             governance_mode, app["service_env_vars"], sync_flag)  # type: ignore[arg-type]
+                                             governance_mode, app["service_env_vars"],  # type: ignore[arg-type]  # NOTE: governance_mode may be None if group not found
+                                             port_k8s_service_names, sync_flag)
             if port_failures:
                 failed_gateway_ports.extend(port_failures)
-            self.__save_env(migrate_tenant, ts, app["service_env_vars"])
+            self.__save_env(migrate_tenant, ts, app["service_env_vars"], hostname_remap, migrate_region, sync_flag)
             self.__save_volume(migrate_tenant, ts, app["service_volumes"],
-                               app["service_config_file"] if 'service_config_file' in app else None)
+                               app["service_config_file"] if 'service_config_file' in app else None, hostname_remap)
             self.__save_compile_env(ts, app["service_compile_env"])
             self.__save_service_label(migrate_tenant, ts, migrate_region, app["service_labels"])
             if sync_flag:
@@ -376,10 +386,73 @@ class GroupappsMigrateService(object):
         ts.save()
         return ts
 
-    def __save_env(self, tenant: Any, service: TenantServiceInfo, tenant_service_env_vars: List[Dict[str, Any]]) -> None:
+    def __collect_port_k8s_service_names(
+            self, tenant: Any, apps: List[Dict[str, Any]],
+            changed_service_map: Dict[str, Any]) -> Tuple[Dict[str, Dict[Any, str]], Dict[str, str]]:
+        """Decide each copied port's k8s_service_name before any data is saved.
+
+        The source port's semantic name (e.g. "postgres") is preserved when it is
+        free in the target tenant. On collision — the common case when copying an
+        app inside the same tenant — the name is suffixed the same way the
+        market-install remap engine does, and the old->new mapping is recorded so
+        custom envs and config files referencing the old hostname get rewritten.
+
+        Returns (port_name_map, hostname_remap): port_name_map maps the source
+        service_id to {container_port: k8s_service_name}; hostname_remap maps
+        renamed old hostnames to their new names.
+        """
+        assigned: Dict[str, str] = {}  # k8s_service_name -> new service_id claimed in this batch
+        port_name_map: Dict[str, Dict[Any, str]] = {}
+        hostname_remap: Dict[str, str] = {}
+        for app in apps:
+            old_service_id = app["service_base"]["service_id"]
+            new_service_id = changed_service_map[old_service_id]["ServiceID"]
+            new_service_alias = changed_service_map[old_service_id]["ServiceAlias"]
+            names = {}
+            for port in app.get("service_ports") or []:
+                old_name = port.get("k8s_service_name") or ""
+                new_name = old_name if old_name else new_service_alias
+                conflict = False
+                try:
+                    port_service.check_k8s_service_name(tenant.tenant_id, new_name, new_service_id)
+                except ErrK8sServiceNameExists:
+                    conflict = True
+                except AbortRequest:
+                    # invalid name (bad chars / too long): fall back to the new alias
+                    old_name = ""
+                    new_name = new_service_alias
+                # names claimed by other components of this batch are not yet in db
+                if not conflict and assigned.get(new_name, new_service_id) != new_service_id:
+                    conflict = True
+                if conflict:
+                    new_name = new_name + "-" + make_uuid()[:4]
+                assigned[new_name] = new_service_id
+                names[port["container_port"]] = new_name
+                if old_name and old_name != new_name:
+                    hostname_remap[old_name] = new_name
+            port_name_map[old_service_id] = names
+        return port_name_map, hostname_remap
+
+    def __save_env(self,
+                   tenant: Any,
+                   service: TenantServiceInfo,
+                   tenant_service_env_vars: List[Dict[str, Any]],
+                   hostname_remap: Optional[Dict[str, str]] = None,
+                   region_name: Optional[str] = None,
+                   sync_flag: bool = False) -> None:
         env_list = []
         for env in tenant_service_env_vars:
             env.pop("ID")
+            # rewrite custom envs (DB_HOST=postgres, redis://redis:6379, DSNs...)
+            # that reference a hostname renamed by a k8s_service_name collision
+            origin_attr_value = env.get("attr_value")
+            env["attr_value"] = apply_hostname_remap(origin_attr_value, hostname_remap or {},
+                                                     is_host_env_name(env.get("attr_name")))
+            if sync_flag and origin_attr_value != env["attr_value"]:
+                region_api.update_service_env(region_name, tenant.tenant_name, service.service_alias, {  # type: ignore[arg-type]  # NOTE: region_name always provided when sync_flag is True
+                    "env_name": env["attr_name"],
+                    "env_value": env["attr_value"]
+                })
             new_env = TenantServiceEnvVar(**env)
             new_env.tenant_id = tenant.tenant_id
             new_env.service_id = service.service_id
@@ -388,7 +461,8 @@ class GroupappsMigrateService(object):
             TenantServiceEnvVar.objects.bulk_create(env_list)
 
     def __save_volume(self, tenant: Any, service: TenantServiceInfo, tenant_service_volumes: List[Dict[str, Any]],
-                      service_config_file: Optional[List[Dict[str, Any]]]) -> None:
+                      service_config_file: Optional[List[Dict[str, Any]]],
+                      hostname_remap: Optional[Dict[str, str]] = None) -> None:
         volume_list = []
         config_list = []
         volume_name_id = {}
@@ -399,6 +473,10 @@ class GroupappsMigrateService(object):
                 for config_file in service_config_file:
                     if config_file["service_id"] == volume["service_id"] and config_file["volume_name"] == volume["volume_name"]:
                         config_file.pop("ID")
+                        # rewrite config-file content referencing hostnames renamed
+                        # by a k8s_service_name collision (e.g. nginx proxy_pass)
+                        config_file["file_content"] = apply_hostname_remap(config_file.get("file_content"), hostname_remap
+                                                                           or {})
                         new_config_file = TenantServiceConfigurationFile(**config_file)
                         new_config_file.service_id = service.service_id
                         config_list.append(new_config_file)
@@ -439,6 +517,7 @@ class GroupappsMigrateService(object):
                     tenant_service_ports: List[Dict[str, Any]],
                     governance_mode: str,
                     tenant_service_env_vars: List[Dict[str, Any]],
+                    port_k8s_service_names: Optional[Dict[Any, str]] = None,
                     sync_flag: bool = False) -> List[Dict[str, Any]]:
         # Best-effort gateway rebuild: collect ports whose data-center bind
         # failed instead of aborting the whole component's port loop. The
@@ -456,8 +535,9 @@ class GroupappsMigrateService(object):
         port_list: List[TenantServicesPort] = []
         for port in tenant_service_ports:
             port.pop("ID")
-            # 直接使用 service 的 service_alias 作为 k8s_service_name
-            k8s_service_name = service.service_alias
+            # 保留源端口的 k8s_service_name(撞名时已在 __collect_port_k8s_service_names
+            # 中按 remap 引擎语义加后缀);无预计算结果时回退到 service_alias
+            k8s_service_name = (port_k8s_service_names or {}).get(port["container_port"]) or service.service_alias
 
             if sync_flag:
                 body = port

--- a/console/services/market_app/hostname_remap.py
+++ b/console/services/market_app/hostname_remap.py
@@ -1,0 +1,58 @@
+# -*- coding: utf8 -*-
+"""Shared hostname remap helpers.
+
+When a component's port k8s_service_name collides with an existing service
+name in the target namespace, the platform suffixes the conflicting name
+(e.g. api -> api-2311). Env values and config-file content referencing the
+original hostname must then be rewritten to the suffixed name. These helpers
+implement the URL/DSN-aware rewrite used by both the market-install path
+(console.services.market_app.new_components) and the app copy/migrate path
+(console.services.groupapp_recovery.groupapps_migrate).
+"""
+from typing import Optional, overload
+
+
+def is_host_env_name(attr_name: Optional[str]) -> bool:
+    """Whether an env holds a bare hostname (``*_HOST`` / ``*_HOSTNAME`` / ``HOST``).
+
+    Only these may have their whole value exact-matched against a colliding
+    service name during hostname remap. Other envs whose value happens to
+    equal a service name (e.g. Harbor's ``POSTGRESQL_DATABASE=registry``,
+    which collides with the ``registry`` component) must NOT be rewritten.
+    """
+    if not attr_name:
+        return False
+    return attr_name == "HOST" or attr_name.endswith("_HOST") or attr_name.endswith("_HOSTNAME")
+
+
+@overload
+def apply_hostname_remap(value: str, remap: Optional[dict], is_host_env: bool = ...) -> str:
+    ...
+
+
+@overload
+def apply_hostname_remap(value: None, remap: Optional[dict], is_host_env: bool = ...) -> None:
+    ...
+
+
+def apply_hostname_remap(value: Optional[str], remap: Optional[dict], is_host_env: bool = False) -> Optional[str]:
+    if not value or not remap:
+        return value
+    for old, new in remap.items():
+        # Exact whole-value match is only safe for hostname-valued envs; a
+        # database name / username that merely equals a service name must be
+        # left alone. URL and host:port rewrites below are unambiguous.
+        if is_host_env and value == old:
+            value = new
+            continue
+        value = value.replace("://" + old + ":", "://" + new + ":")
+        value = value.replace("://" + old + "/", "://" + new + "/")
+        # DSNs with userinfo credentials keep the host after an "@",
+        # e.g. mongodb://user:pass@mongo:27017/db or redis://default:pass@redis:6379.
+        value = value.replace("@" + old + ":", "@" + new + ":")
+        value = value.replace("@" + old + "/", "@" + new + "/")
+        if "://" in value and value.endswith("@" + old):
+            value = value[:-len(old)] + new
+        if value.startswith(old + ":") and "://" not in value:
+            value = new + value[len(old):]
+    return value

--- a/console/services/market_app/new_components.py
+++ b/console/services/market_app/new_components.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from .utils import is_same_component
+from .hostname_remap import apply_hostname_remap, is_host_env_name
 from .enum import ActionType
 from .app_template import AppTemplate
 from console.services.market_app.component import Component
@@ -104,32 +105,11 @@ class NewComponents(object):
         equal a service name (e.g. Harbor's ``POSTGRESQL_DATABASE=registry``,
         which collides with the ``registry`` component) must NOT be rewritten.
         """
-        if not attr_name:
-            return False
-        return attr_name == "HOST" or attr_name.endswith("_HOST") or attr_name.endswith("_HOSTNAME")
+        return is_host_env_name(attr_name)
 
     @staticmethod
     def _apply_hostname_remap(value: str, remap: dict, is_host_env: bool = False) -> str:
-        if not value or not remap:
-            return value
-        for old, new in remap.items():
-            # Exact whole-value match is only safe for hostname-valued envs; a
-            # database name / username that merely equals a service name must be
-            # left alone. URL and host:port rewrites below are unambiguous.
-            if is_host_env and value == old:
-                value = new
-                continue
-            value = value.replace("://" + old + ":", "://" + new + ":")
-            value = value.replace("://" + old + "/", "://" + new + "/")
-            # DSNs with userinfo credentials keep the host after an "@",
-            # e.g. mongodb://user:pass@mongo:27017/db or redis://default:pass@redis:6379.
-            value = value.replace("@" + old + ":", "@" + new + ":")
-            value = value.replace("@" + old + "/", "@" + new + "/")
-            if "://" in value and value.endswith("@" + old):
-                value = value[:-len(old)] + new
-            if value.startswith(old + ":") and "://" not in value:
-                value = new + value[len(old):]
-        return value
+        return apply_hostname_remap(value, remap, is_host_env)
 
     def _resolve_none_placeholder(self, raw_value: str) -> Optional[str]:
         if raw_value == "**None**":

--- a/console/tests/groupapps_migrate_save_port_test.py
+++ b/console/tests/groupapps_migrate_save_port_test.py
@@ -99,7 +99,8 @@ class SavePortHttpFailureVisibleTest(TestCase):
             ports,
             "KUBERNETES_NATIVE_SERVICE",
             [],
-            False,
+            port_k8s_service_names={},
+            sync_flag=False,
         )
 
     def setUpInstance(self):

--- a/console/tests/test_migrate_port_remap.py
+++ b/console/tests/test_migrate_port_remap.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""Tests for k8s_service_name preservation and hostname remap on app copy/migrate.
+
+Copying/migrating an app must keep each port's semantic k8s_service_name
+(e.g. "postgres") instead of resetting it to the new service_alias. When the
+name collides in the target tenant (the normal case for an in-tenant copy),
+it is suffixed like the market-install remap engine does, and custom envs /
+DSN-style connection strings referencing the old hostname are rewritten.
+"""
+import collections
+import os
+import sys
+import typing
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+if not hasattr(typing, "NotRequired"):
+    try:
+        from typing_extensions import NotRequired
+        typing.NotRequired = NotRequired  # type: ignore[attr-defined]
+    except ImportError:
+        typing.NotRequired = lambda item: item  # type: ignore[attr-defined]
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.db.models.query import QuerySet  # noqa: E402
+
+if not hasattr(QuerySet, "__class_getitem__"):
+    QuerySet.__class_getitem__ = classmethod(lambda cls, item: cls)  # type: ignore[assignment]
+
+from console.exception.bcode import ErrK8sServiceNameExists  # noqa: E402
+from console.services.groupapp_recovery.groupapps_migrate import migrate_service  # noqa: E402
+from www.models.main import TenantServiceEnvVar, TenantServiceInfo  # noqa: E402
+
+MIGRATE_MODULE = "console.services.groupapp_recovery.groupapps_migrate"
+
+collect_names = migrate_service._GroupappsMigrateService__collect_port_k8s_service_names
+save_env = migrate_service._GroupappsMigrateService__save_env
+
+
+def _tenant():
+    tenant = MagicMock()
+    tenant.tenant_id = "tenant-1"
+    tenant.tenant_name = "team1"
+    return tenant
+
+
+def _apps(k8s_service_name="postgres", container_port=5432):
+    return [{
+        "service_base": {
+            "service_id": "old-sid-1"
+        },
+        "service_ports": [{
+            "container_port": container_port,
+            "k8s_service_name": k8s_service_name,
+        }],
+    }]
+
+
+CHANGED_SERVICE_MAP = {"old-sid-1": {"ServiceID": "new-sid-1", "ServiceAlias": "gr654321"}}
+
+
+class CollectPortK8sServiceNamesTests:
+    def test_semantic_name_preserved_when_free(self):
+        with patch(MIGRATE_MODULE + ".port_service") as mock_ps:
+            mock_ps.check_k8s_service_name.return_value = None
+            port_name_map, remap = collect_names(_tenant(), _apps(), CHANGED_SERVICE_MAP)
+        assert port_name_map == {"old-sid-1": {5432: "postgres"}}
+        assert remap == {}
+
+    def test_collision_suffixes_and_records_remap(self):
+        with patch(MIGRATE_MODULE + ".port_service") as mock_ps, \
+                patch(MIGRATE_MODULE + ".make_uuid", return_value="abcd1234"):
+            mock_ps.check_k8s_service_name.side_effect = ErrK8sServiceNameExists()
+            port_name_map, remap = collect_names(_tenant(), _apps(), CHANGED_SERVICE_MAP)
+        assert port_name_map == {"old-sid-1": {5432: "postgres-abcd"}}
+        assert remap == {"postgres": "postgres-abcd"}
+
+    def test_empty_name_falls_back_to_alias_without_remap(self):
+        with patch(MIGRATE_MODULE + ".port_service") as mock_ps:
+            mock_ps.check_k8s_service_name.return_value = None
+            port_name_map, remap = collect_names(_tenant(), _apps(k8s_service_name=""), CHANGED_SERVICE_MAP)
+        assert port_name_map == {"old-sid-1": {5432: "gr654321"}}
+        assert remap == {}
+
+    def test_same_service_ports_share_name_without_self_conflict(self):
+        apps = [{
+            "service_base": {
+                "service_id": "old-sid-1"
+            },
+            "service_ports": [
+                {
+                    "container_port": 5432,
+                    "k8s_service_name": "postgres"
+                },
+                {
+                    "container_port": 5433,
+                    "k8s_service_name": "postgres"
+                },
+            ],
+        }]
+        with patch(MIGRATE_MODULE + ".port_service") as mock_ps:
+            mock_ps.check_k8s_service_name.return_value = None
+            port_name_map, remap = collect_names(_tenant(), apps, CHANGED_SERVICE_MAP)
+        assert port_name_map == {"old-sid-1": {5432: "postgres", 5433: "postgres"}}
+        assert remap == {}
+
+    def test_cross_component_conflict_within_batch(self):
+        apps = [
+            {
+                "service_base": {
+                    "service_id": "old-sid-1"
+                },
+                "service_ports": [{
+                    "container_port": 5432,
+                    "k8s_service_name": "postgres"
+                }],
+            },
+            {
+                "service_base": {
+                    "service_id": "old-sid-2"
+                },
+                "service_ports": [{
+                    "container_port": 5432,
+                    "k8s_service_name": "postgres"
+                }],
+            },
+        ]
+        changed = {
+            "old-sid-1": {
+                "ServiceID": "new-sid-1",
+                "ServiceAlias": "gr111111"
+            },
+            "old-sid-2": {
+                "ServiceID": "new-sid-2",
+                "ServiceAlias": "gr222222"
+            },
+        }
+        with patch(MIGRATE_MODULE + ".port_service") as mock_ps, \
+                patch(MIGRATE_MODULE + ".make_uuid", return_value="abcd1234"):
+            mock_ps.check_k8s_service_name.return_value = None
+            port_name_map, remap = collect_names(_tenant(), apps, changed)
+        assert port_name_map["old-sid-1"] == {5432: "postgres"}
+        assert port_name_map["old-sid-2"] == {5432: "postgres-abcd"}
+        assert remap == {"postgres": "postgres-abcd"}
+
+
+class SaveEnvHostnameRemapTests:
+    def _service(self):
+        service = MagicMock(spec=TenantServiceInfo)
+        service.service_id = "new-sid-1"
+        service.service_alias = "gr654321"
+        return service
+
+    def _run_save_env(self, envs, remap):
+        created = []
+        with patch.object(TenantServiceEnvVar.objects, "bulk_create", side_effect=created.extend):
+            save_env(_tenant(), self._service(), envs, remap)
+        return created
+
+    def test_custom_host_env_rewritten_on_collision(self):
+        envs = [{"ID": 1, "attr_name": "DB_POSTGRESDB_HOST", "attr_value": "postgres"}]
+        created = self._run_save_env(envs, {"postgres": "postgres-abcd"})
+        assert created[0].attr_value == "postgres-abcd"
+
+    def test_connection_string_rewritten_on_collision(self):
+        envs = [
+            {
+                "ID": 1,
+                "attr_name": "QUEUE_BULL_REDIS_URI",
+                "attr_value": "redis://redis:6379"
+            },
+            {
+                "ID": 2,
+                "attr_name": "MONGODB_URI",
+                "attr_value": "mongodb://user:pass@mongo:27017/db"
+            },
+        ]
+        created = self._run_save_env(envs, {"redis": "redis-ab12", "mongo": "mongo-cd34"})
+        assert created[0].attr_value == "redis://redis-ab12:6379"
+        assert created[1].attr_value == "mongodb://user:pass@mongo-cd34:27017/db"
+
+    def test_non_host_env_equal_to_service_name_left_alone(self):
+        envs = [{"ID": 1, "attr_name": "POSTGRESQL_DATABASE", "attr_value": "postgres"}]
+        created = self._run_save_env(envs, {"postgres": "postgres-abcd"})
+        assert created[0].attr_value == "postgres"
+
+    def test_no_remap_keeps_values(self):
+        envs = [{"ID": 1, "attr_name": "DB_POSTGRESDB_HOST", "attr_value": "postgres"}]
+        created = self._run_save_env(envs, {})
+        assert created[0].attr_value == "postgres"


### PR DESCRIPTION
## 问题

自 #1815 起,复制/迁移应用时端口的 `k8s_service_name` 被无条件重置为新组件的 `service_alias`,且只改写注入的 `<ALIAS>_HOST` 变量。自定义 env(`DB_POSTGRESDB_HOST=postgres`)和连接串(`redis://redis:6379`、`MONGODB_URI` 等 DSN)仍引用源语义主机名,导致复制后的应用启动即 CrashLoop(实测 n8n 队列模式复制后主组件报 `getaddrinfo ENOTFOUND postgres`)。

## 方案

复用 #2017 / #2065 已合入的安装时 hostname remap 引擎:

- 抽取 `_is_host_env_name` / `_apply_hostname_remap` 为共享模块 `console/services/market_app/hostname_remap.py`,`NewComponents` 静态方法委托到共享函数,安装路径行为与既有测试不变。
- 迁移/复制路径(`groupapps_migrate.py`)新增 `__collect_port_k8s_service_names`:保存前对整组应用统一决定端口名 —— **保留源端口语义名**;目标租户撞名(同租户复制的常见情形)或批内跨组件撞名时按 remap 引擎语义加 `-<uuid[:4]>` 后缀并记录 old→new 映射;名字为空/非法时回退到新 `service_alias`。
- `__save_env` 按映射改写自定义 env:host 型 env(`*_HOST`/`*_HOSTNAME`/`HOST`)全值精确改写,URL/DSN(含凭据形态)按主机位改写;值恰好等于服务名的非 host 型 env(如 `POSTGRESQL_DATABASE`)不误伤。跨集群迁移(sync_flag)时改写结果同步推送数据中心。
- `__save_volume` 对 config-file 内容做同样改写(如 nginx `proxy_pass`)。
- `<ALIAS>_HOST` 注入变量逻辑不变,写入保留/后缀后的名字。

## 测试

- 新增 `console/tests/test_migrate_port_remap.py` 9 例:语义名保留、撞名后缀 + remap 记录、空名回退、同组件多端口共享名不自撞、批内跨组件撞名,以及自定义 host env / redis URI / Mongo DSN 改写与非 host env 不误伤。
- 既有 `test_hostname_remap.py` 22 例、market/copy/migrate/port 相关测试均通过(`app_market_repo_test`、`port_service_delete_test` 为基线既有失败,与本改动无关)。

已与 #1815 作者确认原始场景,本方案的 alias 回退覆盖该场景。