### PR TITLE
fix: handle missing certificate during deletion

### DIFF
--- a/console/tests/app_domain_certificate_test.py
+++ b/console/tests/app_domain_certificate_test.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import sys
+from types import ModuleType
+from unittest import TestCase, mock
+
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _DummyConfiguration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    class _DummyApiException(Exception):
+        status = 500
+        body = ""
+
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    configuration_module.Configuration = _DummyConfiguration
+    rest_module.ApiException = _DummyApiException
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+
+from rest_framework.test import APIRequestFactory  # noqa: E402
+
+from console.views.app_config.app_domain import TenantCertificateManageView  # noqa: E402
+
+
+class TenantCertificateDeleteTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = TenantCertificateManageView()
+
+    # capability_id: console.gateway.certificate-delete-idempotent
+    def test_delete_missing_certificate_is_idempotent(self):
+        request = self.factory.delete("/console/teams/demo-team/certificates/42")
+
+        with (
+                mock.patch(
+                    "console.views.app_config.app_domain.domain_service.get_certificate_by_pk",
+                    return_value=(404, "证书不存在", None),
+                ) as get_certificate,
+                mock.patch(
+                    "console.views.app_config.app_domain.domain_service.delete_certificate_by_pk",
+                ) as delete_certificate,
+                mock.patch(
+                    "console.views.app_config.app_domain.operation_log_service.create_team_log",
+                ) as create_team_log,
+        ):
+            response = self.view.delete(request, certificate_id="42")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["msg_show"], "证书删除成功")
+        get_certificate.assert_called_once_with("42")
+        delete_certificate.assert_not_called()
+        create_team_log.assert_not_called()

--- a/console/views/app_config/app_domain.py
+++ b/console/views/app_config/app_domain.py
@@ -170,6 +170,9 @@ class TenantCertificateManageView(RegionTenantHeaderView):
         """
         certificate_id = kwargs.get("certificate_id", None)
         _, _, cert = domain_service.get_certificate_by_pk(certificate_id)  # type: ignore[arg-type]
+        if cert is None:
+            result = general_message(200, "success", "证书删除成功")
+            return Response(result, status=result["code"])
         old_information = json.dumps({
             "证书名称": cert["alias"],  # type: ignore[index]
             "证书类型": cert["certificate_type"],  # type: ignore[index]

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5664,6 +5664,24 @@
       "status": "active"
     },
     {
+      "id": "console.gateway.certificate-delete-idempotent",
+      "title": "Delete missing gateway certificate idempotently",
+      "title_zh": "Delete missing gateway certificate idempotently",
+      "interface_type": "view_endpoint",
+      "interface": "DELETE /console/teams/{tenant}/certificates/{certificate_id}",
+      "code_paths": [
+        "console/views/app_config/app_domain.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_domain_certificate_test.py",
+          "selector": "TenantCertificateDeleteTests::test_delete_missing_certificate_is_idempotent"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.gateway.component-env-upsert-schema",
       "title": "Gateway Component Env Upsert Schema",
       "title_zh": "Gateway Component Env Upsert Schema",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -301,6 +301,7 @@
 | console.enterprise.region-update | 更新企业集群 | active | regression | console.services.mcp_query_service.call_tool[rainbond_update_region] | console/tests/mcp_query_service_test.py::MCPQueryServiceRegionMutationTests.test_update_region_executes_directly_with_merged_full_payload |
 | console.file-manage.region-request-timeout | 文件管理区域请求使用选定容器与更长超时 | active | regression | www.apiclient.regionapi.RegionInvokeApi.get_files | console/tests/file_manage_service_test.py::test_region_api_get_files_uses_container_name_and_longer_timeout |
 | console.file-manage.selected-container-forwarding | 列出文件管理内容时透传用户选择的容器名 | active | regression | console.services.group_service.GroupService.get_file_and_dir | console/tests/file_manage_service_test.py::test_get_file_and_dir_forwards_selected_container_name |
+| console.gateway.certificate-delete-idempotent | Delete missing gateway certificate idempotently | active | regression | DELETE /console/teams/{tenant}/certificates/{certificate_id} | console/tests/app_domain_certificate_test.py::TenantCertificateDeleteTests::test_delete_missing_certificate_is_idempotent |
 | console.gateway.component-env-upsert-schema | Gateway Component Env Upsert Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.component-env-upsert-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_manage_component_envs_schema_exposes_single_item_upsert_guidance |
 | console.gateway.create-app-invalid-display-name | create_app 对非法应用名返回结构化错误详情 | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-invalid-display-name] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_create_app_returns_structured_details_for_illegal_app_name |
 | console.gateway.create-app-k8s-name-schema | Gateway Create App K8s Name Schema | active | regression | console.services.mcp_query_service.call_tool[console.gateway.create-app-k8s-name-schema] | console/tests/mcp_query_service_test.py::MCPQueryServiceToolVisibilityTests.test_create_app_tool_schema_exposes_k8s_app_constraints |
@@ -3545,6 +3546,16 @@
 - 业务入口: `console.services.group_service.GroupService.get_file_and_dir`
 - 代码路径: `console/services/group_service.py`, `console/views/app_overview.py`
 - 测试路径: `console/tests/file_manage_service_test.py::test_get_file_and_dir_forwards_selected_container_name`
+
+### Delete missing gateway certificate idempotently
+
+- Capability ID: `console.gateway.certificate-delete-idempotent`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `DELETE /console/teams/{tenant}/certificates/{certificate_id}`
+- 代码路径: `console/views/app_config/app_domain.py`
+- 测试路径: `console/tests/app_domain_certificate_test.py::TenantCertificateDeleteTests::test_delete_missing_certificate_is_idempotent`
 
 ### Gateway Component Env Upsert Schema
 


### PR DESCRIPTION
## Summary

- Treat deletion of an already-missing certificate record as a successful idempotent operation.
- Avoid dereferencing a missing certificate while building operation log data.
- Add a managed regression test for the missing-record path.

## Testing

- python scripts/run_pytest.py console/tests/app_domain_certificate_test.py -- -q
- flake8 on changed Python files
- python3 scripts/validate_test_manifest.py

## Related PRs

- https://github.com/goodrain/rainbond/pull/2666
- https://github.com/goodrain/rainbond-console/pull/2084
- https://github.com/goodrain/rainbond-ui/pull/1892