### PR TITLE
perf: reduce console request query amplification

### DIFF
--- a/console/repositories/app_config.py
+++ b/console/repositories/app_config.py
@@ -423,6 +423,9 @@ class TenantServiceRelationRepository(object):
         tsr = TenantServiceRelation.objects.filter(tenant_id=tenant_id, dep_service_id=dep_service_id)
         return tsr
 
+    def get_dependencies_by_dep_ids(self, tenant_id: str, dep_service_ids: Any) -> QuerySet:
+        return TenantServiceRelation.objects.filter(tenant_id=tenant_id, dep_service_id__in=dep_service_ids)
+
     def delete_service_relation(self, tenant_id: str, service_id: str) -> None:
         TenantServiceRelation.objects.filter(tenant_id=tenant_id, service_id=service_id).delete()
 

--- a/console/repositories/perm_repo.py
+++ b/console/repositories/perm_repo.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+import threading
+import time
 from typing import Any, Dict, List, Optional
 
 from django.db import transaction
@@ -17,12 +19,33 @@ logger = logging.getLogger('default')
 
 
 class PermsRepo(object):
-    @transaction.atomic
+    permission_settings_check_interval = 60
+
+    def __init__(self) -> None:
+        self._permission_settings_lock = threading.Lock()
+        self._permission_settings_checked_at = 0.0
+
     def initialize_permission_settings(self) -> None:
         """判断有没有初始化权限数据，没有则初始化"""
+        now = time.monotonic()
+        if (self._permission_settings_checked_at and
+                now - self._permission_settings_checked_at < self.permission_settings_check_interval):
+            return
+        with self._permission_settings_lock:
+            now = time.monotonic()
+            if (self._permission_settings_checked_at and
+                    now - self._permission_settings_checked_at < self.permission_settings_check_interval):
+                return
+            self._sync_permission_settings()
+            self._permission_settings_checked_at = now
+
+    @transaction.atomic
+    def _sync_permission_settings(self) -> None:
         all_perms_list = get_perms_metadata()
         has_perms = PermsInfo.objects.all()
         has_perms_list = list(has_perms.values_list("name", "desc", "code", "group", "kind"))
+        all_perms_list.sort(key=lambda perm: perm[2])
+        has_perms_list.sort(key=lambda perm: perm[2])
         if all_perms_list != has_perms_list:
             has_perms.delete()
             perms_list = []

--- a/console/services/config_service.py
+++ b/console/services/config_service.py
@@ -34,8 +34,12 @@ class ConfigService(object):
     def initialization_or_get_config(self) -> Dict[str, Any]:
         self.init_base_config_value()
         rst_datas: Dict[str, Any] = {}
+        config_keys = list(dict.fromkeys(self.base_cfg_keys + self.cfg_keys))
+        configs_by_key = {
+            config.key: config for config in ConsoleSysConfig.objects.filter(key__in=config_keys)
+        }
         for key in self.base_cfg_keys:
-            tar_key = self.get_config_by_key(key)
+            tar_key = configs_by_key.get(key)
             if not tar_key:
                 enable = self.base_cfg_keys_value[key]["enable"]
                 value = self.base_cfg_keys_value[key]["value"]
@@ -44,6 +48,7 @@ class ConfigService(object):
                 if isinstance(value, (dict, list)):
                     config_type = "json"
                 rst_key = self.add_config(key=key, default_value=value, type=config_type, enable=enable, desc=desc)
+                configs_by_key[key] = rst_key
 
                 value = rst_key.value
                 enable = rst_key.enable
@@ -59,7 +64,7 @@ class ConfigService(object):
                 rst_datas[key.lower()] = {"enable": tar_key.enable, "value": self.base_cfg_keys_value[key]["value"]}
 
         for key in self.cfg_keys:
-            tar_key = self.get_config_by_key(key)
+            tar_key = configs_by_key.get(key)
             if not tar_key:
                 enable = self.cfg_keys_value[key]["enable"]
                 value = self.cfg_keys_value[key]["value"]
@@ -68,6 +73,7 @@ class ConfigService(object):
                 if isinstance(value, (dict, list)):
                     config_type = "json"
                 rst_key = self.add_config(key=key, default_value=value, type=config_type, enable=enable, desc=desc)
+                configs_by_key[key] = rst_key
 
                 value = rst_key.value
                 enable = rst_key.enable

