### PR TITLE
feat: report in-console market app views, and add an MCP tool for component type

### DIFF
--- a/console/services/mcp_query_service.py
+++ b/console/services/mcp_query_service.py
@@ -13,6 +13,7 @@ from django.core import signing
 from django.core.exceptions import ObjectDoesNotExist
 
 from console.constants import AppConstants, PluginCategoryConstants
+from console.enum.component_enum import ComponentType, is_support
 from console.models.main import PluginShareRecordEvent, ServiceShareRecordEvent
 from console.exception.exceptions import ExterpriseNotExistError, TenantNotExistError
 from console.exception.main import ServiceHandleException
@@ -287,7 +288,8 @@ class MCPQueryService(object):
             self._tool_manage_component_storage(),
             self._tool_manage_component_autoscaler(), self._tool_manage_component_probe(),
             self._tool_manage_component_dependency(), self._tool_horizontal_scale_component(),
-            self._tool_vertical_scale_component(), self._tool_close_apps(), self._tool_get_team_apps(),
+            self._tool_vertical_scale_component(), self._tool_change_component_type(), self._tool_close_apps(),
+            self._tool_get_team_apps(),
             self._tool_get_app_version_overview(), self._tool_list_app_version_snapshots(),
             self._tool_get_app_version_snapshot_detail(), self._tool_create_app_version_snapshot(),
             self._tool_delete_app_version_snapshot(), self._tool_rewrite_snapshot_images(),
@@ -439,6 +441,8 @@ class MCPQueryService(object):
             return self.horizontal_scale_component(user, arguments)
         if name == "rainbond_vertical_scale_component":
             return self.vertical_scale_component(user, arguments)
+        if name == "rainbond_change_component_type":
+            return self.change_component_type(user, arguments)
         if name == "rainbond_close_apps":
             return self.close_apps(user, arguments)
         if name == "rainbond_get_team_apps":
@@ -2657,6 +2661,26 @@ class MCPQueryService(object):
             "new_memory": new_memory,
             "new_gpu": new_gpu,
             "new_cpu": new_cpu,
+        }
+
+    def change_component_type(self, user: Any, arguments: dict) -> dict:
+        team, app, service = self._get_team_app_service_context(
+            user,
+            self._require_string(arguments, "team_name"),
+            self._require_string(arguments, "region_name"),
+            self._require_int(arguments, "app_id"),
+            self._require_string(arguments, "service_id"),
+        )
+        extend_method = self._require_string(arguments, "extend_method")
+        if not is_support(extend_method):
+            raise ServiceHandleException(msg="do not support service type", msg_show="组件类型非法", status_code=400)
+        old_extend_method = service.extend_method
+        app_manage_service.change_service_type(team, service, extend_method, user.nick_name)
+        return {
+            "changed": True,
+            "service_id": service.service_id,
+            "old_extend_method": old_extend_method,
+            "extend_method": extend_method,
         }
 
     def close_apps(self, user: Any, arguments: dict) -> dict:
@@ -8184,6 +8208,34 @@ class MCPQueryService(object):
                     "new_cpu": {"type": "integer", "minimum": 0}
                 },
                 "required": ["team_name", "region_name", "app_id", "service_id", "new_memory"]
+            }
+        }
+
+    def _tool_change_component_type(self) -> dict:
+        return {
+            "name": "rainbond_change_component_type",
+            "description": ("Change a component's deploy type (extend_method). Use state_singleton or state_multiple for "
+                            "components that need a stable per-pod network identity, such as ElasticSearch, ZooKeeper, "
+                            "Kafka, Nacos or MinIO clusters: stateful components get a headless Service so each member "
+                            "resolves to its own pod IP."),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "team_name": {"type": "string"},
+                    "region_name": {"type": "string"},
+                    "app_id": {"type": "integer", "minimum": 1},
+                    "service_id": {"type": "string"},
+                    "extend_method": {
+                        "type": "string",
+                        "enum": [
+                            ComponentType.stateless_singleton.value, ComponentType.stateless_multiple.value,
+                            ComponentType.state_singleton.value, ComponentType.state_multiple.value,
+                            ComponentType.job.value, ComponentType.cronjob.value, ComponentType.daemonset.value,
+                            ComponentType.kubeblocks.value
+                        ]
+                    }
+                },
+                "required": ["team_name", "region_name", "app_id", "service_id", "extend_method"]
             }
         }
 

