### PR TITLE
fix: allow local app upgrades in offline mode

### DIFF
--- a/console/services/market_app_service.py
+++ b/console/services/market_app_service.py
@@ -1617,6 +1617,8 @@ class MarketAppService(object):
             market_name = component_source.get_market_name()
             market = None
             install_from_cloud = component_source.is_install_from_cloud()
+            if install_from_cloud and is_cloud_market_disabled():
+                return []
             if install_from_cloud and market_name:
                 market = app_market_repo.get_app_market_by_name(
                     tenant.enterprise_id, market_name, raise_exception=True)  # type: ignore[arg-type]
@@ -1828,7 +1830,7 @@ class MarketAppService(object):
                     component_source = source
             market_name = component_source.get_market_name()
             install_from_cloud = component_source.is_install_from_cloud()
-            if install_from_cloud and market_name:
+            if install_from_cloud and market_name and not is_cloud_market_disabled():
                 market = app_market_repo.get_app_market_by_name(enterprise_id, market_name, raise_exception=True)
         return current_version, component_source.get_template_update_time(), install_from_cloud, market
 
@@ -1845,6 +1847,8 @@ class MarketAppService(object):
         component_group = ComponentGroup(enterprise_id, component_group, record.old_version)
         app_template_source = component_group.app_template_source()
         install_from_cloud = component_group.is_install_from_cloud()
+        if install_from_cloud and is_cloud_market_disabled():
+            return []
         market = None
         if install_from_cloud:
             market_name = app_template_source.get_market_name()

--- a/console/services/upgrade_services.py
+++ b/console/services/upgrade_services.py
@@ -34,6 +34,7 @@ from console.services.market_app.app_restore import AppRestore
 # market app
 from console.services.market_app.app_upgrade import AppUpgrade
 from console.services.market_app.component_group import ComponentGroup
+from console.utils.offline import is_cloud_market_disabled
 from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Q
@@ -196,6 +197,8 @@ class UpgradeService(object):
         component_group = tenant_service_group_repo.get_component_group(upgrade_group_id)
 
         app_template_source = self._app_template_source(app.app_id, component_group.group_key, upgrade_group_id)