--- a/console/services/group_service.py
+++ b/console/services/group_service.py
@@ -418,27 +418,80 @@ class GroupService(object):
                 return False
         return status
 
+    def _get_app_resource_service_statuses(self, tenant: Tenants, region_name: str,
+                                           services: Any) -> Dict[str, Any]:
+        statuses = {
+            service.service_id: "" if service.create_status == "complete" else False for service in services
+        }
+        complete_services = [service for service in services if service.create_status == "complete"]
+        kubeblocks_services = [
+            service for service in complete_services if is_kubeblocks(getattr(service, "extend_method", ""))
+        ]
+        batch_service_ids = [
+            service.service_id for service in complete_services
+            if not is_kubeblocks(getattr(service, "extend_method", ""))
+        ]
+        for service in kubeblocks_services:
+            # KubeBlocks has a dedicated single-component status path. Keep it
+            # unchanged while batching ordinary and VM component statuses.
+            statuses[service.service_id] = self.service_status(tenant, service)
+        if not batch_service_ids:
+            return statuses
+        try:
+            body = region_api.service_status(region_name, tenant.tenant_name, {
+                "service_ids": batch_service_ids,
+                "enterprise_id": tenant.enterprise_id
+            })
+            status_list = body["list"]  # type: ignore[index]
+        except region_api.CallApiError as e:
+            if int(e.status) == 404:
+                for service_id in batch_service_ids:
+                    statuses[service_id] = False
+            return statuses
+        for status_info in status_list:
+            service_id = status_info.get("service_id")
+            if service_id in statuses:
+                statuses[service_id] = status_info.get("status", "")
+        return statuses
+
+    def _get_cross_app_dependency_flags(self, tenant_id: str, service_ids: List[str]) -> Dict[str, bool]:
+        flags = {service_id: False for service_id in service_ids}
+        dependencies = dep_relation_repo.get_dependencies_by_dep_ids(tenant_id, service_ids)
+        if not dependencies:
+            return flags
+        related_service_ids = set(service_ids)
+        related_service_ids.update(dependency.service_id for dependency in dependencies)
+        group_relations = ServiceGroupRelation.objects.filter(
+            tenant_id=tenant_id, service_id__in=related_service_ids)
+        group_by_service_id = {relation.service_id: relation.group_id for relation in group_relations}
+        for dependency in dependencies:
+            dependency_group_id = group_by_service_id.get(dependency.dep_service_id)
+            source_group_id = group_by_service_id.get(dependency.service_id)
+            if dependency_group_id is not None and source_group_id is not None and dependency_group_id != source_group_id:
+                flags[dependency.dep_service_id] = True
+        return flags
+
     def get_app_resource(self, tenant_id: str, region_name: str, app_id: str) -> dict:
         # app all service info
         res: Dict[str, Any] = {}
         services_info = []
         tenant = team_repo.get_team_by_team_id(tenant_id)
-        service_ids = group_service_relation_repo.list_serivce_ids_by_app_id(tenant_id, region_name, app_id)
+        service_ids = list(group_service_relation_repo.list_serivce_ids_by_app_id(tenant_id, region_name, app_id))
         services = service_repo.get_services_by_service_ids(service_ids)
         if len(services) > 0:
             service_volume_map = self.get_service_volume_by_ids(service_ids)
+            service_status_map = self._get_app_resource_service_statuses(tenant, region_name, services)
+            service_related_map = self._get_cross_app_dependency_flags(tenant.tenant_id, service_ids)
             for service in services:
                 service_volumes = []
                 volumes = service_volume_map.get(service.service_id, None)
                 if volumes:
                     service_volumes = [volume.volume_name for volume in volumes]
-                is_related = self.is_service_related_by_other_app_service(tenant, service)
-                status = self.service_status(tenant, service)
                 service_info = {
                     "service_name": service.service_cname,
                     "volume": service_volumes,
-                    "is_related": is_related,
-                    "status": status
+                    "is_related": service_related_map.get(service.service_id, False),
+                    "status": service_status_map.get(service.service_id, False)
                 }
                 services_info.append(service_info)
         res["services_info"] = services_info

--- a/console/tests/config_service_test.py
+++ b/console/tests/config_service_test.py
@@ -63,6 +63,34 @@ class CustomFieldManager(object):
         return CustomFieldQuerySet(configs)
 
 
