### PR TITLE
feat: expose plugin volume options

### DIFF
--- a/console/tests/plugin_volume_options_view_test.py
+++ b/console/tests/plugin_volume_options_view_test.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase, mock
+
+if "openapi_client" not in sys.modules:
+    openapi_client_module = ModuleType("openapi_client")
+    configuration_module = ModuleType("openapi_client.configuration")
+    rest_module = ModuleType("openapi_client.rest")
+
+    class _Configuration(object):
+        def __init__(self):
+            self.client_side_validation = False
+            self.host = ""
+            self.api_key = {}
+
+    configuration_module.Configuration = _Configuration
+    rest_module.ApiException = type("ApiException", (Exception, ), {})
+    openapi_client_module.ApiClient = object
+    openapi_client_module.MarketOpenapiApi = object
+    sys.modules["openapi_client"] = openapi_client_module
+    sys.modules["openapi_client.configuration"] = configuration_module
+    sys.modules["openapi_client.rest"] = rest_module
+
+from django.urls import resolve
+from rest_framework.test import APIRequestFactory
+
+from console.views.plugin import plugin_config
+
+
+class PluginVolumeOptionsViewTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = plugin_config.PluginVolumeOptionsView()
+        self.view.tenant = SimpleNamespace(tenant_name="demo-team")
+        self.view.response_region = "region-1"
+
+    def test_volume_options_route_precedes_plugin_id_route(self):
+        match = resolve("/console/teams/demo-team/plugins/volume-opts")
+
+        self.assertIs(match.func.view_class, plugin_config.PluginVolumeOptionsView)
+
+    def test_get_returns_region_volume_options(self):
+        options = [
+            {
+                "volume_type": "local-path",
+                "name_show": "Local Path",
+                "access_mode": ["RWO"],
+            },
+            {
+                "volume_type": "nfs-client",
+                "name_show": "NFS",
+                "access_mode": ["RWX"],
+            },
+        ]
+        request = self.factory.get("/console/teams/demo-team/plugins/volume-opts")
+
+        with mock.patch.object(
+                plugin_config.region_api,
+                "get_volume_options",
+                return_value=SimpleNamespace(list=options),
+        ) as get_volume_options:
+            response = self.view.get(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["data"]["list"], options)
+        get_volume_options.assert_called_once_with("region-1", "demo-team")
+
+    def test_get_returns_empty_list_when_region_has_no_volume_options(self):
+        request = self.factory.get("/console/teams/demo-team/plugins/volume-opts")
+
+        for region_response in (SimpleNamespace(), SimpleNamespace(list=None), None):
+            with self.subTest(region_response=region_response):
+                with mock.patch.object(
+                        plugin_config.region_api,
+                        "get_volume_options",
+                        return_value=region_response,
+                ) as get_volume_options:
+                    response = self.view.get(request)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data["data"]["list"], [])
+                get_volume_options.assert_called_once_with("region-1", "demo-team")

--- a/console/urls/__init__.py
+++ b/console/urls/__init__.py
@@ -127,7 +127,7 @@ from console.views.oauth import (EnterpriseOauthService, OauthConfig, OAuthGitCo
 from console.views.operation_log import OperationLogView, TeamOperationLogView, AppOperationLogView
 from console.views.perms import (PermsInfoLView, TeamRolePermsRUDView, TeamRolesLCView, TeamRolesPermsLView, TeamRolesRUDView,
                                  TeamUserPermsLView, TeamUserRolesRUDView, TeamUsersRolesLView)
-from console.views.plugin.plugin_config import (ConfigPluginManageView, ConfigPreviewView)
+from console.views.plugin.plugin_config import (ConfigPluginManageView, ConfigPreviewView, PluginVolumeOptionsView)
 from console.views.plugin.plugin_create import (DefaultPluginCreateView, PluginCreateView)
 from console.views.plugin.plugin_info import (AllPluginBaseInfoView, AllPluginVersionInfoView, PluginBaseInfoView,
                                               PluginEventLogView, PluginUsedServiceView, PluginVersionInfoView)
@@ -853,6 +853,9 @@ urlpatterns = [
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/plugins/default$', DefaultPluginCreateView.as_view(), perms.TEAM_PLUGIN_MANAGE),
     # 获取租户下所有插件基础信息
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/plugins/all$', AllPluginBaseInfoView.as_view(), perms.TEAM_PLUGIN_MANAGE),
+    # 获取当前数据中心可用的存储类型
+    re_path(r'^teams/(?P<tenantName>[\w\-]+)/plugins/volume-opts$', PluginVolumeOptionsView.as_view(),
+            perms.TEAM_PLUGIN_MANAGE),
     # 查询某个插件的基础信息
     re_path(r'^teams/(?P<tenantName>[\w\-]+)/plugins/(?P<plugin_id>[\w\-]+)$', PluginBaseInfoView.as_view(),
         perms.TEAM_PLUGIN_MANAGE),

--- a/console/views/plugin/plugin_config.py
+++ b/console/views/plugin/plugin_config.py
@@ -12,11 +12,26 @@ from rest_framework.response import Response
 from console.services.operation_log import operation_log_service, Operation
 from console.services.plugin import plugin_config_service
 from console.utils.realtime_proxy import build_console_realtime_proxy_url
+from console.views.base import RegionTenantHeaderView
 from console.views.plugin.base import PluginBaseView
+from www.apiclient.regionapi import RegionInvokeApi
 from www.utils.return_message import general_message
 from console.constants import PluginMetaType
 
 logger = logging.getLogger("default")
+region_api = RegionInvokeApi()
+
+
+class PluginVolumeOptionsView(RegionTenantHeaderView):
+    @never_cache
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        body = region_api.get_volume_options(self.response_region, self.tenant.tenant_name)
+        if isinstance(body, dict):
+            volume_options = body.get("list")
+        else:
+            volume_options = getattr(body, "list", None)
+        result = general_message(200, "success", "查询成功", list=volume_options or [])
+        return Response(result, status=result["code"])
 
 
 class ConfigPluginManageView(PluginBaseView):


### PR DESCRIPTION
## Summary
- add a plugin volume-options proxy view using the existing Region API client
- return the standard Console list response and default missing Region data to an empty list
- register the exact route before the plugin ID wildcard route

## Testing
- python scripts/run_pytest.py console/tests/plugin_volume_options_view_test.py -- -q (3 passed)
- changed Python files formatted and compiled successfully
- test manifest validation passed
- git diff --check passed

## Validation note
The repository-wide make check still reports the existing large flake8 baseline (about 1498 findings); the new view, route, and tests pass their targeted checks.

Core dependency: https://github.com/goodrain/rainbond/pull/2692