### PR TITLE
fix: persist multi-module Java CNB settings

### DIFF
--- a/console/services/app_check_service.py
+++ b/console/services/app_check_service.py
@@ -87,6 +87,25 @@ class AppCheckService(object):
             "min_cpu": self.DETECTED_DEFAULT_CPU_MILLI,
         }
 
+    @staticmethod
+    def _uses_java_cnb_build_envs(service: TenantServiceInfo) -> bool:
+        if str(getattr(service, "build_strategy", "") or "").strip().lower() != "cnb":
+            return False
+        policy = cnb_build_utils.get_cnb_policy_definition(service.language)
+        return bool(policy and policy.get("policy_key") == "java")
+
+    @staticmethod
+    def _normalize_java_cnb_envs_for_save(service: TenantServiceInfo, envs: Optional[list]) -> Optional[list]:
+        if not envs or not AppCheckService._uses_java_cnb_build_envs(service):
+            return envs
+
+        env_dict = {env["name"]: env.get("value", "") for env in envs if env.get("name")}
+        normalized_env_dict = cnb_build_utils.normalize_java_cnb_env_dict_for_save(env_dict, service.language,
+                                                                                   service.build_strategy)
+        if normalized_env_dict == env_dict:
+            return envs
+        return [{"name": name, "value": value} for name, value in normalized_env_dict.items()]
+
     def __get_service_region_type(self, service_source: str) -> Optional[str]:  # type: ignore[return]
         # NOTE: implicit None fall-through for unknown service_source (e.g. MARKET,
         # DOCKER_COMPOSE). Return is Optional; downstream stores it into body dict.
@@ -398,7 +417,7 @@ class AppCheckService(object):
             service_image = image["name"] + ":" + image["tag"]
             service.image = service_image
             service.version = image["tag"]
-        envs = service_info.get("envs", None)
+        envs = self._normalize_java_cnb_envs_for_save(service, service_info.get("envs", None))
         ports = service_info.get("ports", None)
         volumes = service_info.get("volumes", None)
         service_runtime_os = service_info.get("os", "linux")
@@ -446,6 +465,7 @@ class AppCheckService(object):
 
     def __save_env(self, tenant: Tenants, service: TenantServiceInfo, envs: Optional[list]) -> None:
         if envs:
+            uses_java_cnb_build_envs = self._uses_java_cnb_build_envs(service)
             # 删除原有env
             env_var_service.delete_service_env(tenant, service)
             # 删除原有的build类型环境变量
@@ -454,10 +474,13 @@ class AppCheckService(object):
                                    'SERVICE_EXTEND_METHOD', 'SLUG_URL', 'DEPEND_SERVICE', 'REVERSE_DEPEND_SERVICE', 'POD_ORDER',
                                    'PATH', 'POD_NET_IP')
             for env in envs:
+                is_java_cnb_build_env = False
+                if uses_java_cnb_build_envs:
+                    is_java_cnb_build_env = env["name"] in cnb_build_utils.JAVA_CNB_BP_KEYS
                 if env["name"] in SENSITIVE_ENV_NAMES:
                     continue
                 # BUILD_开头的env保存为build类型的环境变量
-                elif env["name"].startswith("BUILD_"):
+                elif env["name"].startswith("BUILD_") or is_java_cnb_build_env:
                     code, msg, data = env_var_service.add_service_build_env_var(tenant, service, 0, env["name"], env["name"],
                                                                                 env["value"], True)
                     if code != 200:

--- a/console/tests/app_check_service_build_strategy_test.py
+++ b/console/tests/app_check_service_build_strategy_test.py
@@ -67,25 +67,24 @@ class AppCheckServiceBuildStrategyTests(TestCase):
         self.service_helper = AppCheckService()
         self.tenant = DummyTenant()
 
-    def patch_side_effects(self):
+    def patch_side_effects(self, patch_save_env=True):
         stack = ExitStack()