+class ExistingConfigManager(object):
+    def __init__(self, configs):
+        self.configs = {config.key: config for config in configs}
+        self.filter_calls = []
+        self.get_calls = []
+
+    def filter(self, **kwargs):
+        self.filter_calls.append(kwargs)
+        keys = kwargs.get("key__in", [])
+        return [self.configs[key] for key in keys if key in self.configs]
+
+    def get(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return self.configs[kwargs["key"]]
+
+
+class CreatingConfigManager(ExistingConfigManager):
+    def __init__(self):
+        super(CreatingConfigManager, self).__init__([])
+        self.create_calls = []
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        config = types.SimpleNamespace(**kwargs)
+        self.configs[config.key] = config
+        return config
+
+
 class ConfigKey(object):
     def __init__(self, name):
         self.name = name
@@ -177,3 +205,65 @@ class EnterpriseConfigServiceTests(TestCase):
                 "enable": False,
             }],
         )
+
+    def test_initialization_loads_existing_config_keys_in_one_query(self):
+        config_service = self.import_config_service_module()
+        manager = ExistingConfigManager([
+            types.SimpleNamespace(key="BASE_KEY", type="string", value="database-base", enable=False),
+            types.SimpleNamespace(key="CONFIG_KEY", type="string", value="database-config", enable=True),
+        ])
+        config_service.ConsoleSysConfig = types.SimpleNamespace(objects=manager)
+        service = config_service.ConfigService()
+        service.base_cfg_keys = ["BASE_KEY"]
+        service.base_cfg_keys_value = {
+            "BASE_KEY": {
+                "value": "default-base",
+                "desc": "base",
+                "enable": True,
+            }
+        }
+        service.cfg_keys = ["CONFIG_KEY"]
+        service.cfg_keys_value = {
+            "CONFIG_KEY": {
+                "value": "default-config",
+                "desc": "config",
+                "enable": False,
+            }
+        }
+        service.get_custom_fields = lambda: []
+
+        result = service.initialization_or_get_config
+
+        self.assertEqual(result["base_key"], {"enable": False, "value": "default-base"})
+        self.assertEqual(result["config_key"], {"enable": True, "value": "database-config"})
+        self.assertEqual(manager.filter_calls, [{"key__in": ["BASE_KEY", "CONFIG_KEY"]}])
+        self.assertEqual(manager.get_calls, [])
+
+    def test_initialization_keeps_creating_missing_config_keys(self):
+        config_service = self.import_config_service_module()
+        manager = CreatingConfigManager()
+        config_service.ConsoleSysConfig = types.SimpleNamespace(objects=manager)
+        service = config_service.ConfigService()
+        service.base_cfg_keys = ["BASE_KEY"]
+        service.base_cfg_keys_value = {
+            "BASE_KEY": {
+                "value": "default-base",
+                "desc": "base",
+                "enable": True,
+            }
+        }
+        service.cfg_keys = ["CONFIG_KEY"]
+        service.cfg_keys_value = {
+            "CONFIG_KEY": {
+                "value": "default-config",
+                "desc": "config",
+                "enable": False,
+            }
+        }
+        service.get_custom_fields = lambda: []
+
+        result = service.initialization_or_get_config
+
+        self.assertEqual(result["base_key"], {"enable": True, "value": "default-base"})
+        self.assertEqual(result["config_key"], {"enable": False, "value": "default-config"})
+        self.assertEqual([call["key"] for call in manager.create_calls], ["BASE_KEY", "CONFIG_KEY"])

--- a/console/tests/group_service_test.py
+++ b/console/tests/group_service_test.py
@@ -203,6 +203,174 @@ class GroupServiceAppDetailPodCountTests(TestCase):
         get_dynamic_pods.assert_not_called()
 
 
