### PR TITLE
fix: release TCP port mappings on close

### DIFF
--- a/console/services/app_config/port_service.py
+++ b/console/services/app_config/port_service.py
@@ -940,13 +940,13 @@ class AppPortService(object):
                     # NOTE: svc may be None (get_service_port_by_port returns Optional); invariant here.
                     k8s_name = svc.k8s_service_name  # type: ignore[union-attr]
                     for nodeport in body.get("list", []):  # type: ignore[union-attr]
-                        delete_path = f"/v2/proxy-pass/gateway/{tenant.tenant_name}/routes/tcp/{k8s_name}-{nodeport}"
-                        try:
-                            region_api.delete_proxy(region.region_name, delete_path)
-                        except Exception as e:
-                            logger.exception(f"Failed to delete route {delete_path}: {e}")
+                        delete_path = (f"/v2/proxy-pass/gateway/{tenant.tenant_name}/routes/tcp/"
+                                       f"{k8s_name}-{nodeport}?service_id={service.service_id}")
+                        region_api.delete_proxy(region.region_name, delete_path)
             except Exception as e:
-                logger.exception(f"Failed to get routes from API Gateway: {e}")
+                logger.exception(f"Failed to release TCP routes: {e}")
+                raise
+            tcp_domain.delete_by_component_port(service.service_id, deal_port.container_port)
         self.__sync_outer_port_to_region(tenant, service, deal_port, "close", user_name)
         if service.create_status == "complete":
             from console.services.plugin import app_plugin_service

--- a/console/tests/port_service_delete_test.py
+++ b/console/tests/port_service_delete_test.py
@@ -3,7 +3,7 @@ import sys
 import types
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 
 def install_stub(module_name, **attrs):
@@ -111,7 +111,7 @@ class PortServiceDeleteTests(TestCase):
         module.domain_service = MagicMock()
 
     def configure_manage_port_dependencies(self, module, port):
-        region = types.SimpleNamespace(region_id="region-1", httpdomain="apps.example.com")
+        region = types.SimpleNamespace(region_id="region-1", region_name="region-1", httpdomain="apps.example.com")
         app = types.SimpleNamespace(
             app_id=7,
             governance_mode="KUBERNETES_NATIVE_SERVICE",
@@ -125,6 +125,31 @@ class PortServiceDeleteTests(TestCase):
         module.env_var_service.add_service_env_var.return_value = (200, "success", None)
         module.env_var_service.delete_env_by_container_port.return_value = None
         return app
+
+    def configure_tcp_close_dependencies(self, module, routes):
+        tenant = types.SimpleNamespace(tenant_id="tenant-1", tenant_name="default", enterprise_id="enterprise-1")
+        service = types.SimpleNamespace(
+            service_id="component-1",
+            tenant_id="tenant-1",
+            service_region="region-1",
+            service_alias="gr2dc0bf",
+            service_cname="nginx",
+            service_key="nginx",
+            create_status="complete",
+        )
+        port = types.SimpleNamespace(
+            container_port=8080,
+            protocol="tcp",
+            port_alias="tcp",
+            is_inner_service=True,
+            is_outer_service=True,
+            k8s_service_name="gr2dc0bf",
+            save=MagicMock(),
+        )
+        app = self.configure_manage_port_dependencies(module, port)
+        module.tcp_domain.get_service_tcp_domains_by_service_id_and_port.return_value = []
+        module.region_api.api_gateway_get_proxy.return_value = {"list": routes}
+        return tenant, service, port, app
 
     # capability_id: console.component.port-toggle-events
     def test_open_outer_port_synchronizes_region_component_event(self):
@@ -242,6 +267,79 @@ class PortServiceDeleteTests(TestCase):
             80,
             {"operation": "close", "enterprise_id": "enterprise-1", "operator": "alice"},
         )