-        stack.enter_context(patch.multiple(
-            self.service_helper,
-            _AppCheckService__save_compile_env=lambda *args, **kwargs: None,
-            _AppCheckService__save_env=lambda *args, **kwargs: None,
-            _AppCheckService__save_port=lambda *args, **kwargs: None,
-            _AppCheckService__save_volume=lambda *args, **kwargs: None,
-            sync_cnb_build_envs=lambda *args, **kwargs: None,
-        ))
-        stack.enter_context(patch.object(
-            app_check_service_module,
-            "source_build_state_service",
-            Mock(
-                build_snapshot=Mock(return_value={}),
-                save_detected_defaults=Mock(),
-                save_user_snapshot=Mock(),
-            )
-        ))
+        service_patches = {
+            "_AppCheckService__save_compile_env": lambda *args, **kwargs: None,
+            "_AppCheckService__save_port": lambda *args, **kwargs: None,
+            "_AppCheckService__save_volume": lambda *args, **kwargs: None,
+            "sync_cnb_build_envs": lambda *args, **kwargs: None,
+        }
+        if patch_save_env:
+            service_patches["_AppCheckService__save_env"] = lambda *args, **kwargs: None
+        stack.enter_context(patch.multiple(self.service_helper, **service_patches))
+        stack.enter_context(
+            patch.object(app_check_service_module, "source_build_state_service",
+                         Mock(
+                             build_snapshot=Mock(return_value={}),
+                             save_detected_defaults=Mock(),
+                             save_user_snapshot=Mock(),
+                         )))
         return stack
 
     def test_save_service_info_defaults_supported_language_to_cnb(self):
@@ -134,6 +133,105 @@ class AppCheckServiceBuildStrategyTests(TestCase):
             })
 
         self.assertEqual(service.build_strategy, "slug")
+
+    @patch.object(app_check_service_module, "env_var_service")
+    def test_save_service_info_normalizes_multi_module_java_cnb_envs(self, env_var_service):
+        service = DummyService(build_strategy="cnb")
+        env_var_service.add_service_build_env_var.return_value = (200, "success", Mock())
+        env_var_service.add_service_env_var.return_value = (200, "success", Mock())
+
+        with self.patch_side_effects(patch_save_env=False):
+            self.service_helper.save_service_info(
+                self.tenant, service, {
+                    "language":
+                    "Java-maven",
+                    "memory":
+                    256,
+                    "envs": [
+                        {
+                            "name": "BUILD_MAVEN_CUSTOM_GOALS",
+                            "value": "clean package -pl service-a -am"
+                        },
+                        {
+                            "name": "BUILD_MAVEN_CUSTOM_OPTS",
+                            "value": "-DskipTests"
+                        },
+                        {
+                            "name": "BUILD_MAVEN_BUILT_MODULE",
+                            "value": "service-a"
+                        },
+                        {
+                            "name": "BUILD_MAVEN_BUILT_ARTIFACT",
+                            "value": "service-a/target/app.jar"
+                        },
+                        {
+                            "name": "SPRING_PROFILES_ACTIVE",
+                            "value": "prod"
+                        },
+                    ],
+                })
+
+        saved_build_envs = {call.args[4]: call.args[5] for call in env_var_service.add_service_build_env_var.call_args_list}
+        self.assertEqual(
+            saved_build_envs, {
+                "BP_MAVEN_BUILD_ARGUMENTS": "clean package -pl service-a -am",
+                "BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS": "-DskipTests",
+                "BP_MAVEN_BUILT_MODULE": "service-a",
+                "BP_MAVEN_BUILT_ARTIFACT": "service-a/target/app.jar",
+            })
+        env_var_service.add_service_env_var.assert_called_once_with(self.tenant, service, 0, "SPRING_PROFILES_ACTIVE",
+                                                                    "SPRING_PROFILES_ACTIVE", "prod", True, "inner")
+
+    @patch.object(app_check_service_module, "env_var_service")
+    def test_save_env_treats_java_cnb_bp_keys_as_build_envs(self, env_var_service):
+        service = DummyService(build_strategy="cnb")
+        service.language = "Java-maven"
+        env_var_service.add_service_build_env_var.return_value = (200, "success", Mock())
+        env_var_service.add_service_env_var.return_value = (200, "success", Mock())
+        envs = [{
+            "name": name,
+            "value": "value-{0}".format(index)
+        } for index, name in enumerate(app_check_service_module.cnb_build_utils.JAVA_CNB_BP_KEYS)]
+        envs.append({"name": "SPRING_PROFILES_ACTIVE", "value": "prod"})
+
+        self.service_helper._AppCheckService__save_env(self.tenant, service, envs)
+
+        saved_build_env_names = {call.args[4] for call in env_var_service.add_service_build_env_var.call_args_list}
+        self.assertEqual(saved_build_env_names, set(app_check_service_module.cnb_build_utils.JAVA_CNB_BP_KEYS))
+        env_var_service.add_service_env_var.assert_called_once_with(self.tenant, service, 0, "SPRING_PROFILES_ACTIVE",
+                                                                    "SPRING_PROFILES_ACTIVE", "prod", True, "inner")
+
+    @patch.object(app_check_service_module, "env_var_service")
+    def test_save_env_keeps_java_bp_key_as_runtime_env_for_java_slug(self, env_var_service):
+        service = DummyService(build_strategy="slug")
+        service.language = "Java-maven"
+        env_var_service.add_service_build_env_var.return_value = (200, "success", Mock())
+        env_var_service.add_service_env_var.return_value = (200, "success", Mock())
+
+        self.service_helper._AppCheckService__save_env(self.tenant, service, [{
+            "name": "BP_MAVEN_BUILT_MODULE",
+            "value": "service-a"
+        }])
+
+        env_var_service.add_service_build_env_var.assert_not_called()
+        env_var_service.add_service_env_var.assert_called_once_with(self.tenant, service, 0, "BP_MAVEN_BUILT_MODULE",
+                                                                    "BP_MAVEN_BUILT_MODULE", "service-a", True, "inner")
+
+    @patch.object(app_check_service_module, "env_var_service")
+    def test_save_env_keeps_java_bp_key_as_runtime_env_for_python_cnb(self, env_var_service):
+        service = DummyService(build_strategy="cnb")
+        service.language = "Python"
+        env_var_service.add_service_build_env_var.return_value = (200, "success", Mock())
+        env_var_service.add_service_env_var.return_value = (200, "success", Mock())
+
+        self.service_helper._AppCheckService__save_env(self.tenant, service, [{
+            "name": "BP_MAVEN_BUILT_MODULE",
+            "value": "service-a"
+        }])
+
+        env_var_service.add_service_build_env_var.assert_not_called()
+        env_var_service.add_service_env_var.assert_called_once_with(self.tenant, service, 0, "BP_MAVEN_BUILT_MODULE",
+                                                                    "BP_MAVEN_BUILT_MODULE", "service-a", True, "inner")
 
     def test_supports_cnb_build_strategy_falls_back_when_helper_symbol_is_missing(self):
         with patch.object(app_check_service_module.cnb_build_utils, "supports_cnb_build_strategy", None):

