### PR TITLE
fix: disable performance request logging by default

### DIFF
--- a/console/tests/performance_timing_test.py
+++ b/console/tests/performance_timing_test.py
@@ -4,8 +4,7 @@ import os
 from types import SimpleNamespace
 from unittest import TestCase, mock
 
-from goodrain_web.performance import (PerformanceTimingMiddleware, get_performance_context,
-                                      record_region_call)
+from goodrain_web.performance import (PerformanceTimingMiddleware, get_performance_context, record_region_call)
 
 
 class FakeResponse(dict):
@@ -31,7 +30,10 @@ class PerformanceTimingMiddlewareTestCase(TestCase):
             META={"QUERY_STRING": "check_status=yes&token=secret"},
         )
 
-        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+        with mock.patch.dict(os.environ, {
+                "CONSOLE_PERFORMANCE_LOG_ENABLED": "true",
+                "CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500",
+        }), \
                 mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 11.25]), \
                 mock.patch("goodrain_web.performance.logger.info") as log_info:
             response = PerformanceTimingMiddleware(get_response)(request)
@@ -52,7 +54,10 @@ class PerformanceTimingMiddlewareTestCase(TestCase):
     def test_fast_request_does_not_write_performance_log(self):
         request = SimpleNamespace(method="GET", path="/console/teams", META={})
 
-        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+        with mock.patch.dict(os.environ, {
+                "CONSOLE_PERFORMANCE_LOG_ENABLED": "true",
+                "CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500",
+        }), \
                 mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
                 mock.patch("goodrain_web.performance.logger.info") as log_info:
             response = PerformanceTimingMiddleware(lambda _request: FakeResponse())(request)
@@ -67,7 +72,10 @@ class PerformanceTimingMiddlewareTestCase(TestCase):
 
         request = SimpleNamespace(method="GET", path="/console/teams", META={})
 
-        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500"}), \
+        with mock.patch.dict(os.environ, {
+                "CONSOLE_PERFORMANCE_LOG_ENABLED": "true",
+                "CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "500",
+        }), \
                 mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
                 mock.patch("goodrain_web.performance.logger.info") as log_info, \
                 self.assertRaises(RuntimeError):
@@ -80,10 +88,25 @@ class PerformanceTimingMiddlewareTestCase(TestCase):
     def test_logging_failure_does_not_break_request(self):
         request = SimpleNamespace(method="GET", path="/console/teams", META={})
 
-        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "0"}), \
+        with mock.patch.dict(os.environ, {
+                "CONSOLE_PERFORMANCE_LOG_ENABLED": "true",
+                "CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "0",
+        }), \
                 mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
                 mock.patch("goodrain_web.performance.logger.info", side_effect=RuntimeError("log unavailable")):
             response = PerformanceTimingMiddleware(lambda _request: FakeResponse())(request)
 
         self.assertEqual(response.status_code, 200)
+        self.assertIsNone(get_performance_context())
+
+    def test_performance_log_is_disabled_by_default(self):
+        request = SimpleNamespace(method="GET", path="/console/teams", META={})
+
+        with mock.patch.dict(os.environ, {"CONSOLE_SLOW_REQUEST_THRESHOLD_MS": "0"}, clear=True), \
+                mock.patch("goodrain_web.performance.time.monotonic", side_effect=[10.0, 10.1]), \
+                mock.patch("goodrain_web.performance.logger.info") as log_info:
+            response = PerformanceTimingMiddleware(lambda _request: FakeResponse())(request)
+
+        log_info.assert_not_called()
+        self.assertIn("X-Request-ID", response)
         self.assertIsNone(get_performance_context())

--- a/goodrain_web/performance.py
+++ b/goodrain_web/performance.py
@@ -33,10 +33,14 @@ def _start_performance_context():
 
 def _slow_request_threshold_ms():
     try:
-        return max(0.0, float(os.environ.get("CONSOLE_SLOW_REQUEST_THRESHOLD_MS",
-                                             DEFAULT_SLOW_REQUEST_THRESHOLD_MS)))
+        return max(0.0, float(os.environ.get("CONSOLE_SLOW_REQUEST_THRESHOLD_MS", DEFAULT_SLOW_REQUEST_THRESHOLD_MS)))
     except (TypeError, ValueError):
         return DEFAULT_SLOW_REQUEST_THRESHOLD_MS
+
+
+def _performance_logging_enabled():
+    value = os.environ.get("CONSOLE_PERFORMANCE_LOG_ENABLED", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
 
 
 def _safe_url_path(url):
@@ -83,7 +87,7 @@ class PerformanceTimingMiddleware(object):
         finally:
             try:
                 total_ms = round((time.monotonic() - started) * 1000, 3)
-                if status >= 500 or total_ms >= _slow_request_threshold_ms():
+                if _performance_logging_enabled() and (status >= 500 or total_ms >= _slow_request_threshold_ms()):
                     payload = {
                         "event": "console_request_timing",
                         "request_id": context["request_id"],


### PR DESCRIPTION
## Summary

- gate `PERF_REQUEST` emission behind `CONSOLE_PERFORMANCE_LOG_ENABLED`
- keep performance logging disabled by default and enable it with values such as `true`
- preserve request timing context, slow-request thresholds, payload fields, and `X-Request-ID`
- cover the default-disabled and explicitly-enabled behavior

## Testing

- `venv/bin/python -m pytest console/tests/performance_timing_test.py -q --cov=goodrain_web.performance --cov-report=term-missing` (5 passed, 87% coverage)
- `venv/bin/flake8 --extend-ignore=W605 --max-line-length 129 goodrain_web/performance.py console/tests/performance_timing_test.py`
- `PATH="$PWD/venv/bin:$PATH" make test-manifest-check`
- `PATH="$PWD/venv/bin:$PATH" make typecheck-gate`
- `venv/bin/python -m py_compile goodrain_web/performance.py console/tests/performance_timing_test.py`
- `git diff --check`

## Existing baseline issues

- full `make check` reports about 1490 pre-existing flake8 violations outside these files
- full `pytest -q` stops during collection with 87 pre-existing import errors from suite-wide module stubs
- `manage.py check` is blocked locally because the generated `openapi_client` package is absent