+class GroupServiceAppResourcePerformanceTests(TestCase):
+
+    def test_get_app_resource_batches_component_status_and_cross_app_dependencies(self):
+        tenant = Obj(tenant_id="tenant-id", tenant_name="tenant-name", enterprise_id="enterprise-id")
+        services = [
+            Obj(service_id="service-a", service_alias="alias-a", service_cname="A", service_region="rainbond",
+                create_status="complete"),
+            Obj(service_id="service-b", service_alias="alias-b", service_cname="B", service_region="rainbond",
+                create_status="complete"),
+            Obj(service_id="service-c", service_alias="alias-c", service_cname="C", service_region="rainbond",
+                create_status="creating"),
+        ]
+        dependencies = [
+            Obj(service_id="external-service", dep_service_id="service-a"),
+            Obj(service_id="service-b", dep_service_id="service-a"),
+        ]
+        group_relations = [
+            Obj(service_id="service-a", group_id=1),
+            Obj(service_id="service-b", group_id=1),
+            Obj(service_id="service-c", group_id=1),
+            Obj(service_id="external-service", group_id=2),
+        ]
+        status_list = [
+            {"service_id": "service-a", "status": "running"},
+            {"service_id": "service-b", "status": "closed"},
+        ]
+
+        with ExitStack() as stack:
+            stack.enter_context(mock.patch.object(group_service_module.team_repo,
+                                                  "get_team_by_team_id",
+                                                  return_value=tenant))
+            stack.enter_context(mock.patch.object(group_service_module.group_service_relation_repo,
+                                                  "list_serivce_ids_by_app_id",
+                                                  return_value=[service.service_id for service in services]))
+            stack.enter_context(mock.patch.object(group_service_module.service_repo,
+                                                  "get_services_by_service_ids",
+                                                  return_value=services))
+            stack.enter_context(mock.patch.object(group_service, "get_service_volume_by_ids", return_value={}))
+            get_dependencies = stack.enter_context(
+                mock.patch.object(
+                    group_service_module.dep_relation_repo,
+                    "get_dependencies_by_dep_ids",
+                    return_value=dependencies,
+                    create=True,
+                ))
+            group_filter = stack.enter_context(
+                mock.patch.object(
+                    group_service_module.ServiceGroupRelation.objects,
+                    "filter",
+                    return_value=group_relations,
+                ))
+            batch_status = stack.enter_context(
+                mock.patch.object(
+                    group_service_module.region_api,
+                    "service_status",
+                    return_value={"list": status_list},
+                ))
+            single_status = stack.enter_context(
+                mock.patch.object(
+                    group_service_module.region_api,
+                    "check_service_status",
+                    side_effect=[
+                        {"bean": {"cur_status": "running"}},
+                        {"bean": {"cur_status": "closed"}},
+                    ],
+                ))
+            stack.enter_context(mock.patch.object(group_service_module.k8s_resources_repo,
+                                                  "list_by_app_id",
+                                                  return_value=[]))
+            stack.enter_context(mock.patch.object(group_service_module.domain_repo,
+                                                  "get_domains_by_service_ids",
+                                                  return_value=[]))
+            stack.enter_context(mock.patch.object(group_service_module.app_config_group_repo,
+                                                  "list",
+                                                  return_value=[]))
+            stack.enter_context(mock.patch.object(group_service_module.share_repo,
+                                                  "get_app_share_records_by_groupid",
+                                                  return_value=[]))
+
+            result = group_service.get_app_resource("tenant-id", "rainbond", "1")
+
+        self.assertEqual(
+            result["services_info"],
+            [
+                {"service_name": "A", "volume": [], "is_related": True, "status": "running"},
+                {"service_name": "B", "volume": [], "is_related": False, "status": "closed"},
+                {"service_name": "C", "volume": [], "is_related": False, "status": False},
+            ],
+        )
+        batch_status.assert_called_once_with(
+            "rainbond",
+            "tenant-name",
+            {"service_ids": ["service-a", "service-b"], "enterprise_id": "enterprise-id"},
+        )
+        single_status.assert_not_called()
+        get_dependencies.assert_called_once_with(
+            "tenant-id", ["service-a", "service-b", "service-c"])
+        group_filter.assert_called_once_with(
+            tenant_id="tenant-id",
+            service_id__in={"service-a", "service-b", "service-c", "external-service"},
+        )
+
+    def test_app_resource_status_skips_region_when_no_component_is_complete(self):
+        tenant = Obj(tenant_name="tenant-name", enterprise_id="enterprise-id")
+        services = [Obj(service_id="service-a", create_status="creating")]
+
+        with mock.patch.object(group_service_module.region_api, "service_status") as batch_status:
+            result = group_service._get_app_resource_service_statuses(tenant, "rainbond", services)
+
+        self.assertEqual(result, {"service-a": False})
+        batch_status.assert_not_called()
+
+    def test_app_resource_status_keeps_kubeblocks_on_the_single_component_path(self):
+        tenant = Obj(tenant_name="tenant-name", enterprise_id="enterprise-id")
+        services = [
+            Obj(service_id="service-a", create_status="complete", extend_method="stateless_multiple"),
+            Obj(service_id="service-db", create_status="complete", extend_method="kubeblocks_component"),
+        ]
+
+        with mock.patch.object(group_service_module.region_api,
+                               "service_status",
+                               return_value={"list": [{"service_id": "service-a", "status": "running"}]}) as batch_status, \
+                mock.patch.object(group_service, "service_status", return_value="") as single_status:
+            result = group_service._get_app_resource_service_statuses(tenant, "rainbond", services)
+
+        self.assertEqual(result, {"service-a": "running", "service-db": ""})
+        batch_status.assert_called_once_with(
+            "rainbond",
+            "tenant-name",
+            {"service_ids": ["service-a"], "enterprise_id": "enterprise-id"},
+        )
+        single_status.assert_called_once_with(tenant, services[1])
+
+    def test_cross_app_dependency_flags_skip_group_query_when_no_component_is_referenced(self):
+        with mock.patch.object(group_service_module.dep_relation_repo,
+                               "get_dependencies_by_dep_ids",
+                               return_value=[]) as get_dependencies, mock.patch.object(
+                                   group_service_module.ServiceGroupRelation.objects, "filter") as group_filter:
+            result = group_service._get_cross_app_dependency_flags(
+                "tenant-id", ["service-a", "service-b"])
+
+        self.assertEqual(result, {"service-a": False, "service-b": False})
+        get_dependencies.assert_called_once_with("tenant-id", ["service-a", "service-b"])
+        group_filter.assert_not_called()
+
+    def test_app_resource_status_keeps_404_fallback_for_missing_region_component(self):
+        tenant = Obj(tenant_name="tenant-name", enterprise_id="enterprise-id")
+        services = [Obj(service_id="service-a", create_status="complete")]
+        error = group_service_module.region_api.CallApiError(
+            "region", "http://region/services_status", "POST", Obj(status=404), {})
+
+        with mock.patch.object(group_service_module.region_api, "service_status", side_effect=error):
+            result = group_service._get_app_resource_service_statuses(tenant, "rainbond", services)
+
+        self.assertEqual(result, {"service-a": False})
+
+    def test_app_resource_status_keeps_empty_status_fallback_for_non_404_region_errors(self):
+        tenant = Obj(tenant_name="tenant-name", enterprise_id="enterprise-id")
+        services = [Obj(service_id="service-a", create_status="complete")]
+        error = group_service_module.region_api.CallApiError(
+            "region", "http://region/services_status", "POST", Obj(status=500), {})
+
+        with mock.patch.object(group_service_module.region_api, "service_status", side_effect=error):
+            result = group_service._get_app_resource_service_statuses(tenant, "rainbond", services)
+
+        self.assertEqual(result, {"service-a": ""})
+
+
 class RegionApiPodCountTests(TestCase):
 
     def test_get_services_pod_nums_uses_lightweight_endpoint_and_short_timeout(self):