--- a/console/tests/app_check_view_test.py
+++ b/console/tests/app_check_view_test.py
@@ -90,11 +90,11 @@ class AppCheckSourceDiagnosticTests(TestCase):
         with mock.patch("console.views.app_create.app_check.app_check_service.get_service_check_info",
                         return_value=(200, "success", data)), \
                 mock.patch("console.views.app_create.app_check.app_check_service.wrap_service_check_info",
-                           return_value={"check_status": "failure", "error_infos": data["error_infos"], "service_info": []}), \
-                mock.patch(
+                           return_value={"check_status": "failure", "error_infos": data["error_infos"], "service_info": []}):
+            with mock.patch(
                     "console.views.app_create.app_check.enterprise_first_deploy_service.safe_report_source_check_failure"
-                ) as mock_report:
-            response = view.get(request)
+            ) as mock_report:
+                response = view.get(request)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["data"]["bean"]["check_status"], "failure")
@@ -103,3 +103,68 @@ class AppCheckSourceDiagnosticTests(TestCase):
         self.assertEqual(kwargs["reason"], "获取代码超时 请确认源码仓库能否正常访问")
         self.assertEqual(kwargs["source_context"]["git_url"], "https://git.example.com/demo.git")
         self.assertEqual(kwargs["source_context"]["check_uuid"], "check-1")
