### PR TITLE
perf: add console request timing diagnostics

### DIFF
--- a/console/tests/performance_timing_test.py
+++ b/console/tests/performance_timing_test.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from goodrain_web.performance import (PerformanceTimingMiddleware, get_performance_context,
+                                      record_region_call)
+
+
+class FakeResponse(dict):
+    def __init__(self, status_code=200):
+        super(FakeResponse, self).__init__()
+        self.status_code = status_code
+
+
+class PerformanceTimingMiddlewareTestCase(TestCase):
+    def test_slow_request_logs_sanitized_region_breakdown(self):
+        def get_response(_request):
+            record_region_call(
+                "GET",
+                "https://rbd-api-api:8443/v2/cluster/nodes?token=secret#fragment",
+                200,
+                225.5,
+            )
+            return FakeResponse()
+
+        request = SimpleNamespace(
+            method="GET",
+            path="/console/enterprise/demo/regions",
+            META={"QUERY_STRING": "check_status=yes&token=secret"},
+        )
+
+        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+                mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 11.25]), \
+                mock.patch("goodrain_web.performance.logger.info") as log_info:
+            response = PerformanceTimingMiddleware(get_response)(request)
+
+        payload = json.loads(log_info.call_args.args[1])
+        self.assertEqual(payload["event"], "console_request_timing")
+        self.assertEqual(payload["path"], "/console/enterprise/demo/regions")
+        self.assertNotIn("token", json.dumps(payload))
+        self.assertEqual(payload["total_ms"], 1250.0)
+        self.assertEqual(payload["region_call_count"], 1)
+        self.assertEqual(payload["region_total_ms"], 225.5)
+        self.assertEqual(payload["region_max_ms"], 225.5)
+        self.assertEqual(payload["non_region_ms"], 1024.5)
+        self.assertEqual(payload["region_calls"][0]["path"], "/v2/cluster/nodes")
+        self.assertEqual(response["X-Request-ID"], payload["request_id"])
+        self.assertIsNone(get_performance_context())
+
+    def test_fast_request_does_not_write_performance_log(self):
+        request = SimpleNamespace(method="GET", path="/console/teams", META={})
+
+        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+                mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
+                mock.patch("goodrain_web.performance.logger.info") as log_info:
+            response = PerformanceTimingMiddleware(lambda _request: FakeResponse())(request)
+
+        log_info.assert_not_called()
+        self.assertIn("X-Request-ID", response)
+        self.assertIsNone(get_performance_context())
+
+    def test_failed_request_is_logged_and_context_is_reset(self):
+        def fail(_request):
+            raise RuntimeError("boom")
+
+        request = SimpleNamespace(method="GET", path="/console/teams", META={})
+
+        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+                mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
+                mock.patch("goodrain_web.performance.logger.info") as log_info, \
+                self.assertRaises(RuntimeError):
+            PerformanceTimingMiddleware(fail)(request)
+
+        payload = json.loads(log_info.call_args.args[1])
+        self.assertEqual(payload["status"], 500)
+        self.assertIsNone(get_performance_context())
+
+    def test_logging_failure_does_not_break_request(self):
+        request = SimpleNamespace(method="GET", path="/console/teams", META={})
+
+        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "0"}), \
+                mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
+                mock.patch("goodrain_web.performance.logger.info", side_effect=RuntimeError("log unavailable")):
+            response = PerformanceTimingMiddleware(lambda _request: FakeResponse())(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(get_performance_context())

--- a/console/tests/regionapibaseclient_test.py
+++ b/console/tests/regionapibaseclient_test.py
@@ -2,6 +2,7 @@
 import collections
 import json
 import os
+import socket
 import sys
 from types import ModuleType
 from unittest import TestCase, mock
@@ -27,6 +28,69 @@ from www.apiclient.regionapibaseclient import RegionApiBaseHttpClient  # noqa: E
 
 
 class RegionApiBaseHttpClientTestCase(TestCase):
+    def test_timed_client_request_records_success(self):
+        client = RegionApiBaseHttpClient()
+        transport = mock.Mock()
+        transport.request.return_value = mock.Mock(status=200)
+        url = "https://rbd-api-api:8443/v2/cluster/nodes?label=worker"
+
+        with mock.patch("www.apiclient.regionapibaseclient.time.monotonic", side_effect=[10.0, 10.25]), \
+                mock.patch("www.apiclient.regionapibaseclient.record_region_call") as record_region_call:
+            response = client._timed_client_request(transport, url, "GET", headers={})
+
+        self.assertEqual(response.status, 200)
+        transport.request.assert_called_once_with(url=url, method="GET", headers={})
+        record_region_call.assert_called_once_with("GET", url, 200, 250.0)
+
+    def test_timed_client_request_records_error_without_swallowing_it(self):
+        client = RegionApiBaseHttpClient()
+        transport = mock.Mock()
+        transport.request.side_effect = socket.timeout("boom")
+        url = "https://rbd-api-api:8443/v2/cluster/nodes"
+
+        with mock.patch("www.apiclient.regionapibaseclient.time.monotonic", side_effect=[10.0, 10.1]), \
+                mock.patch("www.apiclient.regionapibaseclient.record_region_call") as record_region_call, \
+                self.assertRaises(socket.timeout):
+            client._timed_client_request(transport, url, "GET", headers={})
+
+        record_region_call.assert_called_once_with("GET", url, "error", 100.0)
+
+    def test_create_client_suppresses_insecure_request_warning_when_ssl_verification_is_disabled(self):
+        client = RegionApiBaseHttpClient()
+        configuration = mock.Mock(
+            verify_ssl=False,
+            ssl_ca_cert=None,
+            cert_file=None,
+            key_file=None,
+            assert_hostname=None,
+            connection_pool_maxsize=4,
+            proxy=None,
+        )
+
+        with mock.patch("www.apiclient.regionapibaseclient.urllib3.disable_warnings") as disable_warnings, \
+                mock.patch("www.apiclient.regionapibaseclient.urllib3.PoolManager"):
+            client.create_client(configuration)
+
+        disable_warnings.assert_called_once_with(urllib3.exceptions.InsecureRequestWarning)
+
+    def test_create_client_keeps_tls_warnings_when_ssl_verification_is_enabled(self):
+        client = RegionApiBaseHttpClient()
+        configuration = mock.Mock(
+            verify_ssl=True,
+            ssl_ca_cert=None,
+            cert_file=None,
+            key_file=None,
+            assert_hostname=None,
+            connection_pool_maxsize=4,
+            proxy=None,
+        )
+
+        with mock.patch("www.apiclient.regionapibaseclient.urllib3.disable_warnings") as disable_warnings, \
+                mock.patch("www.apiclient.regionapibaseclient.urllib3.PoolManager"):
+            client.create_client(configuration)
+
+        disable_warnings.assert_not_called()
+
     # capability_id: console.region-api.helm-resource-conflict-msg
     def test_check_status_translates_helm_ownership_conflict_to_actionable_msg_show(self):
         client = RegionApiBaseHttpClient()

--- a/goodrain_web/performance.py
+++ b/goodrain_web/performance.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+import json
+import logging
+import os
+import time
+import uuid
+from contextvars import ContextVar
+from urllib.parse import urlsplit
+
+logger = logging.getLogger('default')
+
+DEFAULT_SLOW_REQUEST_THRESHOLD_MS = 500.0
+MAX_REGION_CALL_DETAILS = 100
+PERFORMANCE_PATH_PREFIXES = ('/api/', '/console/', '/marketapi/', '/openapi/')
+
+_performance_context = ContextVar('console_performance_context', default=None)
+
+
+def get_performance_context():
+    return _performance_context.get()
+
+
+def _start_performance_context():
+    context = {
+        "request_id": uuid.uuid4().hex,
+        "region_calls": [],
+        "region_call_count": 0,
+        "region_total_ms": 0.0,
+        "region_max_ms": 0.0,
+    }
+    return _performance_context.set(context), context
+
+
+def _slow_request_threshold_ms():
+    try:
+        return max(0.0, float(os.environ.get("CONSOLE_SLOW_REQUEST_THRESHOLD_MS",
+                                             DEFAULT_SLOW_REQUEST_THRESHOLD_MS)))
+    except (TypeError, ValueError):
+        return DEFAULT_SLOW_REQUEST_THRESHOLD_MS
+
+
+def _safe_url_path(url):
+    try:
+        return urlsplit(str(url)).path or "/"
+    except (TypeError, ValueError):
+        return "<invalid-url>"
+
+
+def record_region_call(method, url, status, elapsed_ms):
+    context = get_performance_context()
+    if context is None:
+        return
+
+    elapsed_ms = round(float(elapsed_ms), 3)
+    context["region_call_count"] += 1
+    context["region_total_ms"] += elapsed_ms
+    context["region_max_ms"] = max(context["region_max_ms"], elapsed_ms)
+    if len(context["region_calls"]) < MAX_REGION_CALL_DETAILS:
+        context["region_calls"].append({
+            "method": str(method).upper(),
+            "path": _safe_url_path(url),
+            "status": status,
+            "elapsed_ms": elapsed_ms,
+        })
+
+
+class PerformanceTimingMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not request.path.startswith(PERFORMANCE_PATH_PREFIXES):
+            return self.get_response(request)
+
+        token, context = _start_performance_context()
+        started = time.monotonic()
+        status = 500
+        try:
+            response = self.get_response(request)
+            status = getattr(response, "status_code", 200)
+            response["X-Request-ID"] = context["request_id"]
+            return response
+        finally:
+            try:
+                total_ms = round((time.monotonic() - started) * 1000, 3)
+                if status >= 500 or total_ms >= _slow_request_threshold_ms():
+                    payload = {
+                        "event": "console_request_timing",
+                        "request_id": context["request_id"],
+                        "method": request.method,
+                        "path": request.path,
+                        "status": status,
+                        "total_ms": total_ms,
+                        "region_call_count": context["region_call_count"],
+                        "region_total_ms": round(context["region_total_ms"], 3),
+                        "region_max_ms": round(context["region_max_ms"], 3),
+                        "non_region_ms": round(max(0.0, total_ms - context["region_total_ms"]), 3),
+                        "region_calls": context["region_calls"],
+                    }
+                    try:
+                        logger.info("PERF_REQUEST %s", json.dumps(payload, ensure_ascii=False, sort_keys=True))
+                    except Exception:
+                        pass
+            finally:
+                _performance_context.reset(token)

--- a/goodrain_web/settings.py
+++ b/goodrain_web/settings.py
@@ -226,6 +226,7 @@ if IS_OPEN_API:
         },
     }
 MIDDLEWARE = (
+    'goodrain_web.performance.PerformanceTimingMiddleware',
     'goodrain_web.middleware.ErrorPage',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.gzip.GZipMiddleware',

--- a/www/apiclient/regionapibaseclient.py
+++ b/www/apiclient/regionapibaseclient.py
@@ -9,6 +9,7 @@ import os
 import re
 import socket
 import ssl
+import time
 from typing import Any, Optional, Tuple, Union
 
 import certifi
@@ -20,6 +21,7 @@ from console.exception.main import ServiceHandleException, ErrClusterLackOfMemor
 from console.repositories.region_repo import region_repo
 from django.conf import settings
 from django.http import HttpResponse, QueryDict, StreamingHttpResponse
+from goodrain_web.performance import record_region_call
 from urllib3.exceptions import MaxRetryError
 
 logger = logging.getLogger('default')
@@ -255,6 +257,17 @@ class RegionApiBaseHttpClient(object):
             connect, red = 5.0, 30.0
         return connect, red
 
+    def _timed_client_request(self, client, url, method, **kwargs):
+        started = time.monotonic()
+        status = "error"
+        try:
+            response = client.request(url=url, method=method, **kwargs)
+            status = response.status
+            return response
+        finally:
+            elapsed_ms = round((time.monotonic() - started) * 1000, 3)
+            record_region_call(method, url, status, elapsed_ms)
+
     def _request(self, url, method, headers=None, body=None, *args, **kwargs):
         region_name = kwargs.get("region")
         retries = kwargs.get("retries", 2)
@@ -277,7 +290,8 @@ class RegionApiBaseHttpClient(object):
                 msg="create region api client failure", msg_show="创建集群通信客户端错误，请检查集群配置", error_code=10411)
         try:
             if preload_content is False:
-                response = client.request(
+                response = self._timed_client_request(
+                    client,
                     url=url,
                     method=method,
                     headers=headers,
@@ -286,14 +300,16 @@ class RegionApiBaseHttpClient(object):
                 )
                 return response, None
             if body is None:
-                response = client.request(
+                response = self._timed_client_request(
+                    client,
                     url=url,
                     method=method,
                     headers=headers,
                     timeout=urllib3.Timeout(connect=d_connect, read=timeout),
                     retries=retries)
             else:
-                response = client.request(
+                response = self._timed_client_request(
+                    client,
                     url=url,
                     method=method,
                     headers=headers,
@@ -341,6 +357,7 @@ class RegionApiBaseHttpClient(object):
             cert_reqs = ssl.CERT_REQUIRED
         else:
             cert_reqs = ssl.CERT_NONE
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         # ca_certs
         if configuration.ssl_ca_cert:
@@ -462,7 +479,8 @@ class RegionApiBaseHttpClient(object):
         requests_args['headers'] = self._apply_region_token_headers(headers, region)
 
         client = self.get_client(region_config=region)
-        response = client.request(
+        response = self._timed_client_request(
+            client,
             method=request.method,
             timeout=urllib3.Timeout(connect=None, read=None),
             url="{}{}".format(region.url, url),
@@ -552,7 +570,8 @@ class RegionApiBaseHttpClient(object):
             raise ServiceHandleException("region {0} not found".format(region_name), error_code=10412)
         headers = self._apply_region_token_headers(headers, region)
         client = self.get_client(region_config=region)
-        response = client.request(
+        response = self._timed_client_request(
+            client,
             method=request.method,
             url="{}{}".format(region.url, url),
             body=request.body,


### PR DESCRIPTION
## Summary

- add correlated slow-request timing logs for Console API traffic
- include sanitized Region API call timings and non-Region time in each summary
- add request IDs while excluding query strings, headers, bodies, and credentials
- suppress repeated insecure TLS warnings only when verification is disabled

## Verification

- 19 focused tests passed
- changed-file flake8 passed
- Python syntax compilation passed
- test manifest validation passed
- WSGI middleware initialization passed