--- a/console/tests/perm_repo_performance_test.py
+++ b/console/tests/perm_repo_performance_test.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+import importlib
+import sys
+import types
+from unittest import TestCase, mock
+
+
+class DummyModel(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class PermissionQuerySet(object):
+    def __init__(self, rows, manager):
+        self.rows = rows
+        self.manager = manager
+
+    def values_list(self, *fields):
+        return list(self.rows)
+
+    def delete(self):
+        self.manager.delete_count += 1
+
+
+class PermissionManager(object):
+    def __init__(self, rows):
+        self.rows = rows
+        self.all_count = 0
+        self.delete_count = 0
+        self.bulk_create_count = 0
+
+    def all(self):
+        self.all_count += 1
+        return PermissionQuerySet(self.rows, self)
+
+    def bulk_create(self, permissions):
+        self.bulk_create_count += 1
+
+
+def install_stub(module_name, **attrs):
+    module = types.ModuleType(module_name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[module_name] = module
+
+
+class PermsRepoPerformanceTests(TestCase):
+    module_names = (
+        "console.repositories.perm_repo",
+        "console.exception.main",
+        "console.models.main",
+        "console.utils.perms",
+        "www.models.main",
+        "django.db",
+        "django.db.models",
+    )
+
+    def tearDown(self):
+        for module_name in self.module_names:
+            sys.modules.pop(module_name, None)
+
+    def import_perm_repo_module(self, metadata, stored_rows):
+        manager = PermissionManager(stored_rows)
+        perms_model = type("PermsInfo", (DummyModel,), {"objects": manager})
+        install_stub("console.exception.main", ServiceHandleException=Exception)
+        install_stub(
+            "console.models.main",
+            PermsInfo=perms_model,
+            RoleInfo=DummyModel,
+            RolePerms=DummyModel,
+            UserRole=DummyModel,
+        )
+        install_stub("console.utils.perms", get_perms_metadata=lambda: list(metadata))
+        install_stub("www.models.main", PermRelTenant=DummyModel, Users=DummyModel)
+        install_stub("django.db", transaction=types.SimpleNamespace(atomic=lambda function: function))
+        install_stub("django.db.models", Q=lambda *args, **kwargs: None, QuerySet=object)
+        module = importlib.import_module("console.repositories.perm_repo")
+        return module, manager
+
+    def test_initialization_does_not_rebuild_permissions_when_only_row_order_differs(self):
+        metadata = [
+            ("view", "View", 100, "app", "team"),
+            ("edit", "Edit", 200, "app", "team"),
+        ]
+        module, manager = self.import_perm_repo_module(metadata, list(reversed(metadata)))
+
+        module.PermsRepo().initialize_permission_settings()
+
+        self.assertEqual(manager.delete_count, 0)
+        self.assertEqual(manager.bulk_create_count, 0)
+
+    def test_successful_initialization_is_reused_within_the_process(self):
+        metadata = [("view", "View", 100, "app", "team")]
+        module, manager = self.import_perm_repo_module(metadata, metadata)
+        repo = module.PermsRepo()
+
+        repo.initialize_permission_settings()
+        repo.initialize_permission_settings()
+
+        self.assertEqual(manager.all_count, 1)
+
+    def test_changed_permissions_rebuild_once_within_the_check_interval(self):
+        metadata = [("view", "View", 100, "app", "team")]
+        stored_rows = [("old-view", "Old View", 100, "app", "team")]
+        module, manager = self.import_perm_repo_module(metadata, stored_rows)
+        repo = module.PermsRepo()
+
+        repo.initialize_permission_settings()
+        repo.initialize_permission_settings()
+
+        self.assertEqual(manager.delete_count, 1)
+        self.assertEqual(manager.bulk_create_count, 1)
+        self.assertEqual(manager.all_count, 1)
+
+    def test_first_initialization_runs_even_when_monotonic_clock_is_below_interval(self):
+        metadata = [("view", "View", 100, "app", "team")]
+        module, manager = self.import_perm_repo_module(metadata, metadata)
+
+        with mock.patch.object(module.time, "monotonic", return_value=10):
+            module.PermsRepo().initialize_permission_settings()
+
+        self.assertEqual(manager.all_count, 1)

--- a/console/views/logos.py
+++ b/console/views/logos.py
@@ -70,7 +70,8 @@ class ConfigRUDView(AlowAnyApiView):
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         code = 200
         user = request.user
-        status = perms_repo.initialize_permission_settings()
+        perms_repo.initialize_permission_settings()
+        status = None
         data = platform_config_service.initialization_or_get_config
         if data.get("enterprise_id", None) is None:
             data["enterprise_id"] = os.getenv('ENTERPRISE_ID', '')


### PR DESCRIPTION
## Summary

- batch system configuration reads and throttle repeated permission metadata checks
- batch ordinary component status and cross-application dependency lookups in the application resource endpoint
- preserve the existing single-component KubeBlocks status path and error fallbacks
- add regression tests for query counts and response compatibility

## Verification

- `pytest console/tests/config_service_test.py -q` (6 passed)
- `pytest console/tests/perm_repo_performance_test.py -q` (4 passed)
- `pytest console/tests/group_service_test.py::GroupServiceAppResourcePerformanceTests -q` (6 passed)
- `pytest console/tests/app_component_performance_test.py -q` (7 passed)
- `make typecheck-gate`
- `make test-manifest-check`
- Python compile check and `git diff --check`

Full `make check` remains blocked by pre-existing repository-wide flake8 violations; the changed lines introduce no new flake8 violations.