### PR TITLE
feat: proxy event logs over SSE

### DIFF
--- a/console/tests/app_event_stream_test.py
+++ b/console/tests/app_event_stream_test.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+if "openapi_client" not in sys.modules:
+    openapi_client = ModuleType("openapi_client")
+    openapi_client.ApiClient = object
+    openapi_client.MarketOpenapiApi = object
+    configuration = ModuleType("openapi_client.configuration")
+    configuration.Configuration = type("Configuration", (), {})
+    rest = ModuleType("openapi_client.rest")
+    rest.ApiException = type("ApiException", (Exception, ), {})
+    sys.modules["openapi_client"] = openapi_client
+    sys.modules["openapi_client.configuration"] = configuration
+    sys.modules["openapi_client.rest"] = rest
+
+from django.http import StreamingHttpResponse  # noqa: E402
+from django.test import RequestFactory, SimpleTestCase  # noqa: E402
+from django.urls import resolve  # noqa: E402
+
+from console.utils import perms_route_config as perms  # noqa: E402
+
+
+class AppEventLogStreamViewTests(SimpleTestCase):
+    def test_get_uses_component_region_and_fixed_upstream_path(self):
+        from console.views import app_event
+
+        view = app_event.AppEventLogStreamView()
+        view.service = SimpleNamespace(service_region="component-region")
+        request = RequestFactory().get("/console/ignored?region_name=caller-region&path=/arbitrary")
+        upstream_response = StreamingHttpResponse(iter(["data: {}\n\n"]), content_type="text/event-stream")
+
+        with mock.patch.object(app_event.region_api, "sse_proxy", return_value=upstream_response) as sse_proxy:
+            response = view.get(request, eventId="event-1")
+
+        sse_proxy.assert_called_once_with("component-region", "/v2/events/event-1/stream")
+        self.assertIs(response, upstream_response)
+
+    def test_route_is_component_scoped_and_requires_overview_permission(self):
+        from console.views.app_event import AppEventLogStreamView
+
+        match = resolve("/console/teams/demo-team/apps/demo-service/events/event-1/stream")
+
+        self.assertIs(match.func.view_class, AppEventLogStreamView)
+        self.assertEqual(match.kwargs["tenantName"], "demo-team")
+        self.assertEqual(match.kwargs["serviceAlias"], "demo-service")
+        self.assertEqual(match.kwargs["eventId"], "event-1")
+        self.assertEqual(match.kwargs["__message"], perms.APP_OVERVIEW_PERMS["__message"])
+
+    def test_route_rejects_unauthenticated_requests(self):
+        path = "/console/teams/demo-team/apps/demo-service/events/event-1/stream"
+        match = resolve(path)
+
+        response = match.func(RequestFactory().get(path), **match.kwargs)
+
+        self.assertEqual(response.status_code, 401)

--- a/console/urls/__init__.py
+++ b/console/urls/__init__.py
@@ -49,8 +49,8 @@ from console.views.app_create.source_outer import (ThirdPartyAppPodsView, ThirdP
                                                    ThirdPartyServiceCreateView, ThirdPartyUpdateSecretKeyView)
 from console.views.app_create.vm_run import VMRunCreateView
 from console.views.app_create.kubeblocks_create import KubeBlocksComponentCreateView
-from console.views.app_event import (AppEventLogView, AppEventsLogView, AppEventsView, AppEventView, AppHistoryLogView,
-                                     AppLogInstanceView, AppLogView)
+from console.views.app_event import (AppEventLogStreamView, AppEventLogView, AppEventsLogView, AppEventsView, AppEventView,
+                                     AppHistoryLogView, AppLogInstanceView, AppLogView)
 from console.views.app_manage import (AgainDelete, BatchActionView, BatchDelete, ChangeServiceNameView, ChangeServiceTypeView,
                                       ChangeServiceUpgradeView, DeleteAppView, DeployAppView, HorizontalExtendAppView,
                                       MarketServiceUpgradeView, ReStartAppView, RollBackAppView, StartAppView, StopAppView,
@@ -749,6 +749,8 @@ urlpatterns = [
         perms.APP_OVERVIEW_PERMS),
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/apps/(?P<serviceAlias>[\w\-]+)/event_log$', AppEventLogView.as_view(),
         perms.APP_OVERVIEW_PERMS),
+    re_path(r'^teams/(?P<tenantName>[\w\-]+)/apps/(?P<serviceAlias>[\w\-]+)/events/(?P<eventId>[\w\-]+)/stream$',
+        AppEventLogStreamView.as_view(), perms.APP_OVERVIEW_PERMS),
     # 某个组件的日志
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/apps/(?P<serviceAlias>[\w\-]+)/log$', AppLogView.as_view()),
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/apps/(?P<serviceAlias>[\w\-]+)/log_instance$', AppLogInstanceView.as_view()),

--- a/console/views/app_event.py
+++ b/console/views/app_event.py
@@ -15,10 +15,12 @@ from console.views.app_config.base import AppBaseView
 from console.views.base import RegionTenantHeaderView
 from console.utils.cache_decorators import never_cache
 from rest_framework.response import Response
+from www.apiclient.regionapi import RegionInvokeApi
 from www.models.main import TenantServiceInfo
 from www.utils.return_message import error_message, general_message
 
 logger = logging.getLogger("default")
+region_api = RegionInvokeApi()
 
 
 class AppEventView(AppBaseView):
@@ -115,6 +117,14 @@ class AppEventLogView(AppBaseView):
         log_list = event_service.get_service_event_log(self.tenant, self.service, level, event_id)
         result = general_message(200, "success", "查询成功", list=log_list)
         return Response(result, status=result["code"])
+
+
+class AppEventLogStreamView(AppBaseView):
+    @never_cache
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Any:
+        event_id = kwargs["eventId"]
+        path = "/v2/events/{0}/stream".format(event_id)
+        return region_api.sse_proxy(self.service.service_region, path)
 
 
 class AppLogView(AppBaseView):


### PR DESCRIPTION
## Summary
- add an authenticated component-scoped event-log SSE route
- enforce AppBaseView context and APP_OVERVIEW_PERMS before opening the stream
- proxy only the fixed region endpoint selected from the resolved component region
- reuse the existing streaming proxy transport without exposing the unauthenticated generic SSE route

## Dependencies
- goodrain/rainbond#2678

## Consumer
- goodrain/rainbond-ui#1903

## Verification
- pytest -q console/tests/app_event_stream_test.py console/tests/regionapi_sse_proxy_test.py (7 passed)
- Python syntax and targeted static checks passed
- git diff --check passed

## Existing baseline
The repository-wide make check currently reports 1489 pre-existing flake8 errors on origin/main. This PR keeps a minimal three-file diff; its targeted tests and changed-code review pass.