+        if app_template_source.is_install_from_cloud() and is_cloud_market_disabled():
+            return {"upgrade_info": {}}, []
         app_template = self._app_template(user.enterprise_id, component_group.group_key, version, app_template_source)
 
         app_upgrade = AppUpgrade(user.enterprise_id, tenant, region, user, app, version, component_group, app_template,

--- a/console/tests/app_upgrade_offline_test.py
+++ b/console/tests/app_upgrade_offline_test.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+import collections
+import os
+import sys
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import patch
+
+for attr in ("Mapping", "MutableMapping", "Sequence", "Iterable", "Iterator"):
+    if not hasattr(collections, attr):
+        setattr(collections, attr, getattr(collections.abc, attr))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "openapi-client")))
+sys.modules.setdefault("MySQLdb", ModuleType("MySQLdb"))
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _DummyConfiguration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    class _DummyApiException(Exception):
+        status = 500
+        body = ""
+
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    configuration_module.Configuration = _DummyConfiguration
+    rest_module.ApiException = _DummyApiException
+
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "goodrain_web.settings")
+
+import django  # noqa: E402
+from django.test import RequestFactory  # noqa: E402
+
+django.setup()
+
+from console.services.upgrade_services import UpgradeService  # noqa: E402
+from console.views import app_upgrade as app_upgrade_view  # noqa: E402
+
+
+class Obj(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class AppUpgradeOfflineTests(TestCase):
+    # capability_id: console.app-upgrade.local-offline-detail
+    def test_offline_upgrade_info_view_calculates_local_details(self):
+        view = app_upgrade_view.AppUpgradeInfoView()
+        view.tenant = Obj(tenant_id="tenant-1")
+        view.region = Obj(region_name="rainbond")
+        view.user = Obj(enterprise_id="enterprise-1")
+        view.app = Obj(app_id="app-1")
+        app_changes = {"upgrade_info": {"snapshot-template": {"version": "1.0.3"}}}
+        changes = [{"type": "env", "name": "LOG_LEVEL"}]
+
+        with patch.dict(os.environ, {
+            "DISABLE_DEFAULT_APP_MARKET": "true",
+            "DISABLE_CLOUD_MARKET": "",
+        }, clear=False), \
+                patch.object(app_upgrade_view.upgrade_service, "get_property_changes",
+                             return_value=(app_changes, changes)) as get_property_changes:
+            response = view.get(RequestFactory().get("/upgrade-info", {
+                "upgrade_group_id": 7,
+                "version": "1.0.3",
+            }), "app-1")
+
+        get_property_changes.assert_called_once_with(view.tenant, view.region, view.user, view.app, 7, "1.0.3")
+        self.assertEqual(app_changes, response.data["data"]["bean"])
+        self.assertEqual(changes, response.data["data"]["list"])
+
+    # capability_id: console.app-upgrade.remote-offline-market-guard
+    def test_remote_upgrade_details_skip_market_lookup_when_offline(self):
+        service = UpgradeService()
+        component_group = Obj(group_key="cloud-template")
+        source = Obj(
+            is_install_from_cloud=lambda: True,
+            get_market_name=lambda: "goodrain",
+        )
+        tenant = Obj(enterprise_id="enterprise-1")
+        region = Obj(region_name="rainbond")
+        user = Obj(enterprise_id="enterprise-1")
+        app = Obj(app_id="app-1")
+
+        with patch("console.services.upgrade_services.tenant_service_group_repo.get_component_group",
+                   return_value=component_group), \
+                patch.object(service, "_app_template_source", return_value=source), \
+                patch.object(service, "_app_template") as app_template, \
+                patch("console.services.upgrade_services.AppUpgrade") as app_upgrade, \
+                patch("console.services.upgrade_services.is_cloud_market_disabled",
+                      return_value=True, create=True):
+            result = service.get_property_changes(tenant, region, user, app, "7", "1.0.3")
+
+        self.assertEqual(({"upgrade_info": {}}, []), result)
+        app_template.assert_not_called()
+        app_upgrade.assert_not_called()
+
+    def test_local_upgrade_details_still_load_template_when_offline(self):
+        service = UpgradeService()
+        component_group = Obj(group_key="snapshot-template")
+        source = Obj(
+            is_install_from_cloud=lambda: False,
+            get_market_name=lambda: None,
+        )
+        tenant = Obj(enterprise_id="enterprise-1")
+        region = Obj(region_name="rainbond")
+        user = Obj(enterprise_id="enterprise-1")
+        app = Obj(app_id="app-1")
+        app_template = {"apps": []}
+        app_upgrade_result = Obj(
+            app_property_changes={"upgrade_info": {
+                "snapshot-template": {}
+            }},
+            changes=lambda: [{
+                "type": "port"
+            }],
+        )
+
+        with patch("console.services.upgrade_services.tenant_service_group_repo.get_component_group",
+                   return_value=component_group), \
+                patch.object(service, "_app_template_source", return_value=source), \
+                patch.object(service, "_app_template", return_value=app_template) as load_template, \
+                patch("console.services.upgrade_services.AppUpgrade", return_value=app_upgrade_result) as app_upgrade, \
+                patch("console.services.upgrade_services.is_cloud_market_disabled",
+                      return_value=True, create=True):
+            result = service.get_property_changes(tenant, region, user, app, "7", "1.0.3")
+
+        load_template.assert_called_once_with("enterprise-1", "snapshot-template", "1.0.3", source)
+        app_upgrade.assert_called_once()
+        self.assertEqual((app_upgrade_result.app_property_changes, [{"type": "port"}]), result)

--- a/console/tests/market_app_service_test.py
+++ b/console/tests/market_app_service_test.py
@@ -431,8 +431,14 @@ class MarketAppServicePlatformPluginPreflightTests(SimpleTestCase):
         get_license_status.assert_not_called()
         self.assertIs(non_platform_market, cloud_conversion.call_args[0][0])
         self.assertEqual(self.preflight, result)
-# capability_id: console.market-app.local-snapshot-offline-upgrade
+
+
 class MarketAppServiceOfflineUpgradeTests(SimpleTestCase):
+    class SourceCollection(list):
+        def filter(self, *args, **kwargs):
+            return self
+
+    # capability_id: console.market-app.local-snapshot-offline-upgrade
     def test_local_snapshot_offline_upgrade_is_detected(self):
         from console.services.market_app_service import market_app_service
 
@@ -484,6 +490,105 @@ class MarketAppServiceOfflineUpgradeTests(SimpleTestCase):
         self.assertEqual("1.0.2", result[0]["current_version"])
         self.assertTrue(result[0]["can_upgrade"])
         self.assertIn("1.0.3", result[0]["upgrade_versions"])
+
+    # capability_id: console.market-app.local-snapshot-offline-upgrade
+    def test_local_snapshot_versions_still_use_local_repository_when_offline(self):
+        from console.services.market_app_service import market_app_service
+
+        installed_at = datetime.datetime(2026, 8, 14, 9, 0, 0)
+        tenant = Obj(enterprise_id="enterprise-1")
+        service = Obj(tenant_id="tenant-1", service_id="service-1")
+        component_source = Obj(
+            group_key="snapshot-template-1",
+            version="1.0.2",
+            get_market_name=lambda: None,
+            is_install_from_cloud=lambda: False,
+            get_template_update_time=lambda: installed_at,
+        )
+        local_upgrade_version = Obj(version="1.0.3", update_time=installed_at)
+
+        with patch("console.services.market_app_service.is_cloud_market_disabled", return_value=True), \
+                patch("console.services.market_app_service.service_source_repo.get_service_source",
+                      return_value=component_source), \
+                patch("console.services.market_app_service.rainbond_app_repo.get_rainbond_app_versions",
+                      return_value=[local_upgrade_version]) as get_local_versions, \
+                patch("console.services.market_app_service.app_market_repo.get_app_market_by_name") as get_market:
+            result = market_app_service.list_upgradeable_versions(tenant, service)
+
+        self.assertEqual(["1.0.3"], result)
+        get_local_versions.assert_called_once_with("snapshot-template-1")
+        get_market.assert_not_called()
+
+    # capability_id: console.app-upgrade.remote-offline-market-guard
+    def test_remote_component_versions_skip_market_lookup_when_offline(self):
+        from console.services.market_app_service import market_app_service
+
+        tenant = Obj(enterprise_id="enterprise-1")
+        service = Obj(tenant_id="tenant-1", service_id="service-1")
+        component_source = Obj(
+            group_key="cloud-template-1",
+            version="1.0.2",
+            get_market_name=lambda: "goodrain",
+            is_install_from_cloud=lambda: True,
+            get_template_update_time=lambda: None,
+        )
+
+        with patch("console.services.market_app_service.is_cloud_market_disabled", return_value=True), \
+                patch("console.services.market_app_service.service_source_repo.get_service_source",
+                      return_value=component_source), \
+                patch("console.services.market_app_service.app_market_repo.get_app_market_by_name") as get_market:
+            result = market_app_service.list_upgradeable_versions(tenant, service)
+
+        self.assertEqual([], result)
+        get_market.assert_not_called()
+
+    # capability_id: console.app-upgrade.remote-offline-market-guard
+    def test_remote_model_versions_skip_market_lookup_when_offline(self):
+        from console.services.market_app_service import market_app_service
+
+        component_source = Obj(
+            group_key="cloud-template-1",
+            version="1.0.2",
+            get_market_name=lambda: "goodrain",
+            is_install_from_cloud=lambda: True,
+            get_template_update_time=lambda: None,
+        )
+        sources = self.SourceCollection([component_source])
+
+        with patch("console.services.market_app_service.is_cloud_market_disabled", return_value=True), \
+                patch("console.services.market_app_service.group_service.get_component_and_resource_by_group_ids",
+                      return_value=([], sources)), \
+                patch("console.services.market_app_service.app_market_repo.get_app_market_by_name") as get_market:
+            result = market_app_service.get_models_upgradeable_version(
+                "enterprise-1", "cloud-template-1", "app-1", "7")
+
+        self.assertEqual([], result)
+        get_market.assert_not_called()
+
+    # capability_id: console.app-upgrade.remote-offline-market-guard
+    def test_remote_record_versions_skip_market_lookup_when_offline(self):
+        from console.services.market_app_service import market_app_service
+
+        source = Obj(
+            get_market_name=lambda: "goodrain",
+            get_template_update_time=lambda: None,
+        )
+        component_group = Obj(
+            app_model_key="cloud-template-1",
+            version="1.0.2",
+            app_template_source=lambda: source,
+            is_install_from_cloud=lambda: True,
+        )
+        record = Obj(upgrade_group_id=7, old_version="1.0.2")
+
+        with patch("console.services.market_app_service.is_cloud_market_disabled", return_value=True), \
+                patch("console.services.market_app_service.tenant_service_group_repo.get_component_group"), \
+                patch("console.services.market_app_service.ComponentGroup", return_value=component_group), \
+                patch("console.services.market_app_service.app_market_repo.get_app_market_by_name") as get_market:
+            result = market_app_service.list_app_upgradeable_versions("enterprise-1", record)
+
+        self.assertEqual([], result)
+        get_market.assert_not_called()
 
 
 class MarketAppServiceResourceLimitTests(UnitTestCase):

--- a/console/views/app_upgrade.py
+++ b/console/views/app_upgrade.py
@@ -16,7 +16,6 @@ from console.services.group_service import group_service
 from console.services.market_app_service import market_app_service
 from console.services.telemetry import telemetry_service
 from console.services.upgrade_services import upgrade_service
-from console.utils.offline import is_cloud_market_disabled
 from console.utils.reqparse import parse_argument, parse_item
 from console.utils.response import MessageResponse
 from console.views.base import ApplicationView, RegionTenantHeaderView, AppUpgradeRecordView
@@ -100,8 +99,6 @@ class AppUpgradeInfoView(ApplicationView):
         upgrade_group_id = parse_argument(
             request, 'upgrade_group_id', default=None, value_type=int, error='upgrade_group_id is a required parameter')
         version = parse_argument(request, 'version', value_type=str, required=True, error='version is a required parameter')
-        if is_cloud_market_disabled():
-            return MessageResponse(msg="success", bean={"upgrade_info": {}}, list=[])
         app_changes, changes = upgrade_service.get_property_changes(self.tenant, self.region, self.user, self.app,
                                                                     upgrade_group_id, version)
         return MessageResponse(msg="success", bean=app_changes, list=changes)

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -3,26 +3,6 @@
   "repo": "rainbond-console",
   "capabilities": [
     {
-      "id": "console.app-create.available-resources",
-      "title": "Get available cluster resources for component configuration",
-      "title_zh": "获取组件配置可用集群资源",
-      "interface_type": "view_endpoint",
-      "interface": "console.views.app_create.available_resources.AvailableResourcesView.get",
-      "code_paths": [
-        "console/services/available_resources_service.py",
-        "console/views/app_create/available_resources.py",
-        "console/urls/__init__.py"
-      ],
-      "tests": [
-        {
-          "path": "console/tests/available_resources_test.py",
-          "selector": "AvailableResourcesServiceTests,AvailableResourcesViewTests"
-        }
-      ],
-      "test_type": "regression",
-      "status": "active"
-    },
-    {
       "id": "console.app-backup.create",
       "title": "Create application backup",
       "title_zh": "创建应用备份",
@@ -823,6 +803,26 @@
         {
           "path": "console/tests/app_config_volume_service_import_test.py",
           "selector": "AppConfigVolumeServiceImportTests.test_volume_service_module_exports_package_singleton"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app-create.available-resources",
+      "title": "Get available cluster resources for component configuration",
+      "title_zh": "获取组件配置可用集群资源",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_create.available_resources.AvailableResourcesView.get",
+      "code_paths": [
+        "console/services/available_resources_service.py",
+        "console/views/app_create/available_resources.py",
+        "console/urls/__init__.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/available_resources_test.py",
+          "selector": "AvailableResourcesServiceTests,AvailableResourcesViewTests"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1862,6 +1862,25 @@
       "status": "active"
     },
     {
+      "id": "console.app-upgrade.local-offline-detail",
+      "title": "Show local application upgrade details in offline mode",
+      "title_zh": "离线模式展示本地应用升级详情",
+      "interface_type": "view_endpoint",
+      "interface": "console.views.app_upgrade.AppUpgradeInfoView.get",
+      "code_paths": [
+        "console/views/app_upgrade.py",
+        "console/services/upgrade_services.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_upgrade_offline_test.py",
+          "selector": "AppUpgradeOfflineTests::test_offline_upgrade_info_view_calculates_local_details"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.app-upgrade.openapi-upgrade-group-id",
       "title": "OpenAPI upgrade passes upgrade_group_id to record creation",
       "title_zh": "OpenAPI 升级向记录创建传递 upgrade_group_id",
@@ -1928,6 +1947,37 @@
         {
           "path": "console/tests/mcp_query_service_test.py",
           "selector": "MCPQueryServiceApplicationToolTests.test_query_app_upgrade_records_returns_paginated_items"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "console.app-upgrade.remote-offline-market-guard",
+      "title": "Block remote application market access in offline upgrade flows",
+      "title_zh": "离线升级流程阻断远程应用市场访问",
+      "interface_type": "service_method",
+      "interface": "console.services.upgrade_services.UpgradeService.get_property_changes",
+      "code_paths": [
+        "console/services/upgrade_services.py",
+        "console/services/market_app_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/app_upgrade_offline_test.py",
+          "selector": "AppUpgradeOfflineTests::test_remote_upgrade_details_skip_market_lookup_when_offline"
+        },
+        {
+          "path": "console/tests/market_app_service_test.py",
+          "selector": "MarketAppServiceOfflineUpgradeTests::test_remote_component_versions_skip_market_lookup_when_offline"
+        },
+        {
+          "path": "console/tests/market_app_service_test.py",
+          "selector": "MarketAppServiceOfflineUpgradeTests::test_remote_model_versions_skip_market_lookup_when_offline"
+        },
+        {
+          "path": "console/tests/market_app_service_test.py",
+          "selector": "MarketAppServiceOfflineUpgradeTests::test_remote_record_versions_skip_market_lookup_when_offline"
         }
       ],
       "test_type": "regression",
@@ -6866,7 +6916,11 @@
       "tests": [
         {
           "path": "console/tests/market_app_service_test.py",
-          "selector": "MarketAppServiceOfflineUpgradeTests"
+          "selector": "MarketAppServiceOfflineUpgradeTests::test_local_snapshot_offline_upgrade_is_detected"
+        },
+        {
+          "path": "console/tests/market_app_service_test.py",
+          "selector": "MarketAppServiceOfflineUpgradeTests::test_local_snapshot_versions_still_use_local_repository_when_offline"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -48,6 +48,7 @@
 | console.app-config-group.list | 查询应用配置组列表 | active | regression | console.services.app_config_group.AppConfigGroupService.list_config_groups | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_list_config_groups_returns_items_and_total |
 | console.app-config-group.update | 更新应用配置组 | active | regression | console.services.app_config_group.AppConfigGroupService.update_config_group | console/tests/app_config_group_service_test.py::AppConfigGroupServiceWorkflowTests.test_update_config_group_updates_remote_and_local_records |
 | console.app-config.volume-service-module-export | 应用配置存储服务模块导出 | active | regression | console.services.app_config.volume_service.volume_service | console/tests/app_config_volume_service_import_test.py::AppConfigVolumeServiceImportTests.test_volume_service_module_exports_package_singleton |
+| console.app-create.available-resources | 获取组件配置可用集群资源 | active | regression | console.views.app_create.available_resources.AvailableResourcesView.get | console/tests/available_resources_test.py::AvailableResourcesServiceTests,AvailableResourcesViewTests |
 | console.app-creator.full-permissions | App creator full permissions | active | regression | console.services.perm_services.UserKindPermService.get_user_perms | console/tests/perm_services_test.py |
 | console.app-export.query-status | 查询应用导出状态 | active | regression | console.services.app_import_and_export_service.AppExportService.get_export_status | console/tests/app_import_and_export_service_test.py::AppExportServiceMetadataTestCase.test_get_export_status_updates_exporting_record_and_wraps_download_url |
 | console.app-import.abandon | 放弃应用导入 | active | regression | console.views.center_pool.app_import.CenterAppImportView.delete | console/tests/app_import_and_export_service_test.py::CenterAppImportViewWorkflowTestCase.test_delete_abandons_import |
@@ -277,7 +278,6 @@
 | console.deploy-diagnostics.offline-mode | 离线模式禁用部署诊断上报 | active | regression | console.services.enterprise_first_deploy_service.EnterpriseFirstDeployService | console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_start_report_sweeper<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_online_mode_starts_report_sweeper<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_skips_report_request<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_create_deploy_tracking<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_persist_source_check_failure<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_marks_first_deploy_report_handled_without_thread<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_removes_unreported_deploy_attempt<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_forgets_unpersisted_report |
 | console.deploy-diagnostics.source-check | 源码构建源检测失败诊断埋点 | active | regression | console.views.app_create.app_check.AppCheck.get | console/tests/app_check_view_test.py::AppCheckSourceDiagnosticTests.test_get_reports_source_check_failure_without_changing_response<br>console/tests/source_component_service_test.py::SourceComponentServiceTests.test_auto_create_component_raises_on_check_failure<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_report_source_check_failure_sends_pre_deploy_diagnostic |
 | console.deploy-diagnostics.v3 | 部署失败 v3 诊断埋点 | active | regression | console.services.enterprise_first_deploy_service.EnterpriseFirstDeployService | console/tests/enterprise_first_deploy_service_test.py<br>console/tests/app_build_first_deploy_test.py::AppBuildFirstDeployTrackingTests.test_app_build_tracks_source_image_and_package_deploy_types<br>console/tests/market_app_first_deploy_test.py::MarketAppFirstDeployTrackingTests.test_install_app_reports_first_deploy_tracking_for_market_install<br>console/tests/compose_check_first_deploy_test.py<br>console/tests/compose_build_first_deploy_test.py::ComposeBuildFirstDeployTrackingTests.test_compose_build_tracks_first_deploy_and_binds_all_component_events<br>console/tests/auto_create_first_deploy_tracking_test.py<br>console/tests/platform_plugin_first_deploy_test.py::PlatformPluginFirstDeployTrackingTests.test_install_platform_plugin_reports_first_deploy_tracking |
-| console.deploy-preflight.permission-scope | 部署预检权限范围 | active | regression | console.views.app_create.deploy_preflight.DeployPreflightView | console/tests/deploy_preflight_service_test.py::DeployPreflightServiceTests |
 | console.endpoint-address.reject-invalid-format | 拒绝既不是 IP 也不是域名的非法端点地址 | active | regression | console.utils.validation.validate_endpoint_address | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoint_address_rejects_invalid_format |
 | console.endpoint-address.reject-special-ranges | 拒绝 unspecified 和 loopback 的端点地址 | active | regression | console.utils.validation.validate_endpoint_address | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoint_address_rejects_special_ranges |
 | console.endpoint-list.normalize-scheme-port | 在多端点校验前规范化协议和端口 | active | regression | console.utils.validation.validate_endpoints_info | console/tests/utils/validation_test.py::EndpointValidationTests.test_validate_endpoints_info_normalizes_scheme_and_port |
@@ -494,6 +494,7 @@
 | console.rke2.cluster-install-structured-helm-error | Rainbond 安装失败时返回结构化错误且不进入集成中状态 | active | regression | console.views.rke2.ClusterRKEInstallRB.post | console/tests/rke2_cluster_errors_test.py::ClusterRKEErrorTests.test_cluster_install_returns_structured_helm_error_without_saving_integrating |
 | console.rke2.cluster-missing-metadata-404 | 请求的 RKE 集群元数据缺失时返回 404 | active | regression | console.views.rke2.ClusterRKE.get | console/tests/rke2_cluster_errors_test.py::ClusterRKEErrorTests.test_cluster_get_returns_structured_404_when_cluster_metadata_missing |
 | console.rke2.helm-subprocess-error-sanitized | 清洗 Rainbond 安装中的 Helm 子进程失败信息 | active | regression | console.utils.k8s_cli.K8sClient.install_rainbond | console/tests/rke2_cluster_errors_test.py::ClusterRKEErrorTests.test_install_rainbond_returns_sanitized_subprocess_error |
+| console.service-share.cnb-publish-command | 发布组件模板时清理 CNB 源码启动命令 | active | regression | console.services.share_services.ShareService.query_share_service_info | console/tests/service_share_test.py::ShareServiceCNBPublishCommandTestCase |
 | console.service-share.create-record | 创建组件共享记录 | active | regression | console.views.service_share.ServiceShareRecordView.post | console/tests/service_share_test.py::ServiceShareRecordViewTestCase |
 | console.service-share.create-snapshot-record | 创建基于快照的服务分享记录 | active | regression | console.views.service_share.ServiceShareRecordView.post | console/tests/service_share_test.py::ServiceShareRecordViewTestCase.test_post_snapshot_mode_uses_hidden_template_app_id |
 | console.service-share.error-response | 服务分享异常时返回错误响应 | active | regression | console.views.service_share.ServiceShareRecordView.post | console/tests/service_share_test.py::ServiceShareRecordViewTestCase.test_post_returns_500_response_for_unexpected_exception |
@@ -551,6 +552,7 @@
 | console.vm-overview.vnc-url-plugin-fallback | 在缺少查询参数时从插件回填虚拟机概览 VNC 地址 | active | regression | console.views.app_overview.AppDetailView.get | console/tests/vm_detail_view_test.py::AppVMDetailViewTests.test_get_builds_vm_vnc_url_from_plugin_fallback_when_query_param_missing |
 | console.vm-profile.template-root-disk-fallback | VM profile falls back to template root disk metadata | active | regression | console.services.virtual_machine.VirtualMachineService.get_vm_profile | console/tests/virtual_machine_service_test.py::VirtualMachineServiceTests.test_get_vm_profile_falls_back_to_template_root_disk_metadata_when_asset_missing |
 | console.vm-root-disk-selected-storage-type | update_check_app 为新建虚拟机根盘使用所选存储类型 | active | regression | console.services.app.AppService.update_check_app | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk |
+| console.vm-run.new-asset-image-name-validation | 校验新建虚拟机镜像资产名称 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_rejects_invalid_image_name_before_new_asset_or_component_creation<br>console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_rejects_non_string_image_name_and_import_sources<br>console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_runtime_image_name_validator_enforces_oci_tag_boundaries |
 | console.vm-run.platform-runtime-guard | 虚拟机平台异常时禁止创建虚拟机组件 | active | regression | console.views.app_create.vm_run.VMRunCreateView.post | console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_create_rejects_when_vm_plugin_not_running |
 | console.vm-storage-any-access-mode | 允许虚拟机使用任意访问模式的存储 | active | regression | console.services.app_config.volume_service.AppVolumeService.build_vm_live_migration_volume_settings | console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests |
 | console.vm-template-import.delete-abnormal-vm | delete 允许异常状态虚拟机跳过运行中校验 | active | regression | console.services.app_actions.app_manage.AppManageService.delete | console/tests/app_manage_test.py::AppManageVMRestoreDeleteTests.test_delete_allows_abnormal_vm_to_skip_running_guard |
@@ -1017,6 +1019,16 @@
 - 业务入口: `console.services.app_config.volume_service.volume_service`
 - 代码路径: `console/services/app_config/volume_service.py`, `console/services/app_config/__init__.py`
 - 测试路径: `console/tests/app_config_volume_service_import_test.py::AppConfigVolumeServiceImportTests.test_volume_service_module_exports_package_singleton`
+
+### 获取组件配置可用集群资源
+
+- Capability ID: `console.app-create.available-resources`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.app_create.available_resources.AvailableResourcesView.get`
+- 代码路径: `console/services/available_resources_service.py`, `console/views/app_create/available_resources.py`, `console/urls/__init__.py`
+- 测试路径: `console/tests/available_resources_test.py::AvailableResourcesServiceTests,AvailableResourcesViewTests`
 
 ### App creator full permissions
 
@@ -3308,16 +3320,6 @@
 - 代码路径: `console/services/enterprise_first_deploy_service.py`, `console/repositories/first_deploy_repo.py`, `console/views/app_create/app_build.py`, `console/views/app_manage.py`, `console/services/market_app_service.py`, `console/services/platform_plugin_service.py`, `console/services/source_component_service.py`, `console/services/package_component_service.py`
 - 测试路径: `console/tests/enterprise_first_deploy_service_test.py`, `console/tests/app_build_first_deploy_test.py::AppBuildFirstDeployTrackingTests.test_app_build_tracks_source_image_and_package_deploy_types`, `console/tests/market_app_first_deploy_test.py::MarketAppFirstDeployTrackingTests.test_install_app_reports_first_deploy_tracking_for_market_install`, `console/tests/compose_check_first_deploy_test.py`, `console/tests/compose_build_first_deploy_test.py::ComposeBuildFirstDeployTrackingTests.test_compose_build_tracks_first_deploy_and_binds_all_component_events`, `console/tests/auto_create_first_deploy_tracking_test.py`, `console/tests/platform_plugin_first_deploy_test.py::PlatformPluginFirstDeployTrackingTests.test_install_platform_plugin_reports_first_deploy_tracking`
 
-### 部署预检权限范围
-
-- Capability ID: `console.deploy-preflight.permission-scope`
-- 状态: `active`
-- 测试类型: `regression`
-- 接口类型: `view_endpoint`
-- 业务入口: `console.views.app_create.deploy_preflight.DeployPreflightView`
-- 代码路径: `console/views/app_create/deploy_preflight.py`
-- 测试路径: `console/tests/deploy_preflight_service_test.py::DeployPreflightServiceTests`
-
 ### 拒绝既不是 IP 也不是域名的非法端点地址
 
 - Capability ID: `console.endpoint-address.reject-invalid-format`
@@ -5478,6 +5480,16 @@
 - 代码路径: `console/utils/k8s_cli.py`
 - 测试路径: `console/tests/rke2_cluster_errors_test.py::ClusterRKEErrorTests.test_install_rainbond_returns_sanitized_subprocess_error`
 
+### 发布组件模板时清理 CNB 源码启动命令
+
+- Capability ID: `console.service-share.cnb-publish-command`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.share_services.ShareService.query_share_service_info`
+- 代码路径: `console/services/share_services.py`
+- 测试路径: `console/tests/service_share_test.py::ShareServiceCNBPublishCommandTestCase`
+
 ### 创建组件共享记录
 
 - Capability ID: `console.service-share.create-record`
@@ -6047,6 +6059,16 @@
 - 业务入口: `console.services.app.AppService.update_check_app`
 - 代码路径: `console/services/app.py`
 - 测试路径: `console/tests/vm_live_migration_storage_test.py::VMLiveMigrationStorageTests.test_update_check_app_uses_selected_storage_type_for_new_vm_root_disk`
+
+### 校验新建虚拟机镜像资产名称
+
+- Capability ID: `console.vm-run.new-asset-image-name-validation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.app_create.vm_run.VMRunCreateView.post`
+- 代码路径: `console/services/vm_boot_source.py`, `console/views/app_create/vm_run.py`
+- 测试路径: `console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_rejects_invalid_image_name_before_new_asset_or_component_creation`, `console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_run_rejects_non_string_image_name_and_import_sources`, `console/tests/vm_asset_instantiation_test.py::VMAssetInstantiationTests.test_vm_runtime_image_name_validator_enforces_oci_tag_boundaries`
 
 ### 虚拟机平台异常时禁止创建虚拟机组件
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -104,10 +104,12 @@
 | console.app-upgrade.execute-record | App Upgrade Execute Record | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.execute-record] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_execute_app_upgrade_record_calls_upgrade_service |
 | console.app-upgrade.info | 查询应用升级信息 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_app_upgrade_info] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_upgrade_info_returns_upgrade_items |
 | console.app-upgrade.last-record | App Upgrade Last Record | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.last-record] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_last_upgrade_record_returns_snapshot_metadata |
+| console.app-upgrade.local-offline-detail | 离线模式展示本地应用升级详情 | active | regression | console.views.app_upgrade.AppUpgradeInfoView.get | console/tests/app_upgrade_offline_test.py::AppUpgradeOfflineTests::test_offline_upgrade_info_view_calculates_local_details |
 | console.app-upgrade.openapi-upgrade-group-id | OpenAPI 升级向记录创建传递 upgrade_group_id | active | regression | console.services.upgrade_services.UpgradeService.openapi_upgrade_app_models | console/tests/upgrade_services_test.py::OpenapiUpgradeGroupIdTests |
 | console.app-upgrade.record | App Upgrade Record | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.record] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_upgrade_record_returns_record_detail |
 | console.app-upgrade.record-status-summary | 应用升级记录状态汇总 | active | regression | console.services.upgrade_services.UpgradeService._update_app_record_status | console/tests/upgrade_services_test.py::UpgradeServiceRecordStatusTests |
 | console.app-upgrade.records | App Upgrade Records | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.records] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_upgrade_records_returns_paginated_items |
+| console.app-upgrade.remote-offline-market-guard | 离线升级流程阻断远程应用市场访问 | active | regression | console.services.upgrade_services.UpgradeService.get_property_changes | console/tests/app_upgrade_offline_test.py::AppUpgradeOfflineTests::test_remote_upgrade_details_skip_market_lookup_when_offline<br>console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_component_versions_skip_market_lookup_when_offline<br>console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_model_versions_skip_market_lookup_when_offline<br>console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_record_versions_skip_market_lookup_when_offline |
 | console.app-upgrade.rollback | App Upgrade Rollback | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.rollback] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_rollback_app_upgrade_record_calls_restore |
 | console.app-upgrade.rollback-records | App Upgrade Rollback Records | active | regression | console.services.mcp_query_service.call_tool[console.app-upgrade.rollback-records] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_rollback_records_returns_items |
 | console.app-version.component-diff-details | 生成应用版本组件差异明细 | active | regression | console.services.app_version_service._build_component_diff_details | console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_added_removed_and_field_updates<br>console/tests/app_version_test.py::AppVersionServiceComponentDiffDetailTestCase.test_build_component_diff_details_tracks_connect_envs_and_other_changes |
@@ -361,6 +363,7 @@
 | console.market-app.create-template-scope-name | 按发布范围和团队检查应用市场模板重名 | active | regression | console.services.market_app_service.MarketAppService.create_rainbond_app | console/tests/market_app_service_test.py::MarketAppServiceCreateRainbondAppTests |
 | console.market-app.install-default-storage-class | 应用市场安装使用平台默认存储类 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_default_volume_type_prefers_configured_storage_class<br>console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_uses_configured_default_storage_class |
 | console.market-app.install-unlimited-resources | 市场发布和安装保留不限制资源 | active | regression | console.services.share_services.ShareService.query_share_service_info / console.services.market_app.new_components.NewComponents._template_to_component / console.services.market_app_service.MarketAppService.__init_component_from_market_app / console.services.app_import_and_export_service.AppImportService.__normalize_import_component_template | console/tests/service_share_test.py::ShareServiceQueryResourceLimitTestCase.test_query_share_service_info_preserves_unlimited_resource_limits<br>console/tests/market_app_update_components_test.py::MarketAppNewComponentsResourceLimitTests.test_template_to_component_preserves_explicit_unlimited_cpu_and_memory<br>console/tests/market_app_service_test.py::MarketAppServiceResourceLimitTests.test_init_component_from_market_app_preserves_explicit_unlimited_cpu_and_memory<br>console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_preserves_explicit_unlimited_resources |
+| console.market-app.local-snapshot-offline-upgrade | 离线模式检测本地快照升级 | active | regression | console.services.market_app_service.MarketAppService.get_market_apps_in_app | console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_local_snapshot_offline_upgrade_is_detected<br>console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_local_snapshot_versions_still_use_local_repository_when_offline |
 | console.market-app.restore-preserves-volume-capacity-on-storage-fallback | 市场恢复在存储类型回退时保留卷容量 | active | regression | console.services.market_app.new_components.NewComponents._template_to_volumes | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_template_to_volumes_preserves_capacity_when_storage_type_changes |
 | console.market-app.restore-volume-capacity-helper | resolve_market_restore_volume_settings 在存储类型变化时保留容量 | active | regression | console.services.app_config.volume_service.AppVolumeService.resolve_market_restore_volume_settings | console/tests/market_app_storage_test.py::MarketAppDefaultStorageClassTests.test_resolve_market_restore_volume_settings_preserves_capacity_when_storage_type_changes |
 | console.market-app.upgrade-share-image-fallback | Market App Upgrade Share Image Fallback | active | regression | console.services.market_app.update_components | console/tests/market_app_update_components_test.py::MarketAppUpdateComponentsCompatibilityTests.test_create_update_components_falls_back_to_image_when_share_image_missing |
@@ -1580,6 +1583,16 @@
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_app_last_upgrade_record_returns_snapshot_metadata`
 
+### 离线模式展示本地应用升级详情
+
+- Capability ID: `console.app-upgrade.local-offline-detail`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `view_endpoint`
+- 业务入口: `console.views.app_upgrade.AppUpgradeInfoView.get`
+- 代码路径: `console/views/app_upgrade.py`, `console/services/upgrade_services.py`
+- 测试路径: `console/tests/app_upgrade_offline_test.py::AppUpgradeOfflineTests::test_offline_upgrade_info_view_calculates_local_details`
+
 ### OpenAPI 升级向记录创建传递 upgrade_group_id
 
 - Capability ID: `console.app-upgrade.openapi-upgrade-group-id`
@@ -1619,6 +1632,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[console.app-upgrade.records]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_query_app_upgrade_records_returns_paginated_items`
+
+### 离线升级流程阻断远程应用市场访问
+
+- Capability ID: `console.app-upgrade.remote-offline-market-guard`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.upgrade_services.UpgradeService.get_property_changes`
+- 代码路径: `console/services/upgrade_services.py`, `console/services/market_app_service.py`
+- 测试路径: `console/tests/app_upgrade_offline_test.py::AppUpgradeOfflineTests::test_remote_upgrade_details_skip_market_lookup_when_offline`, `console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_component_versions_skip_market_lookup_when_offline`, `console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_model_versions_skip_market_lookup_when_offline`, `console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_remote_record_versions_skip_market_lookup_when_offline`
 
 ### App Upgrade Rollback
 
@@ -4149,6 +4172,16 @@
 - 业务入口: `console.services.share_services.ShareService.query_share_service_info / console.services.market_app.new_components.NewComponents._template_to_component / console.services.market_app_service.MarketAppService.__init_component_from_market_app / console.services.app_import_and_export_service.AppImportService.__normalize_import_component_template`
 - 代码路径: `console/services/share_services.py`, `console/services/market_app/new_components.py`, `console/services/market_app_service.py`, `console/services/app_import_and_export_service.py`
 - 测试路径: `console/tests/service_share_test.py::ShareServiceQueryResourceLimitTestCase.test_query_share_service_info_preserves_unlimited_resource_limits`, `console/tests/market_app_update_components_test.py::MarketAppNewComponentsResourceLimitTests.test_template_to_component_preserves_explicit_unlimited_cpu_and_memory`, `console/tests/market_app_service_test.py::MarketAppServiceResourceLimitTests.test_init_component_from_market_app_preserves_explicit_unlimited_cpu_and_memory`, `console/tests/app_import_and_export_service_test.py::AppImportServiceMetadataTestCase.test_save_enterprise_import_info_preserves_explicit_unlimited_resources`
+
+### 离线模式检测本地快照升级
+
+- Capability ID: `console.market-app.local-snapshot-offline-upgrade`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.market_app_service.MarketAppService.get_market_apps_in_app`
+- 代码路径: `console/services/market_app_service.py`
+- 测试路径: `console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_local_snapshot_offline_upgrade_is_detected`, `console/tests/market_app_service_test.py::MarketAppServiceOfflineUpgradeTests::test_local_snapshot_versions_still_use_local_repository_when_offline`
 
 ### 市场恢复在存储类型回退时保留卷容量
 


### PR DESCRIPTION
## Summary

- remove the blanket offline short-circuit from the application upgrade detail endpoint
- allow local component-library snapshots to load versions and calculate property changes while cloud market access is disabled
- keep remote-market sources blocked before market repository or API access
- add managed regression coverage for local details and all remote version-discovery entry points

## Verification

- pytest -q console/tests/app_upgrade_offline_test.py console/tests/market_app_service_test.py (32 passed)
- flake8 on all changed Python files
- make test-manifest-check
- make check was also run and remains blocked by pre-existing repository-wide lint debt; no changed file was reported
- cross-repository API compatibility check: request and response contracts are unchanged

## Related

- Core mount-relation fix: https://github.com/goodrain/rainbond/pull/2682