+
+    # capability_id: console.component.tcp-port-close-release
+    def test_close_tcp_port_releases_all_region_routes_before_local_mapping(self):
+        module = self.import_port_service_module()
+        tenant, service, _, app = self.configure_tcp_close_dependencies(module, [31000, 31001])
+        operations = []
+        module.region_api.delete_proxy.side_effect = lambda *args: operations.append("region-delete")
+        module.tcp_domain.delete_by_component_port.side_effect = lambda *args: operations.append("local-delete")
+        module.region_api.manage_outer_port.side_effect = lambda *args: operations.append("sync")
+        plugin_service = sys.modules["console.services.plugin"].app_plugin_service
+        plugin_service.update_config_if_have_entrance_plugin.side_effect = lambda *args: operations.append("plugin")
+
+        result = module.AppPortService().manage_port(
+            tenant, service, "region-1", 8080, "close_outer", "tcp", "SVC8080", user_name="alice", app=app)
+
+        self.assertEqual(result[:2], (200, "操作成功"))
+        region = module.region_repo.get_region_by_region_name.return_value
+        module.region_api.api_gateway_get_proxy.assert_called_once_with(
+            region,
+            "tenant-1",
+            "/api-gateway/v1/default/routes/tcp/domains?service_alias=gr2dc0bf&port=8080",
+            7,
+        )
+        route_base = "/v2/proxy-pass/gateway/default/routes/tcp/gr2dc0bf-"
+        module.region_api.delete_proxy.assert_has_calls([
+            call("region-1", route_base + "31000?service_id=component-1"),
+            call("region-1", route_base + "31001?service_id=component-1"),
+        ])
+        self.assertEqual(module.region_api.delete_proxy.call_count, 2)
+        module.tcp_domain.delete_by_component_port.assert_called_once_with("component-1", 8080)
+        self.assertEqual(operations, ["region-delete", "region-delete", "local-delete", "sync", "plugin"])
+
+    # capability_id: console.component.tcp-port-close-release
+    def test_close_tcp_port_with_no_region_routes_deletes_stale_local_mapping(self):
+        module = self.import_port_service_module()
+        tenant, service, _, app = self.configure_tcp_close_dependencies(module, [])
+
+        result = module.AppPortService().manage_port(
+            tenant, service, "region-1", 8080, "close_outer", "tcp", "SVC8080", user_name="alice", app=app)
+
+        self.assertEqual(result[:2], (200, "操作成功"))
+        module.region_api.delete_proxy.assert_not_called()
+        module.tcp_domain.delete_by_component_port.assert_called_once_with("component-1", 8080)
+
+    # capability_id: console.component.tcp-port-close-release
+    def test_close_tcp_port_preserves_local_mapping_when_region_query_fails(self):
+        module = self.import_port_service_module()
+        tenant, service, _, app = self.configure_tcp_close_dependencies(module, [])
+        module.region_api.api_gateway_get_proxy.side_effect = RuntimeError("query failed")
+
+        with self.assertRaisesRegex(RuntimeError, "query failed"):
+            module.AppPortService().manage_port(
+                tenant, service, "region-1", 8080, "close_outer", "tcp", "SVC8080", user_name="alice", app=app)
+
+        module.region_api.delete_proxy.assert_not_called()
+        module.tcp_domain.delete_by_component_port.assert_not_called()
+        module.region_api.manage_outer_port.assert_not_called()
+        sys.modules["console.services.plugin"].app_plugin_service.update_config_if_have_entrance_plugin.assert_not_called()
+
+    # capability_id: console.component.tcp-port-close-release
+    def test_close_tcp_port_preserves_local_mapping_when_region_delete_fails(self):
+        module = self.import_port_service_module()
+        tenant, service, _, app = self.configure_tcp_close_dependencies(module, [31000, 31001])
+        module.region_api.delete_proxy.side_effect = [None, RuntimeError("delete failed")]
+
+        with self.assertRaisesRegex(RuntimeError, "delete failed"):
+            module.AppPortService().manage_port(
+                tenant, service, "region-1", 8080, "close_outer", "tcp", "SVC8080", user_name="alice", app=app)
+
+        self.assertEqual(module.region_api.delete_proxy.call_count, 2)
+        module.tcp_domain.delete_by_component_port.assert_not_called()
+        module.region_api.manage_outer_port.assert_not_called()
+        sys.modules["console.services.plugin"].app_plugin_service.update_config_if_have_entrance_plugin.assert_not_called()
 
     def test_delete_closed_port_ignores_inactive_custom_http_domains(self):
         module = self.import_port_service_module()

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -5216,6 +5216,36 @@
       "status": "active"
     },
     {
+      "id": "console.component.tcp-port-close-release",
+      "title": "Release TCP port mappings after Region routes",
+      "title_zh": "数据中心路由释放后清理 TCP 端口映射",
+      "interface_type": "service_method",
+      "interface": "console.services.app_config.port_service.AppPortService.manage_port",
+      "code_paths": [
+        "console/services/app_config/port_service.py"
+      ],
+      "tests": [
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_tcp_port_releases_all_region_routes_before_local_mapping"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_tcp_port_with_no_region_routes_deletes_stale_local_mapping"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_query_fails"
+        },
+        {
+          "path": "console/tests/port_service_delete_test.py",
+          "selector": "PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_delete_fails"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "console.component.volume-delete-blocks-shared-mount",
       "title": "Block deleting shared mounted component volumes",
       "title_zh": "被共享挂载时阻止删除组件存储卷",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -276,6 +276,7 @@
 | console.component.storage-update-volume | 按当前路径更新组件存储卷 | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage#update_volume] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_update_volume_can_resolve_target_by_current_volume_path |
 | console.component.storage-update-volume-capacity | Component Storage Update Volume Capacity | active | regression | console.services.mcp_query_service.call_tool[rainbond_manage_component_storage] | console/tests/mcp_query_storage_ops_test.py::ManageComponentStorageTests.test_update_volume_allows_capacity_change_without_path_change |
 | console.component.summary | 查看组件概览 | active | regression | console.services.mcp_query_service.call_tool[rainbond_get_component_summary] | console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_summary_returns_aggregated_info |
+| console.component.tcp-port-close-release | 数据中心路由释放后清理 TCP 端口映射 | active | regression | console.services.app_config.port_service.AppPortService.manage_port | console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_releases_all_region_routes_before_local_mapping<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_with_no_region_routes_deletes_stale_local_mapping<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_query_fails<br>console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_delete_fails |
 | console.component.volume-delete-blocks-shared-mount | 被共享挂载时阻止删除组件存储卷 | active | regression | console.services.app_config.volume_service.AppVolumeService.delete_service_volume_by_id | console/tests/app_config_volume_delete_test.py::AppVolumeDeleteTests.test_delete_service_volume_rejects_shared_mount_even_when_forced |
 | console.dependency.invalid-container-port | Dependency Invalid Container Port | active | regression | console.services.app_config.app_relation_service.AppServiceRelationService | console/tests/app_relation_service_test.py::AppRelationServiceTests.test_add_service_dependency_rejects_unknown_dep_service_port |
 | console.deploy-diagnostics.offline-mode | 离线模式禁用部署诊断上报 | active | regression | console.services.enterprise_first_deploy_service.EnterpriseFirstDeployService | console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_start_report_sweeper<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_online_mode_starts_report_sweeper<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_skips_report_request<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_create_deploy_tracking<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_does_not_persist_source_check_failure<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_marks_first_deploy_report_handled_without_thread<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_removes_unreported_deploy_attempt<br>console/tests/enterprise_first_deploy_service_test.py::EnterpriseFirstDeployServiceTests.test_offline_mode_forgets_unpersisted_report |
@@ -3303,6 +3304,16 @@
 - 业务入口: `console.services.mcp_query_service.call_tool[rainbond_get_component_summary]`
 - 代码路径: `console/services/mcp_query_service.py`
 - 测试路径: `console/tests/mcp_query_service_test.py::MCPQueryServiceApplicationToolTests.test_get_component_summary_returns_aggregated_info`
+
+### 数据中心路由释放后清理 TCP 端口映射
+
+- Capability ID: `console.component.tcp-port-close-release`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `service_method`
+- 业务入口: `console.services.app_config.port_service.AppPortService.manage_port`
+- 代码路径: `console/services/app_config/port_service.py`
+- 测试路径: `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_releases_all_region_routes_before_local_mapping`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_with_no_region_routes_deletes_stale_local_mapping`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_query_fails`, `console/tests/port_service_delete_test.py::PortServiceDeleteTests::test_close_tcp_port_preserves_local_mapping_when_region_delete_fails`
 
 ### 被共享挂载时阻止删除组件存储卷
 


### PR DESCRIPTION
## Summary

- pass the component `service_id` when deleting Region TCP routes
- delete the local TCP mapping only after every Region route deletion succeeds
- release stale local mappings idempotently when Region already reports no routes
- propagate Region query or deletion failures so the surrounding database transaction rolls back

Depends on goodrain/rainbond#2687.

## Verification

- `pytest -q console/tests/port_service_delete_test.py` — 9 passed
- capability manifest validation passed
- `git diff --check` passed
- `make format` was run; unrelated repository-wide formatting output was excluded

## Existing repository gates

- the isolated full-suite runner is currently blocked by missing generated `openapi_client` and other pre-existing environment failures
- `make check` is currently blocked by the repository existing full-tree flake8 baseline; the changed lines add no flake8 findings