--- a/console/tests/app_server_proxy_view_report_test.py
+++ b/console/tests/app_server_proxy_view_report_test.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from unittest import TestCase, mock
+
+from console.views.app_server_proxy import AppServerProxyView
+
+
+def make_request(path, method="GET", meta=None):
+    request = mock.Mock()
+    request.path = path
+    request.method = method
+    request.META = meta if meta is not None else {}
+    return request
+
+
+def make_response(status_code=200, content=b'{"marketID": "m1", "appKeyID": "a1"}', content_type="application/json"):
+    response = mock.Mock()
+    response.status_code = status_code
+    response.content = content
+    response.headers = {"Content-Type": content_type}
+    return response
+
+
+class AppServerProxyViewReportTests(TestCase):
+    """控制台内的应用市场经由 /app-server 代理请求商店的应用详情, 但从不上报浏览量,
+    所以商店的 showCount 只统计到网页商店那一侧, 控制台内的浏览是空的(P0-1).
+    这里覆盖"哪些请求该上报、上报到哪个地址、以及上报失败不能影响详情返回".
+    """
+    def setUp(self):
+        self.view = AppServerProxyView()
+
+    def test_app_detail_request_reports_view_to_store(self):
+        request = make_request("/app-server/marketui/apps/1723/detail",
+                               meta={
+                                   "REMOTE_ADDR": "10.0.0.9",
+                                   "HTTP_X_FORWARDED_FOR": "1.2.3.4"
+                               })
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response())
+
+        thread.assert_called_once()
+        url, headers = thread.call_args.kwargs["args"]
+        self.assertEqual("https://hub.grapps.cn/app-server/markets/m1/apps/a1/view", url)
+        self.assertEqual("1.2.3.4", headers["X-Forwarded-For"])
+        self.assertEqual("10.0.0.9", headers["X-Real-IP"])
+        self.assertTrue(thread.call_args.kwargs["daemon"])
+        thread.return_value.start.assert_called_once()
+
+    def test_legacy_app_detail_path_also_reports(self):
+        request = make_request("/app-server/marketui/859a51f9/apps/a1/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response())
+
+        thread.assert_called_once()
+
+    def test_non_detail_request_does_not_report(self):
+        request = make_request("/app-server/marketui/859a51f9/indexApps")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response())
+
+        thread.assert_not_called()
+
+    def test_failed_detail_request_does_not_report(self):
+        request = make_request("/app-server/marketui/apps/1723/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response(status_code=404))
+
+        thread.assert_not_called()
+
+    def test_non_get_request_does_not_report(self):
+        request = make_request("/app-server/marketui/apps/1723/detail", method="POST")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response())
+
+        thread.assert_not_called()
+
+    def test_response_without_app_identity_does_not_report(self):
+        request = make_request("/app-server/marketui/apps/1723/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response(content=b'{"name": "Coze"}'))
+
+        thread.assert_not_called()
+
+    def test_non_json_response_does_not_report(self):
+        request = make_request("/app-server/marketui/apps/1723/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response(content=b"<html>", content_type="text/html"))
+
+        thread.assert_not_called()
+
+    def test_broken_json_response_does_not_report(self):
+        request = make_request("/app-server/marketui/apps/1723/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread") as thread:
+            self.view.report_app_view(request, make_response(content=b"{not json"))
+
+        thread.assert_not_called()
+
+    def test_store_failure_is_swallowed(self):
+        with mock.patch("console.views.app_server_proxy.requests.post", side_effect=Exception("boom")):
+            self.view.post_app_view("https://hub.grapps.cn/app-server/markets/m1/apps/a1/view", {})

--- a/console/tests/app_server_proxy_view_report_test.py
+++ b/console/tests/app_server_proxy_view_report_test.py
@@ -103,6 +103,12 @@ class AppServerProxyViewReportTests(TestCase):
 
         thread.assert_not_called()
 
+    def test_thread_start_failure_does_not_break_the_detail_response(self):
+        request = make_request("/app-server/marketui/apps/1723/detail")
+
+        with mock.patch("console.views.app_server_proxy.threading.Thread", side_effect=RuntimeError("no threads")):
+            self.view.report_app_view(request, make_response())
+
     def test_store_failure_is_swallowed(self):
         with mock.patch("console.views.app_server_proxy.requests.post", side_effect=Exception("boom")):
             self.view.post_app_view("https://hub.grapps.cn/app-server/markets/m1/apps/a1/view", {})

--- a/console/tests/app_server_proxy_view_report_test.py
+++ b/console/tests/app_server_proxy_view_report_test.py
@@ -28,6 +28,7 @@ class AppServerProxyViewReportTests(TestCase):
     def setUp(self):
         self.view = AppServerProxyView()
 
+    # capability_id: console.market.report-app-view
     def test_app_detail_request_reports_view_to_store(self):
         request = make_request("/app-server/marketui/apps/1723/detail",
                                meta={

--- a/console/tests/mcp_query_change_component_type_test.py
+++ b/console/tests/mcp_query_change_component_type_test.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import django
+from django.test import SimpleTestCase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+django.setup()
+
+from console.exception.main import ServiceHandleException  # noqa: E402
+from console.services.mcp_query_service import mcp_query_service  # noqa: E402
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class MCPQueryChangeComponentTypeTests(SimpleTestCase):
+    """agent 全程通过 MCP 操作集群, 而 ElasticSearch / ZooKeeper / Kafka / Nacos 这类
+    集群模板必须是有状态组件(才能拿到 headless Service 和每个 pod 自己的稳定地址)。
+    REST 层的 ChangeServiceTypeView 一直都在, 缺的只是 MCP 工具层的封装。
+    """
+    def setUp(self):
+        self.user = Obj(
+            user_id=1,
+            pk=1,
+            enterprise_id="eid-1",
+            nick_name="admin",
+            real_name="Admin User",
+            email="admin@example.com",
+            is_active=True,
+            is_enterprise_admin=True,
+        )
+        self.user.get_username = lambda: self.user.nick_name
+
+        self.team = Obj(
+            ID=11,
+            tenant_id="team-1",
+            tenant_name="demo-team",
+            tenant_alias="Demo Team",
+            enterprise_id="eid-1",
+            namespace="default",
+            creater=1,
+        )
+        self.app = Obj(ID=12, tenant_id="team-1", group_name="demo-app", region_name="rainbond")
+        self.service = Obj(
+            service_id="svc-1",
+            tenant_id="team-1",
+            service_region="rainbond",
+            service_alias="alias-1",
+            service_cname="nacos",
+            create_status="complete",
+            extend_method="stateless_multiple",
+            min_node=3,
+        )
+        self.service.save = lambda: None
+        self.region = Obj(region_name="rainbond", enterprise_id="eid-1")
+
+        patchers = [
+            patch(
+                "console.services.mcp_query_service.team_services.get_enterprise_tenant_by_tenant_name",
+                return_value=self.team),
+            patch(
+                "console.services.mcp_query_service.region_services.get_enterprise_region_by_region_name",
+                return_value=self.region),
+            patch("console.services.mcp_query_service.group_service.get_app_by_id", return_value=self.app),
+            patch("console.services.mcp_query_service.service_repo.get_service_by_service_id", return_value=self.service),
+            patch(
+                "console.services.mcp_query_service.group_service_relation_repo.get_services_by_group",
+                return_value=[Obj(service_id="svc-1")]),
+        ]
+        for patcher in patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_tool_is_registered(self):
+        tool = next(tool for tool in mcp_query_service.list_tools(self.user) if tool["name"] == "rainbond_change_component_type")
+        self.assertIn("state_multiple", tool["inputSchema"]["properties"]["extend_method"]["enum"])
+        self.assertEqual(["team_name", "region_name", "app_id", "service_id", "extend_method"],
+                         tool["inputSchema"]["required"])
+
+    # capability_id: console.component.change-type
+    @patch("console.services.mcp_query_service.app_manage_service.change_service_type")
+    def test_change_component_type_to_state_multiple(self, mock_change):
+        result = mcp_query_service.call_tool(
+            self.user,
+            "rainbond_change_component_type",
+            {
+                "team_name": "demo-team",
+                "region_name": "rainbond",
+                "app_id": 12,
+                "service_id": "svc-1",
+                "extend_method": "state_multiple",
+            },
+        )
+
+        self.assertTrue(result["changed"])
+        self.assertEqual("svc-1", result["service_id"])
+        self.assertEqual("stateless_multiple", result["old_extend_method"])
+        self.assertEqual("state_multiple", result["extend_method"])
+        mock_change.assert_called_once_with(self.team, self.service, "state_multiple", "admin")
+
+    @patch("console.services.mcp_query_service.app_manage_service.change_service_type")
+    def test_unsupported_component_type_is_rejected(self, mock_change):
+        with self.assertRaises(ServiceHandleException):
+            mcp_query_service.call_tool(
+                self.user,
+                "rainbond_change_component_type",
+                {
+                    "team_name": "demo-team",
+                    "region_name": "rainbond",
+                    "app_id": 12,
+                    "service_id": "svc-1",
+                    "extend_method": "not_a_type",
+                },
+            )
+
+        mock_change.assert_not_called()
+
+    @patch("console.services.mcp_query_service.app_manage_service.change_service_type")
+    def test_extend_method_is_required(self, mock_change):
+        with self.assertRaises(ServiceHandleException):
+            mcp_query_service.call_tool(
+                self.user,
+                "rainbond_change_component_type",
+                {
+                    "team_name": "demo-team",
+                    "region_name": "rainbond",
+                    "app_id": 12,
+                    "service_id": "svc-1",
+                },
+            )
+
+        mock_change.assert_not_called()

--- a/console/tests/vm_manage_view_test.py
+++ b/console/tests/vm_manage_view_test.py
@@ -52,7 +52,60 @@ django.setup()
 from django.test import TestCase  # noqa: E402
 from rest_framework.test import APIRequestFactory  # noqa: E402
 
-from console.views.app_manage import PauseAppView, StartAppView, UNPauseAppView  # noqa: E402
+from console.views.app_manage import ChangeServiceTypeView, PauseAppView, StartAppView, UNPauseAppView  # noqa: E402
+
+
+class ChangeServiceTypeViewTests(TestCase):
+    """改类型曾经把 change_service_type 调了两次(等于向 region 下发两次),
+    并且操作日志里的 old/new_information 是反的 —— 变更前的类型被记成"变更后"。
+    """
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+    def build_view(self):
+        view = ChangeServiceTypeView()
+        view.tenant = SimpleNamespace(tenant_name="demo-team")
+        view.service = SimpleNamespace(
+            service_alias="nacos",
+            service_region="demo-region",
+            service_cname="nacos",
+            extend_method="stateless_multiple",
+        )
+        view.user = SimpleNamespace(nick_name="tester", enterprise_id="eid")
+        view.app = SimpleNamespace(ID=1)
+        return view
+
+    # capability_id: console.component-type.change-once
+    def test_change_service_type_is_applied_once(self):
+        view = self.build_view()
+        request = view.initialize_request(
+            self.factory.put(
+                "/console/teams/demo-team/apps/nacos/service-type", {"extend_method": "state_multiple"}, format="json"))
+
+        with mock.patch("console.views.app_manage.app_manage_service.change_service_type") as change_service_type, \
+                mock.patch("console.views.app_manage.operation_log_service"):
+            response = view.put(request)
+
+        self.assertEqual(200, response.status_code)
+        change_service_type.assert_called_once()
+
+    # capability_id: console.component-type.change-log-direction
+    def test_operation_log_records_old_type_before_and_new_type_after(self):
+        view = self.build_view()
+        request = view.initialize_request(
+            self.factory.put(
+                "/console/teams/demo-team/apps/nacos/service-type", {"extend_method": "state_multiple"}, format="json"))
+
+        def apply_change(tenant, service, extend_method, user_name):
+            service.extend_method = extend_method
+
+        with mock.patch("console.views.app_manage.app_manage_service.change_service_type", side_effect=apply_change), \
+                mock.patch("console.views.app_manage.operation_log_service") as operation_log:
+            view.put(request)
+
+        kwargs = operation_log.create_component_log.call_args.kwargs
+        self.assertIn("无状态多实例", kwargs["old_information"])
+        self.assertIn("有状态多实例", kwargs["new_information"])
 
 
 class VMManageViewTests(TestCase):

--- a/console/views/app_manage.py
+++ b/console/views/app_manage.py
@@ -910,13 +910,6 @@ class ChangeServiceTypeView(AppBaseView):
 
             if not is_support(extend_method):
                 raise AbortRequest(msg="do not support service type", msg_show="组件类型非法")
-            new_information = json.dumps({
-                "组件": self.service.service_cname,
-                "组件部署类型": app_manage_service.get_extend_method_name(self.service.extend_method)
-            },
-                                         ensure_ascii=False)
-            app_manage_service.change_service_type(
-                self.tenant, self.service, extend_method, self.user.nick_name)  # type: ignore[arg-type]
             old_information = json.dumps({
                 "组件": self.service.service_cname,
                 "组件部署类型": app_manage_service.get_extend_method_name(self.service.extend_method)
@@ -925,6 +918,11 @@ class ChangeServiceTypeView(AppBaseView):
             logger.debug("tenant: {0}, service:{1}, extend_method:{2}".format(self.tenant, self.service, extend_method))
             app_manage_service.change_service_type(
                 self.tenant, self.service, extend_method, self.user.nick_name)  # type: ignore[arg-type]
+            new_information = json.dumps({
+                "组件": self.service.service_cname,
+                "组件部署类型": app_manage_service.get_extend_method_name(self.service.extend_method)
+            },
+                                         ensure_ascii=False)
             result = general_message(200, "success", "操作成功")
             comment = operation_log_service.generate_component_comment(
                 operation=Operation.CHANGE,

--- a/console/views/app_server_proxy.py
+++ b/console/views/app_server_proxy.py
@@ -151,7 +151,10 @@ class AppServerProxyView(View):
             headers['X-Real-IP'] = remote_addr
 
         url = f"{self.target_base_url}/app-server/markets/{market_id}/apps/{app_key_id}/view"
-        threading.Thread(target=self.post_app_view, args=(url, headers), daemon=True).start()
+        try:
+            threading.Thread(target=self.post_app_view, args=(url, headers), daemon=True).start()
+        except Exception as e:
+            logger.warning("report app view not started url=%s error=%s", url, e)
 
     @staticmethod
     def parse_app_identity(response: Any) -> Optional[Tuple[str, str]]:

--- a/console/views/app_server_proxy.py
+++ b/console/views/app_server_proxy.py
@@ -1,10 +1,24 @@
-from typing import Any
+import json
+import logging
+import re
+import threading
+from typing import Any, Optional, Tuple
 
 import requests
 from django.http import HttpResponse
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
+
+logger = logging.getLogger('default')
+
+# 控制台内应用市场的"应用详情"接口，前端打开条目详情时经由本代理请求。
+# 新版: /app-server/marketui/apps/{主键}/detail
+# 旧版: /app-server/marketui/{marketID}/apps/{appID}/detail
+APP_DETAIL_PATH_RE = re.compile(r'^/app-server/marketui/(?:[\w\-]+/)?apps/[\w\-]+/detail/?$')
+
+# 上报浏览量的超时时间，上报失败不影响详情本身
+VIEW_REPORT_TIMEOUT = 5
 
 
 @method_decorator(csrf_exempt, name='dispatch')
@@ -104,7 +118,63 @@ class AppServerProxyView(View):
                 if key.lower() not in hop_by_hop_headers:
                     django_response[key] = value
 
+            self.report_app_view(request, response)
+
             return django_response
 
         except requests.RequestException as e:
             return HttpResponse(f"Error proxying request: {str(e)}", status=502)
+
+    def report_app_view(self, request: Any, response: Any) -> None:
+        """控制台内打开应用详情时，向商店上报一次浏览量(showCount)。
+
+        商店只在网页商店里统计浏览，控制台内的浏览一直没有上报，
+        导致漏斗最顶端的一格是空的。上报为旁路操作，失败不影响详情返回。
+        """
+        if request.method != 'GET' or response.status_code != 200:
+            return
+        if not APP_DETAIL_PATH_RE.match(request.path):
+            return
+
+        app = self.parse_app_identity(response)
+        if not app:
+            return
+        market_id, app_key_id = app
+
+        headers = {'Content-Type': 'application/json'}
+        # 商店按 X-Forwarded-For / X-Real-Ip 记录浏览来源，透传真实客户端 IP
+        forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '')
+        remote_addr = request.META.get('REMOTE_ADDR', '')
+        if forwarded_for:
+            headers['X-Forwarded-For'] = forwarded_for
+        if remote_addr:
+            headers['X-Real-IP'] = remote_addr
+
+        url = f"{self.target_base_url}/app-server/markets/{market_id}/apps/{app_key_id}/view"
+        threading.Thread(target=self.post_app_view, args=(url, headers), daemon=True).start()
+
+    @staticmethod
+    def parse_app_identity(response: Any) -> Optional[Tuple[str, str]]:
+        """从应用详情响应里取出商店 ID 和应用 ID。"""
+        if 'application/json' not in response.headers.get('Content-Type', ''):
+            return None
+        try:
+            detail = json.loads(response.content)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(detail, dict):
+            return None
+        market_id = detail.get('marketID')
+        app_key_id = detail.get('appKeyID')
+        if not market_id or not app_key_id:
+            return None
+        return market_id, app_key_id
+
+    @staticmethod
+    def post_app_view(url: str, headers: dict) -> None:
+        try:
+            resp = requests.post(url, headers=headers, data='{}', timeout=VIEW_REPORT_TIMEOUT, verify=False)
+            if resp.status_code != 200:
+                logger.warning("report app view failed url=%s status_code=%s", url, resp.status_code)
+        except Exception as e:
+            logger.warning("report app view failed url=%s error=%s", url, e)

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -3637,6 +3637,42 @@
       "status": "active"
     },
     {
+      "id": "console.component-type.change-log-direction",
+      "title": "Component type change records old type before and new type after",
+      "title_zh": "改组件类型的操作日志按变更前后正确记录",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_manage.ChangeServiceTypeView.put",
+      "code_paths": [
+        "console/views/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/vm_manage_view_test.py",
+          "selector": "ChangeServiceTypeViewTests.test_operation_log_records_old_type_before_and_new_type_after"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component-type.change-once",
+      "title": "Component type change is applied once",
+      "title_zh": "改组件类型只下发一次",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_manage.ChangeServiceTypeView.put",
+      "code_paths": [
+        "console/views/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/vm_manage_view_test.py",
+          "selector": "ChangeServiceTypeViewTests.test_change_service_type_is_applied_once"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component-type.daemonset",
       "title": "DaemonSet component type support",
       "title_zh": "DaemonSet 组件类型支持",
@@ -3845,6 +3881,29 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_change_component_image_updates_service_fields"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.component.change-type",
+      "title": "Change component deploy type",
+      "title_zh": "修改组件部署类型",
+      "interface_type": "workflow",
+      "interface": "console.services.mcp_query_service.call_tool[rainbond_change_component_type]",
+      "code_paths": [
+        "console/services/mcp_query_service.py",
+        "console/services/app_actions/app_manage.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/mcp_query_change_component_type_test.py",
+          "selector": "MCPQueryChangeComponentTypeTests.test_change_component_type_to_state_multiple"
+        },
+        {
+          "path": "console/tests/mcp_query_change_component_type_test.py",
+          "selector": "MCPQueryChangeComponentTypeTests.test_unsupported_component_type_is_rejected"
         }
       ],
       "test_type": "regression",
@@ -7126,6 +7185,28 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_query_local_app_models_returns_paginated_templates"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.market.report-app-view",
+      "title": "Report in-console app view to the store",
+      "title_zh": "上报控制台内应用条目浏览量",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_server_proxy.AppServerProxyView.report_app_view",
+      "code_paths": [
+        "console/views/app_server_proxy.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_server_proxy_view_report_test.py",
+          "selector": "AppServerProxyViewReportTests.test_app_detail_request_reports_view_to_store"
+        },
+        {
+          "path": "console/tests/app_server_proxy_view_report_test.py",
+          "selector": "AppServerProxyViewReportTests.test_non_detail_request_does_not_report"
         }
       ],
       "test_type": "regression",


### PR DESCRIPTION
两件互不依赖的事，分别在独立的 commit 里，可以按 commit review。

## 1. 控制台内应用市场的浏览量没有被统计

商店的 `showCount` 一直只统计到 hub.grapps.cn 网页商店那一侧，控制台内的浏览完全没有上报 —— 而真实流量正是从用户自己控制台里的应用市场来的。结果是有安装量的条目 `showCount` 仍然是 0，安装漏斗最顶端的一格是空的。

读两侧代码后确认，缺的只是控制台侧的一次调用：

- 商店的计数接口本来就有：`POST /app-server/markets/{marketID}/apps/{appID}/view` → `AddAppShowCount`。它挂在 UI 服务上，网页商店打开详情时会单独调它一次。
- 商店的 `getMarketAppDetail` 本身**不**计数，所以只查详情不会让计数动。
- 控制台已经把 `/app-server/*` 整段代理到 hub（`AppServerProxyView`），控制台内的市场正是通过它取应用详情 —— 也就是说，那批没被统计的流量本来就从控制台手里过。

所以这里不需要改商店，也不需要改 rainbond-ui：代理成功返回应用详情时，顺带向商店上报一次浏览。`marketID` / `appKeyID` 从详情响应体里取，两种详情路由（新版 `/marketui/apps/{主键}/detail`、旧版 `/marketui/{marketID}/apps/{appID}/detail`）都覆盖到。

上报是纯旁路：放在 daemon 线程里，带 5s 超时，商店挂了、响应体不是 JSON、甚至线程起不来，都不会影响详情本身的返回。同时透传 `X-Forwarded-For` / `X-Real-IP`，让商店记到真实客户端 IP 而不是控制台的 IP。

**没有做去重**，是有意的：商店对网页商店那侧也不去重，保持一致才能让控制台和网页两边的数字直接可比。用户重复打开详情会重复计数，和 hub 上的行为相同。

## 2. MCP 工具无法把组件设为有状态类型

agent 全程通过 MCP 操作平台，而工具集里没有任何一个能设置 `extend_method`，等于 agent 建不出有状态组件。ElasticSearch / ZooKeeper / Kafka / Nacos / MinIO 集群全都必须是有状态组件 —— 有状态组件才会拿到 headless Service，集群成员才能解析到各自的 pod IP，而不是一个 ClusterIP。

平台侧能力是齐的（核心的 headless Service、console 的 REST 接口、组件类型枚举、模板携带都在），缺的只有工具层。这里加 `rainbond_change_component_type` 包住已有的 `ChangeServiceTypeView`，走同一个 `is_support()` 校验，**不动任何业务逻辑**。工具描述里写清了什么场景该选 `state_multiple`，免得 agent 自己猜。

顺带修掉 `ChangeServiceTypeView` 里的两个 bug：

- `change_service_type` 被调用了两次 —— 不只是多写一次本地字段，是向 region 多下发了一次更新。
- 操作日志的 `old_information` / `new_information` 反了：变更**前**的类型被记成了"变更后"。也就是说此前每一条改类型的审计日志，新旧值都是颠倒的。

两个 bugfix 都有回归测试，且都已确认在修复前的代码上会失败。

## 验证

- 新增 16 个测试：代理上报 10、MCP 工具 4、view 修复 2
- `mcp_*`、`app_manage`、`vm_manage` 各套件全绿（约 290 个）
- `flake8` 相比 baseline 零新增告警；`test-manifest.json` 已登记新能力，校验通过

说明两点：

- 整目录 `pytest console/tests` 在本地基线上本来就有 70 个 collection error（`console.enum` 命名空间解析冲突，与本 PR 无关），所以按文件跑的。
- 没有跑 `yapf`：手上的 0.43.0 会把它碰到的每个文件里的存量代码都重排。`make check` 跑的是 flake8 + manifest 校验，两项都过。如果按仓库 pin 的 yapf 版本格式化，预计会挪动我这边的一些换行。
