### PR TITLE
perf: speed up registry image metadata queries

### DIFF
--- a/console/repositories/team_repo.py
+++ b/console/repositories/team_repo.py
@@ -62,7 +62,7 @@ class TeamRepo(object):
             PermRelTenant.objects.filter(enterprise_id=enterprise.ID, user_id=user_id).values_list("tenant_id",
                                                                                                    flat=True).order_by("-ID"))
         tenant_ids = list(dict.fromkeys(tenant_ids))
-        filters = {"ID__in": tenant_ids}
+        filters: dict[str, Any] = {"ID__in": tenant_ids}
         if name:
             filters["tenant_alias__contains"] = name
         tenants_by_id = {tenant.ID: tenant for tenant in Tenants.objects.filter(**filters)}

--- a/console/services/team_services.py
+++ b/console/services/team_services.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+from concurrent.futures import ThreadPoolExecutor
 import json
 import logging
 import os
@@ -46,6 +47,7 @@ region_api = RegionInvokeApi()
 class TeamService(object):
     USER_REGISTRY_SCOPE = "user"
     ENTERPRISE_REGISTRY_SCOPE = "enterprise"
+    REGISTRY_METADATA_MAX_WORKERS = 20
     SUPPORTED_REGISTRY_HUB_TYPES = (
         "Docker", "Harbor", "AliyunACR", "TencentTCR", "HuaweiSWR", "VolcanoCR")
     LEGACY_REGISTRY_HUB_TYPE_ALIASES = {
@@ -890,7 +892,8 @@ class TeamService(object):
         challenge = header[len("Bearer "):]
         return dict((key, value) for key, value in re.findall(r'(\w+)="([^"]*)"', challenge))
 
-    def _get_registry_bearer_token(self, challenge: Dict[str, str], username: str, password: str) -> Optional[str]:
+    def _get_registry_bearer_token(self, challenge: Dict[str, str], username: str, password: str,
+                                   session: Optional[Any] = None) -> Optional[str]:
         realm = challenge.get("realm")
         if not realm:
             return None
@@ -899,7 +902,8 @@ class TeamService(object):
             params["service"] = challenge["service"]
         if challenge.get("scope"):
             params["scope"] = challenge["scope"]
-        response = requests.get(
+        requester = session or requests
+        response = requester.get(
             realm,
             params=params,
             auth=(username, password),
@@ -916,11 +920,16 @@ class TeamService(object):
         data = response.json()
         return data.get("token") or data.get("access_token")
 
-    def _registry_v2_get(self, url: str, username: str, password: str, headers: Optional[Dict[str, str]] = None) -> Any:
+    def _registry_v2_get(self, url: str, username: str, password: str, headers: Optional[Dict[str, str]] = None,
+                         session: Optional[Any] = None,
+                         bearer_token_cache: Optional[Dict[str, str]] = None) -> Any:
         request_headers = self._registry_v2_headers(username, password)
         if headers:
             request_headers.update(headers)
-        response = requests.get(
+        if bearer_token_cache is not None and bearer_token_cache.get("token"):
+            request_headers["Authorization"] = "Bearer {}".format(bearer_token_cache["token"])
+        requester = session or requests
+        response = requester.get(
             url,
             headers=request_headers,
             verify=False,
@@ -931,12 +940,14 @@ class TeamService(object):
         challenge = self._parse_registry_bearer_challenge(response.headers.get("WWW-Authenticate"))
         if not challenge:
             return response
-        token = self._get_registry_bearer_token(challenge, username, password)
+        token = self._get_registry_bearer_token(challenge, username, password, session=session)
         if not token:
             return response
+        if bearer_token_cache is not None:
+            bearer_token_cache["token"] = token
         bearer_headers = dict(request_headers)
         bearer_headers["Authorization"] = "Bearer {}".format(token)
-        return requests.get(
+        return requester.get(
             url,
             headers=bearer_headers,
             verify=False,
@@ -1787,6 +1798,45 @@ class TeamService(object):
         } for repo in filtered_repos[start:end]]
         return {"images": images, "total": total, "page": page, "page_size": page_size}
 
+    def _get_registry_image_metadata(self, base_url: str, repo_name: str, username: str,
+                                     password: str) -> Dict[str, str]:
+        bearer_token_cache: Dict[str, str] = {}
+        with requests.Session() as session:
+            tags_url = "{}/v2/{}/tags/list".format(base_url, repo_name)
+            tags_response = self._registry_v2_get(
+                tags_url,
+                username,
+                password,
+                session=session,
+                bearer_token_cache=bearer_token_cache,
+            )
+            if tags_response.status_code == 200:
+                tags = tags_response.json().get("tags", []) or []
+                if tags:
+                    tag_info = self._get_registry_tag_info(
+                        base_url,
+                        repo_name,
+                        tags[0],
+                        username,
+                        password,
+                        session=session,
+                        bearer_token_cache=bearer_token_cache,
+                    )
+                    updated_at = tag_info["updated_at"]
+                    return {"created_at": updated_at, "updated_at": updated_at}
+        return {"created_at": "", "updated_at": ""}
+
+    def _get_registry_images_metadata(self, base_url: str, repo_names: List[str], username: str,
+                                      password: str) -> List[Dict[str, str]]:
+        if not repo_names:
+            return []
+        max_workers = min(self.REGISTRY_METADATA_MAX_WORKERS, len(repo_names))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(
+                lambda repo_name: self._get_registry_image_metadata(base_url, repo_name, username, password),
+                repo_names,
+            ))
+
     def _registry_tag_info_to_payload(self, tag: str, tag_info: Dict[str, Any]) -> Dict[str, Any]:
         created_at = tag_info.get("created_at") or tag_info.get("updated_at") or ""
         updated_at = tag_info.get("updated_at") or created_at
@@ -2083,22 +2133,15 @@ class TeamService(object):
                         start = (page - 1) * page_size
                         end = start + page_size
                         paginated_repos = filtered_repos[start:end]
-                        
+                        repo_names = [
+                            repo if namespace == "library" else "{}/{}".format(namespace, repo)
+                            for repo in paginated_repos
+                        ]
+                        metadata = self._get_registry_images_metadata(
+                            base_url, repo_names, username, password)
+
                         images = []
-                        for repo in paginated_repos:
-                            # 获取仓库的标签列表
-                            tags_url = "{}/v2/{}/tags/list".format(base_url, repo if namespace == "library" else f"{namespace}/{repo}")
-                            tags_response = self._registry_v2_get(tags_url, username, password)
-                            updated_at = ""
-                            
-                            if tags_response.status_code == 200:
-                                tags = tags_response.json().get("tags", [])
-                                if tags:
-                                    # 获取最新标签的信息
-                                    repo_name = repo if namespace == "library" else f"{namespace}/{repo}"
-                                    tag_info = self._get_registry_tag_info(base_url, repo_name, tags[0], username, password)
-                                    updated_at = tag_info["updated_at"]
-                            
+                        for repo, repo_metadata in zip(paginated_repos, metadata):
                             images.append({
                                 "name": repo,
                                 "namespace": namespace,
@@ -2106,8 +2149,8 @@ class TeamService(object):
                                 "is_public": True,
                                 "pull_count": 0,
                                 "star_count": 0,
-                                "created_at": updated_at,
-                                "updated_at": updated_at,
+                                "created_at": repo_metadata["created_at"],
+                                "updated_at": repo_metadata["updated_at"],
                                 "status": "active",
                                 "registry_type": "Docker"
                             })
@@ -2321,7 +2364,8 @@ class TeamService(object):
                 status_code=500)
 
     def _get_registry_tag_info(self, base_url: str, repo_name: str, tag_name: str,
-                               username: str, password: str) -> dict:
+                               username: str, password: str, session: Optional[Any] = None,
+                               bearer_token_cache: Optional[Dict[str, str]] = None) -> dict:
         """获取 Docker Registry 标签的详细信息
         
         Args:
@@ -2340,7 +2384,9 @@ class TeamService(object):
                 manifest_url,
                 username,
                 password,
-                {"Accept": ", ".join(self.REGISTRY_MANIFEST_ACCEPT_TYPES)}
+                {"Accept": ", ".join(self.REGISTRY_MANIFEST_ACCEPT_TYPES)},
+                session=session,
+                bearer_token_cache=bearer_token_cache,
             )
             
             if manifest_response.status_code == 200:
@@ -2363,7 +2409,13 @@ class TeamService(object):
 
                 if config_digest:
                     config_url = "{}/v2/{}/blobs/{}".format(base_url, repo_name, config_digest)
-                    config_response = self._registry_v2_get(config_url, username, password)
+                    config_response = self._registry_v2_get(
+                        config_url,
+                        username,
+                        password,
+                        session=session,
+                        bearer_token_cache=bearer_token_cache,
+                    )
                     if config_response.status_code == 200:
                         config = config_response.json()
                         return {

--- a/console/tests/registry_service_test.py
+++ b/console/tests/registry_service_test.py
@@ -2,6 +2,7 @@
 import collections
 import os
 import sys
+import threading
 from types import ModuleType, SimpleNamespace
 from unittest import TestCase, mock
 try:
@@ -620,6 +621,109 @@ class RegistryNamespaceServiceTestCase(TestCase):
 
         self.assertEqual([image["name"] for image in data["images"]], ["console"])
         self.assertEqual(data["total"], 1)
+
+    def test_get_docker_images_fetches_page_metadata_concurrently(self):
+        repositories = ["image-{}".format(index) for index in range(20)]
+        catalog_response = mock.Mock(status_code=200, headers={})
+        metadata_barrier = threading.Barrier(len(repositories))
+
+        def get_metadata(base_url, repo_name, username, password):
+            metadata_barrier.wait(timeout=2)
+            return {
+                "created_at": "created-{}".format(repo_name),
+                "updated_at": "updated-{}".format(repo_name),
+            }
+
+        with mock.patch.object(
+                team_services,
+                "_get_registry_v2_catalog",
+                return_value=(repositories, catalog_response)), \
+                mock.patch.object(
+                    team_services,
+                    "_get_registry_image_metadata",
+                    side_effect=get_metadata,
+                    create=True) as metadata_mock, \
+                mock.patch.object(team_services, "_registry_v2_get") as registry_get:
+            data = team_services.get_registry_images(
+                domain="https://registry.example.com",
+                username="demo-user",
+                password="demo-password",
+                hub_type="Docker",
+                namespace="library",
+                page=1,
+                page_size=len(repositories),
+            )
+
+        self.assertEqual(metadata_mock.call_count, len(repositories))
+        registry_get.assert_not_called()
+        self.assertEqual([image["name"] for image in data["images"]], repositories)
+        self.assertEqual(
+            [image["created_at"] for image in data["images"]],
+            ["created-{}".format(repository) for repository in repositories],
+        )
+
+    def test_registry_image_metadata_reuses_http_session(self):
+        session = mock.MagicMock()
+        session.__enter__.return_value = session
+        tags_response = mock.Mock(status_code=200)
+        tags_response.json.return_value = {"tags": ["latest"]}
+        tag_info = {"updated_at": "2026-08-09T12:00:00Z"}
+
+        with mock.patch("console.services.team_services.requests.Session", return_value=session) as session_factory, \
+                mock.patch.object(team_services, "_registry_v2_get", return_value=tags_response) as registry_get, \
+                mock.patch.object(team_services, "_get_registry_tag_info", return_value=tag_info) as get_tag_info:
+            metadata = team_services._get_registry_image_metadata(
+                "https://registry.example.com", "library/nginx", "user", "password")
+
+        session_factory.assert_called_once_with()
+        self.assertIs(registry_get.call_args.kwargs["session"], session)
+        self.assertIs(
+            registry_get.call_args.kwargs["bearer_token_cache"],
+            get_tag_info.call_args.kwargs["bearer_token_cache"],
+        )
+        self.assertEqual(metadata["updated_at"], tag_info["updated_at"])
+
+    def test_registry_v2_get_reuses_cached_bearer_token(self):
+        challenge = mock.Mock(
+            status_code=401,
+            headers={
+                "WWW-Authenticate": (
+                    'Bearer realm="https://registry.example.com/service/token",'
+                    'service="registry.example.com",'
+                    'scope="repository:library/nginx:pull"'
+                )
+            },
+        )
+        token_response = mock.Mock(status_code=200)
+        token_response.json.return_value = {"token": "registry-token"}
+        first_response = mock.Mock(status_code=200)
+        second_response = mock.Mock(status_code=200)
+        session = mock.Mock()
+        session.get.side_effect = [challenge, token_response, first_response, second_response]
+        bearer_token_cache = {}
+
+        first_result = team_services._registry_v2_get(
+            "https://registry.example.com/v2/library/nginx/tags/list",
+            "user",
+            "password",
+            session=session,
+            bearer_token_cache=bearer_token_cache,
+        )
+        second_result = team_services._registry_v2_get(
+            "https://registry.example.com/v2/library/nginx/manifests/latest",
+            "user",
+            "password",
+            session=session,
+            bearer_token_cache=bearer_token_cache,
+        )
+
+        self.assertIs(first_result, first_response)
+        self.assertIs(second_result, second_response)
+        self.assertEqual(session.get.call_count, 4)
+        self.assertEqual(
+            session.get.call_args_list[-1].kwargs["headers"]["Authorization"],
+            "Bearer registry-token",
+        )
 
     def test_get_docker_namespaces_rejects_cross_origin_catalog_link(self):
         response = mock.Mock(

--- a/console/views/app_monitor.py
+++ b/console/views/app_monitor.py
@@ -208,7 +208,7 @@ class BatchAppMonitorQueryView(RegionTenantHeaderView):
         response_data = response_body["data"]["result"]  # type: ignore[index]
         throughput_data = throughput_body["data"]["result"]  # type: ignore[index]
 
-        throughput_by_key = {}
+        throughput_by_key: dict[str, list[Any]] = {}
         for throughput in throughput_data:
             metric = throughput["metric"]
             union_key = metric["client"] + "+" + metric["service_id"]

--- a/console/views/public_areas.py
+++ b/console/views/public_areas.py
@@ -34,7 +34,7 @@ region_api = RegionInvokeApi()
 logger = logging.getLogger('default')
 
 
-def _get_group_service_ids(team_id: str, region_name: str, group_ids: Any) -> dict:
+def _get_group_service_ids(team_id: str, region_name: str, group_ids: Any) -> dict[int, list[str]]:
     if not group_ids:
         return {}
     service_ids = list(TenantServiceInfo.objects.filter(
@@ -49,7 +49,7 @@ def _get_group_service_ids(team_id: str, region_name: str, group_ids: Any) -> di
         group_id__in=group_ids,
         service_id__in=service_ids,
     ).values("group_id", "service_id")
-    result = {}
+    result: dict[int, list[str]] = {}
     for relation in relations:
         result.setdefault(relation["group_id"], []).append(relation["service_id"])
     return result


### PR DESCRIPTION
## Summary

- fetch metadata for the current registry image page concurrently with a bounded 20-worker pool
- reuse one HTTP session and Bearer token within each repository metadata lookup
- preserve pagination results, response order, and existing metadata fields

## Testing

- mypy on console/services/team_services.py
- 29 registry service tests passed
- Python syntax compilation passed
- test manifest validation passed
- git diff check passed

## Known baseline issue

- repository-wide make check still reports pre-existing flake8 findings on main; the changed lines introduce no new lint findings