### PR TITLE
fix: remove vertical scaling memory limit

### DIFF
--- a/console/services/app_actions/app_manage.py
+++ b/console/services/app_actions/app_manage.py
@@ -945,8 +945,8 @@ class AppManageService(AppManageBase):
                          new_cpu: Optional[int] = None) -> Tuple[int, str]:
         """组件垂直升级"""
         new_memory = int(new_memory)
-        if new_memory > 65536 or new_memory < 0:
-            return 400, "内存范围在0M到64G之间"
+        if new_memory < 0:
+            return 400, "内存不能小于0M"
         if new_memory > service.min_memory and not check_account_quota(tenant.creater, service.service_region, self.ResourceOperationVerticalUpgrade):
             raise ServiceHandleException(error_code=20002, msg="not enough quota")
         if service.create_status == "complete":

--- a/console/tests/app_manage_test.py
+++ b/console/tests/app_manage_test.py
@@ -234,6 +234,54 @@ class AppManageStartErrorTests(TestCase):
         self.assertEqual(409, code)
         self.assertEqual("当前虚拟机不满足热更新条件，请停机后再修改规格。", msg)
 
+    def test_vertical_upgrade_allows_memory_above_64g(self):
+        tenant = mock.Mock(creater="creator", enterprise_id="eid", tenant_name="demo-team")
+        user = mock.Mock(nick_name="tester")
+        service = mock.Mock(
+            min_memory=4096,
+            service_region="demo-region",
+            service_alias="demo-service",
+            create_status="complete",
+            container_gpu=0,
+        )
+
+        with mock.patch.object(app_manage_module, "check_account_quota", return_value=True), \
+                mock.patch.object(app_manage_module.region_api, "vertical_upgrade") as vertical_upgrade:
+            code, msg = app_manage_module.AppManageService().vertical_upgrade(
+                tenant,
+                service,
+                user,
+                131072,
+                oauth_instance=None,
+                new_cpu=8000,
+            )
+
+        self.assertEqual(200, code)
+        self.assertEqual("操作成功", msg)
+        self.assertEqual(131072, service.min_memory)
+        service.save.assert_called_once()
+        body = vertical_upgrade.call_args[0][3]
+        self.assertEqual(131072, body["container_memory"])
+
+    def test_vertical_upgrade_rejects_negative_memory_without_obsolete_upper_bound_message(self):
+        tenant = mock.Mock()
+        service = mock.Mock()
+        user = mock.Mock()
+
+        with mock.patch.object(app_manage_module.region_api, "vertical_upgrade") as vertical_upgrade:
+            code, msg = app_manage_module.AppManageService().vertical_upgrade(
+                tenant,
+                service,
+                user,
+                -1,
+                oauth_instance=None,
+            )
+
+        self.assertEqual(400, code)
+        self.assertEqual("内存不能小于0M", msg)
+        service.save.assert_not_called()
+        vertical_upgrade.assert_not_called()
+
 
 class AppManageBatchActionDeployEventTests(DjangoTestCase):
 


### PR DESCRIPTION
## Summary
- remove the fixed 64 GiB upper bound from component vertical scaling
- keep negative memory validation and quota checks intact
- add regression coverage for 128 GiB scaling and negative values

## Verification
- venv/bin/pytest -q console/tests/app_manage_test.py -k vertical_upgrade
- venv/bin/python -m py_compile console/services/app_actions/app_manage.py console/tests/app_manage_test.py
- venv/bin/python scripts/validate_test_manifest.py --repo-root . --manifest test-manifest.json
- git diff --check

## Known baseline issues
- repository-wide make check remains blocked by pre-existing flake8 violations outside this change