+
+
+class AppCheckMultiModuleLanguageTests(TestCase):
+    def get_multi_module_check(self, language, check_status="success", build_strategy="slug"):
+        view = AppCheck()
+        save = mock.Mock()
+        view.tenant = Obj(tenant_name="demo-team", enterprise_id="eid-1")
+        view.service = Obj(
+            service_region="rainbond",
+            service_id="svc-1",
+            service_alias="grsource",
+            service_cname="源码组件",
+            service_source="source_code",
+            code_from="git",
+            git_url="https://git.example.com/demo.git",
+            code_version="master",
+            server_type="git",
+            create_status="checking",
+            language="",
+            build_strategy=build_strategy,
+            save=save,
+        )
+        view.app = Obj(ID=12, group_name="demo-app")
+        data = {
+            "check_status": check_status,
+            "service_info": [
+                {"language": language, "service_name": "service-a"},
+                {"language": language, "service_name": "service-b"},
+            ],
+        }
+        request = RequestFactory().get("/console/check", {"check_uuid": "check-1"})
+
+        with mock.patch("console.views.app_create.app_check.app_check_service.get_service_check_info",
+                        return_value=(200, "success", data)), \
+                mock.patch("console.views.app_create.app_check.app_check_service.wrap_service_check_info",
+                           return_value=data), \
+                mock.patch("console.views.app_create.app_check.app_check_service.save_service_check_info") as mock_save_info:
+            response = view.get(request)
+
+        return view.service, response, save, mock_save_info
+
+    def test_get_persists_only_language_for_successful_java_maven_multi_module_check(self):
+        service, response, save, mock_save_info = self.get_multi_module_check("Java-maven")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(service.language, "Java-maven")
+        self.assertEqual(service.build_strategy, "slug")
+        save.assert_called_once_with(update_fields=["language"])
+        mock_save_info.assert_not_called()
+
+    def test_get_does_not_persist_language_for_other_multi_module_projects(self):
+        service, response, save, mock_save_info = self.get_multi_module_check("Python")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(service.language, "")
+        save.assert_not_called()
+        mock_save_info.assert_not_called()
+
+    def test_get_does_not_persist_java_language_before_check_succeeds(self):
+        service, response, save, mock_save_info = self.get_multi_module_check("Java-maven", check_status="checking")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(service.language, "")
+        save.assert_not_called()
+        mock_save_info.assert_not_called()

--- a/console/views/app_create/app_check.py
+++ b/console/views/app_create/app_check.py
@@ -15,7 +15,7 @@ from console.services.app_check_service import (app_check_service, resolve_lang_
 from console.services.enterprise_first_deploy_service import enterprise_first_deploy_service
 from console.services.source_build_state_service import source_build_state_service
 from console.utils.oauth.oauth_types import support_oauth_type
-from console.utils.source_build_state import is_java_maven_language
+from console.utils.source_build_state import is_java_maven_language, pick_preferred_language
 from console.views.app_config.base import AppBaseView
 from console.utils.cache_decorators import never_cache
 from rest_framework.request import Request
@@ -106,6 +106,12 @@ class AppCheck(AppBaseView):
             # No need to save env, ports and other information for multiple services here.
             logger.debug("start save check info ! {0}".format(self.service.create_status))
             app_check_service.save_service_check_info(self.tenant, self.app.ID, self.service, data)
+        elif data.get("check_status") == "success" and service_info_list and is_java_maven_language(
+                service_info_list[0].get("language")):
+            detected_language = pick_preferred_language(service_info_list[0].get("language"))
+            if self.service.language != detected_language:
+                self.service.language = detected_language
+                self.service.save(update_fields=["language"])
         check_brief_info = app_check_service.wrap_service_check_info(self.service, data)
         code_from = self.service.code_from
         if code_from in list(support_oauth_type.keys()):


### PR DESCRIPTION
## Summary

- persist the detected Java Maven language for the temporary multi-module component so buildsource returns the existing CNB version policy
- normalize legacy Maven build aliases before saving module settings
- store canonical Java CNB parameters as build environment variables only for Java CNB builds

## Verification

- 75 focused pytest tests passed
- touched-file flake8 passed
- test manifest validation passed
- git diff --check passed

Full-repository make check remains blocked by pre-existing repository-wide flake8 findings; no new touched-file lint findings remain.

## Companion PRs

- Core: https://github.com/goodrain/rainbond/pull/2689
- UI: https://github.com/goodrain/rainbond-ui/pull/1920